### PR TITLE
Add CORS policy to allow frontend connection #37

### DIFF
--- a/Server/ConcordiaCurriculumManager/Settings/CorsSettings.cs
+++ b/Server/ConcordiaCurriculumManager/Settings/CorsSettings.cs
@@ -1,0 +1,8 @@
+﻿namespace ConcordiaCurriculumManager.Settings;
+
+public class CorsSettings
+{
+    public const string SectionName = nameof(CorsSettings);
+
+    public required string AllowedWebsite { get; set; }
+}

--- a/Server/ConcordiaCurriculumManager/appsettings.Development.json
+++ b/Server/ConcordiaCurriculumManager/appsettings.Development.json
@@ -17,7 +17,7 @@
   },
   "SeedDatabase": {
     "SkipUserDatabaseSeed": false,
-    "SkipCourseDatabaseSeed":  false,
+    "SkipCourseDatabaseSeed": false,
     "Users": [
       {
         "Id": "37581d9d-713f-475c-9668-23971b0e64d0",
@@ -47,5 +47,8 @@
         ]
       }
     ]
+  },
+  "CorsSettings": {
+    "AllowedWebsite": "http://localhost:4173"
   }
 }

--- a/Server/ConcordiaCurriculumManager/appsettings.json
+++ b/Server/ConcordiaCurriculumManager/appsettings.json
@@ -18,5 +18,8 @@
   "SeedDatabase": {
     "SkipUserDatabaseSeed": true,
     "SkipCourseDatabaseSeed": true
+  },
+  "CorsSettings": {
+    "AllowedWebsite": "[[FROM CLI]]"
   }
 }


### PR DESCRIPTION
This is needed to allow the front end to communicate with the back end. This PR closes: #37 

If the front end uses a different URL, please edit the `appsettings.Development.json`. For deployments, edit `appsetting.json`. Please note that the URL scheme must be identical (e.g., HTTP or HTTPS). 