### PR TITLE
#59 Use application/json for registration API calls

### DIFF
--- a/App/package-lock.json
+++ b/App/package-lock.json
@@ -35,7 +35,6 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
-        "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.0.3",
@@ -6264,12 +6263,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/harmony-reflect": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
-      "dev": true
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6421,18 +6414,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/identity-obj-proxy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
-      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
-      "dev": true,
-      "dependencies": {
-        "harmony-reflect": "^1.4.6"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ignore": {
@@ -16041,12 +16022,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "harmony-reflect": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
-      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
-      "dev": true
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -16153,15 +16128,6 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
-      }
-    },
-    "identity-obj-proxy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
-      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
-      "dev": true,
-      "requires": {
-        "harmony-reflect": "^1.4.6"
       }
     },
     "ignore": {

--- a/App/src/main.tsx
+++ b/App/src/main.tsx
@@ -5,9 +5,9 @@ import "./index.css";
 import axios from "axios";
 
 axios.defaults.baseURL = import.meta.env.VITE_API_URL;
-axios.defaults.headers.post["Content-Type"] = "application/x.ccm.authentication+json;v=1";
+axios.defaults.headers.post["Content-Type"] = "application/json";
 axios.defaults.headers.put["charset"] = "utf-8";
-axios.defaults.headers.common["Accept"] = "application/x.ccm.authentication.token+json;v=1";
+axios.defaults.headers.common["Accept"] = "application/json";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>

--- a/App/src/services/auth.ts
+++ b/App/src/services/auth.ts
@@ -48,9 +48,7 @@ export function login(dto: LoginDTO): Promise<AuthenticationResponse> {
 
 export function RegisterUser(dto: RegisterDTO): Promise<AuthenticationResponse> {
     return axios
-        .post("/Authentication/Register", dto, {
-            headers: { "Content-Type": "application/x.ccm.authentication.create+json;v=1" },
-        })
+        .post("/Authentication/Register", dto)
         .then((response) => {
             localStorage.setItem("token", response.data.accessToken);
             return response;

--- a/App/src/services/auth.ts
+++ b/App/src/services/auth.ts
@@ -47,12 +47,10 @@ export function login(dto: LoginDTO): Promise<AuthenticationResponse> {
 }
 
 export function RegisterUser(dto: RegisterDTO): Promise<AuthenticationResponse> {
-    return axios
-        .post("/Authentication/Register", dto)
-        .then((response) => {
-            localStorage.setItem("token", response.data.accessToken);
-            return response;
-        });
+    return axios.post("/Authentication/Register", dto).then((response) => {
+        localStorage.setItem("token", response.data.accessToken);
+        return response;
+    });
 }
 
 export function logout(): Promise<void> {

--- a/Server/ConcordiaCurriculumManager/Controllers/AuthenticationController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/AuthenticationController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 using System.ComponentModel.DataAnnotations;
+using System.Net.Mime;
 
 namespace ConcordiaCurriculumManager.Controllers;
 
@@ -27,7 +28,7 @@ public class AuthenticationController : Controller
     }
 
     [HttpPost(nameof(Register))]
-    [Consumes(typeof(RegisterDTO), RegisterDTO.MediaType)]
+    [Consumes(typeof(RegisterDTO), MediaTypeNames.Application.Json)]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid input")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
     [SwaggerResponse(StatusCodes.Status201Created, "User created successfully", typeof(AuthenticationResponse), AuthenticationResponse.MediaType)]
@@ -65,7 +66,7 @@ public class AuthenticationController : Controller
     }
 
     [HttpPost(nameof(Login))]
-    [Consumes(typeof(LoginDTO), LoginDTO.MediaType)]
+    [Consumes(typeof(LoginDTO), MediaTypeNames.Application.Json)]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid input")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
     [SwaggerResponse(StatusCodes.Status200OK, "User logged in successfully", typeof(AuthenticationResponse), AuthenticationResponse.MediaType)]

--- a/Server/ConcordiaCurriculumManager/DTO/LoginDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/LoginDTO.cs
@@ -4,8 +4,6 @@ namespace ConcordiaCurriculumManager.DTO;
 
 public class LoginDTO
 {
-    public const string MediaType = "application/x.ccm.authentication+json;v=1";
-
     [EmailAddress]
     public required string Email { get; set; }
 

--- a/Server/ConcordiaCurriculumManager/DTO/RegisterDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/RegisterDTO.cs
@@ -4,8 +4,6 @@ namespace ConcordiaCurriculumManager.DTO;
 
 public class RegisterDTO
 {
-    public const string MediaType = "application/x.ccm.authentication.create+json;v=1";
-
     public required string FirstName { get; set; }
 
     public required string LastName { get; set; }

--- a/Server/ConcordiaCurriculumManager/Services/UserAuthenticationService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/UserAuthenticationService.cs
@@ -68,8 +68,8 @@ public class UserAuthenticationService : IUserAuthenticationService
         var hashedPassword = _inputHasher.Hash(user.Password);
         user.Password = hashedPassword;
 
-        var visitorRole = new Role() { UserRole = RoleEnum.FacultyMember };
-        user.Roles.Add(visitorRole);
+        user.Roles.Add(new Role() { UserRole = RoleEnum.FacultyMember });
+        user.Roles.Add(new Role() { UserRole = RoleEnum.Initiator });
 
         var savedUser = await _userRepository.SaveUser(user);
 


### PR DESCRIPTION
Remove references to `application/x.ccm.authentication+json;v=1` and instead use `application/json` in all API calls.

Closes #59