### PR TITLE
#100 Make user email unique

### DIFF
--- a/Server/ConcordiaCurriculumManager/Migrations/20231017013029_MakeEmailUnique.Designer.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20231017013029_MakeEmailUnique.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConcordiaCurriculumManager.Migrations
 {
     [DbContext(typeof(CCMDbContext))]
-    partial class CCMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231017013029_MakeEmailUnique")]
+    partial class MakeEmailUnique
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/ConcordiaCurriculumManager/Migrations/20231017013029_MakeEmailUnique.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20231017013029_MakeEmailUnique.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcordiaCurriculumManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeEmailUnique : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                column: "Email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_Email",
+                table: "Users");
+        }
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Repositories/DatabaseContext/CCMDbContext.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DatabaseContext/CCMDbContext.cs
@@ -58,6 +58,10 @@ public class CCMDbContext : DbContext
         modelBuilder.Entity<User>()
             .HasMany(user => user.Roles)
             .WithMany(role => role.Users);
+
+        modelBuilder.Entity<User>()
+            .HasIndex(user => user.Email)
+            .IsUnique();
     }
 
     private static void ConfigureDossiersRelationship(ModelBuilder modelBuilder)


### PR DESCRIPTION
On attempting to insert a new row into the Users table in the database, require that the email be unique. Additionally, create an index for emails for faster searching, as many queries are done against this column.

Closes #100