### PR TITLE
#128 create get all users endpoint

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       run: dotnet restore Server/ConcordiaCurriculumManager/ConcordiaCurriculumManager.csproj
 
     - name: Run backend tests
-      run: dotnet test Server/ConcordiaCurriculumManagerTest/ConcordiaCurriculumManagerTest.csproj
+      run: dotnet test Server/ConcordiaCurriculumManagerTest/ConcordiaCurriculumManagerTest.csproj /p:TreatWarningsAsErrors=true
 
   deploy-backend:
     needs:

--- a/Server/ConcordiaCurriculumManager/Controllers/UsersController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/UsersController.cs
@@ -1,0 +1,52 @@
+﻿using AutoMapper;
+using ConcordiaCurriculumManager.DTO;
+using ConcordiaCurriculumManager.Models.Users;
+using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcordiaCurriculumManager.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Authorize(Roles = RoleNames.Admin)]
+public class UsersController : Controller
+{
+    private readonly IMapper _mapper;
+    private readonly IUserService _userService;
+
+    public UsersController(IMapper mapper, IUserService userService)
+    {
+        _mapper = mapper;
+        _userService = userService;
+    }
+
+    [HttpGet(nameof(GetAllUsersAsync))]
+    [SwaggerResponse(StatusCodes.Status200OK, "Current page of users was retrieved")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    public async Task<ActionResult> GetAllUsersAsync([FromQuery] Guid? lastId)
+    {
+        var users = await _userService.GetAllUsersPageableAsync(lastId ?? Guid.Empty);
+        var userDTOs = _mapper.Map<List<UserDTO>>(users);
+        return Ok(userDTOs);
+    }
+
+    [HttpGet(nameof(SearchUsersByEmail))]
+    [SwaggerResponse(StatusCodes.Status200OK, "Current page of users was retrieved by email")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    public async Task<ActionResult> SearchUsersByEmail([FromQuery] Guid? lastId, [FromQuery, Required] string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return BadRequest("Email cannot be null or white space");
+        }
+
+        var users = await _userService.GetUserLikeEmailAsync(lastId ?? Guid.Empty, email.Trim());
+        var userDTOs = _mapper.Map<List<UserDTO>>(users);
+        return Ok(userDTOs);
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Program.cs
+++ b/Server/ConcordiaCurriculumManager/Program.cs
@@ -162,6 +162,7 @@ public class Program
         services.AddScoped<ICourseService, CourseService>();
         services.AddScoped<IDossierService, DossierService>();
         services.AddScoped<IGroupService, GroupService>();
+        services.AddScoped<IUserService, UserService>();
 
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IGroupRepository, GroupRepository>();

--- a/Server/ConcordiaCurriculumManager/Repositories/UserRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/UserRepository.cs
@@ -9,6 +9,8 @@ public interface IUserRepository
     ValueTask<User?> GetUserById(Guid id);
     Task<User?> GetUserByEmail(string email);
     Task<bool> SaveUser(User user);
+    Task<IList<User>> GetAllUsersPageable(Guid id);
+    Task<IList<User>> GetUsersLikeEmailPageable(Guid id, string email);
 }
 
 public class UserRepository : IUserRepository
@@ -33,4 +35,18 @@ public class UserRepository : IUserRepository
         var result = await _dbContext.SaveChangesAsync();
         return result > 0;
     }
+
+    public async Task<IList<User>> GetAllUsersPageable(Guid id) => await _dbContext.Users
+        .OrderBy(u => u.Id)
+        .Where(u => u.Id > id)
+        .Take(10)
+        .Select(ObjectSelectors.UserSelector())
+        .ToListAsync();
+
+    public async Task<IList<User>> GetUsersLikeEmailPageable(Guid id, string email) => await _dbContext.Users
+        .OrderBy(u => u.Id)
+        .Where(u => u.Id > id && u.Email.Contains(email))
+        .Take(10)
+        .Select(ObjectSelectors.UserSelector())
+        .ToListAsync();
 }

--- a/Server/ConcordiaCurriculumManager/Services/GroupService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/GroupService.cs
@@ -83,6 +83,6 @@ public class GroupService : IGroupService
     public async Task<bool> IsGroupMaster(Guid userId, Guid groupId)
     {
         var group = await _groupRepository.GetGroupById(groupId);
-        return group.GroupMasters.Any(gm => gm.Id == userId);
+        return group is not null && group.GroupMasters.Any(gm => gm.Id == userId);
     }
 }

--- a/Server/ConcordiaCurriculumManager/Services/UserService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/UserService.cs
@@ -1,0 +1,24 @@
+﻿using ConcordiaCurriculumManager.Models.Users;
+using ConcordiaCurriculumManager.Repositories;
+
+namespace ConcordiaCurriculumManager.Services;
+
+public interface IUserService
+{
+    Task<IList<User>> GetUserLikeEmailAsync(Guid id, string email);
+    Task<IList<User>> GetAllUsersPageableAsync(Guid id);
+}
+
+public class UserService : IUserService
+{
+    private readonly IUserRepository _userRepository;
+
+    public UserService(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+
+    public async Task<IList<User>> GetAllUsersPageableAsync(Guid id) => await _userRepository.GetAllUsersPageable(id);
+
+    public async Task<IList<User>> GetUserLikeEmailAsync(Guid id, string email) => await _userRepository.GetUsersLikeEmailPageable(id, email);
+}

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/CourseRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/CourseRepositoryTests.cs
@@ -21,6 +21,9 @@ public class CourseRepositoryTests
         dbContext = new CCMDbContext(options);
     }
 
+    [ClassCleanup]
+    public static void ClassCleanup() => dbContext.Dispose();
+
     [TestInitialize] 
     public void TestInitialize()
     {

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/DossierRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/DossierRepositoryTests.cs
@@ -24,6 +24,9 @@ namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories
             dbContext = new CCMDbContext(options);
         }
 
+        [ClassCleanup]
+        public static void ClassCleanup() => dbContext.Dispose();
+
         [TestInitialize]
         public void TestInitialize()
         {

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/GroupRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/GroupRepositoryTests.cs
@@ -23,6 +23,9 @@ public class GroupRepositoryTests
         dbContext = new CCMDbContext(options);
     }
 
+    [ClassCleanup]
+    public static void ClassCleanup() => dbContext.Dispose();
+
     [TestInitialize]
     public void TestInitialize() 
     {

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/UserRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/UserRepositoryTests.cs
@@ -2,8 +2,6 @@
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using ConcordiaCurriculumManager.Repositories;
 using Microsoft.EntityFrameworkCore;
-using ConcordiaCurriculumManager.Settings;
-using Microsoft.Extensions.Options;
 
 namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories;
 
@@ -23,51 +21,42 @@ public class UserRepositoryTests
         dbContext = new CCMDbContext(options);
     }
 
+    [ClassCleanup]
+    public static void ClassCleanup() => dbContext.Dispose();
+
     [TestInitialize]
     public void TestInitialize()
     {
         userRepository = new UserRepository(dbContext);
     }
 
+    [TestCleanup]
+    public void TestCleanup()
+    {
+        dbContext.Users.RemoveRange(dbContext.Users);
+        dbContext.SaveChanges();
+    }
+
     [TestMethod]
     public async Task GetUserById_ValidId_ReturnsUser()
     {
-        var user = new User
-        {
-            Id = Guid.NewGuid(),
-            FirstName = "fname",
-            LastName = "lname",
-            Email = "test@example.com",
-            Password = "password"
-        };
+        var user = await InsertUsersIntoDbContext(numberOfUsersToInsert: 3);
 
-        dbContext.Users.Add(user);
-        await dbContext.SaveChangesAsync();
-
-        var result = await userRepository.GetUserById(user.Id);
+        var result = await userRepository.GetUserById(user[1].Id);
 
         Assert.IsNotNull(result);
-        Assert.AreEqual(user.Id, result.Id);
+        Assert.AreEqual(user[1].Id, result.Id);
     }
 
     [TestMethod]
     public async Task GetUserByEmail_ValidEmail_ReturnsUser()
     {
-        var user = new User
-        {
-            FirstName = "fname",
-            LastName = "lname",
-            Email = "test@example.com",
-            Password = "password"
-        };
+        var user = await InsertUsersIntoDbContext(numberOfUsersToInsert: 4);
 
-        dbContext.Users.Add(user);
-        await dbContext.SaveChangesAsync();
-
-        var result = await userRepository.GetUserByEmail(user.Email);
+        var result = await userRepository.GetUserByEmail(user[3].Email);
 
         Assert.IsNotNull(result);
-        Assert.AreEqual(user.Email, result.Email);
+        Assert.AreEqual(user[3].Email, result.Email);
     }
 
     [TestMethod]
@@ -84,5 +73,87 @@ public class UserRepositoryTests
         var result = await userRepository.SaveUser(user);
 
         Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public async Task GetAllUsersPageable_ReturnsCorrectNumberOfUsers()
+    {
+        await InsertUsersIntoDbContext(numberOfUsersToInsert: 20);
+        Guid id = Guid.Empty;
+        var users = await userRepository.GetAllUsersPageable(id);
+
+        Assert.AreEqual(10, users.Count);
+    }
+
+    [TestMethod]
+    public async Task GetAllUsersPageable_ReturnsCorrectPageableUsers()
+    {
+        var users = await InsertUsersIntoDbContext(numberOfUsersToInsert: 25);
+        users = users.OrderBy(u => u.Id).ToList();
+        Guid firstSearch = Guid.Empty, secondSearch = users[9].Id, thirdSearch = users[19].Id, fourthSearch = users[24].Id;
+
+        var firstResult = await userRepository.GetAllUsersPageable(firstSearch);
+        var secondResult = await userRepository.GetAllUsersPageable(secondSearch);
+        var thirdResult = await userRepository.GetAllUsersPageable(thirdSearch);
+        var fourthResult = await userRepository.GetAllUsersPageable(fourthSearch);
+
+        Assert.AreEqual(10, firstResult.Count);
+        Assert.AreEqual(10, secondResult.Count);
+        Assert.AreEqual(5, thirdResult.Count);
+        Assert.AreEqual(0, fourthResult.Count);
+    }
+
+    [TestMethod]
+    public async Task GetUsersLikeEmail_ReturnsCorrectNumberOfUsersAfterInsertion()
+    {
+        await InsertUsersIntoDbContext(numberOfUsersToInsert: 20);
+        Guid id = Guid.Empty;
+        string email = "@example";
+
+        var users = await userRepository.GetUsersLikeEmailPageable(id, email);
+
+        Assert.AreEqual(10, users.Count);
+    }
+
+    [TestMethod]
+    public async Task GetUsersLikeEmail_ReturnsCorrectPageableUsers()
+    {
+        var users = await InsertUsersIntoDbContext(numberOfUsersToInsert: 25);
+        users = users.OrderBy(u => u.Id).ToList();
+        string email = "@example";
+        Guid firstSearch = Guid.Empty, secondSearch = users[9].Id, thirdSearch = users[19].Id, fourthSearch = users[24].Id;
+
+        var firstResult = await userRepository.GetUsersLikeEmailPageable(firstSearch, email);
+        var secondResult = await userRepository.GetUsersLikeEmailPageable(secondSearch, email);
+        var thirdResult = await userRepository.GetUsersLikeEmailPageable(thirdSearch, email);
+        var fourthResult = await userRepository.GetUsersLikeEmailPageable(fourthSearch, email);
+
+        Assert.AreEqual(10, firstResult.Count);
+        Assert.AreEqual(10, secondResult.Count);
+        Assert.AreEqual(5, thirdResult.Count);
+        Assert.AreEqual(0, fourthResult.Count);
+    }
+
+    private async Task<List<User>> InsertUsersIntoDbContext(int numberOfUsersToInsert)
+    {
+        var usersToAdd = new List<User>();
+
+        for (int i = 0; i < numberOfUsersToInsert; i++)
+        {
+            var user = new User
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "John",
+                LastName = "Doe",
+                Email = $"user{i}@example.com",
+                Password = "password123"
+            };
+
+            usersToAdd.Add(user);
+        }
+
+        await dbContext.Users.AddRangeAsync(usersToAdd);
+        await dbContext.SaveChangesAsync();
+        return usersToAdd;
     }
 }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/GroupControllerTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/GroupControllerTests.cs
@@ -31,18 +31,18 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Controllers
         public async Task CreateGroup_ValidRequest_CreatesGroup()
         {
             var groupCreateDTO = new GroupCreateDTO { Name = "Test Group" };
-            var createdGroup = new ConcordiaCurriculumManager.Models.Users.Group { Id = Guid.NewGuid(), Name = groupCreateDTO.Name };
+            var createdGroup = new Group { Id = Guid.NewGuid(), Name = groupCreateDTO.Name };
 
-            _groupService.Setup(x => x.CreateGroupAsync(It.IsAny<ConcordiaCurriculumManager.Models.Users.Group>()))
+            _groupService.Setup(x => x.CreateGroupAsync(It.IsAny<Group>()))
                          .ReturnsAsync(true)
-                         .Callback<ConcordiaCurriculumManager.Models.Users.Group>((x) => x.Id = createdGroup.Id); // Simulate setting the ID upon creation
+                         .Callback<Group>((x) => x.Id = createdGroup.Id); // Simulate setting the ID upon creation
 
             var result = await _groupController.CreateGroup(groupCreateDTO);
 
             Assert.IsInstanceOfType(result, typeof(CreatedAtActionResult));
             var createdResult = (CreatedAtActionResult)result;
             Assert.AreEqual((int)HttpStatusCode.Created, createdResult.StatusCode);
-            Assert.AreEqual(createdGroup.Id, ((ConcordiaCurriculumManager.Models.Users.Group)createdResult.Value).Id);
+            Assert.AreEqual(createdGroup.Id, (createdResult.Value as Group)!.Id);
         }
 
         [TestMethod]
@@ -74,14 +74,14 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Controllers
 
             var objectResult = result as OkObjectResult;
 
-            Assert.AreEqual((int)HttpStatusCode.OK, objectResult.StatusCode);
+            Assert.AreEqual((int)HttpStatusCode.OK, objectResult!.StatusCode);
             Assert.AreEqual(expectedGroup, objectResult.Value);
         }
 
         [TestMethod]
         public async Task GetGroupById_NotFound_Returns404()
         {
-            _groupService.Setup(x => x.GetGroupByIdAsync(It.IsAny<Guid>())).ReturnsAsync((GroupDTO)null);
+            _groupService.Setup(x => x.GetGroupByIdAsync(It.IsAny<Guid>())).ReturnsAsync((GroupDTO)null!);
 
             var result = await _groupController.GetGroupById(Guid.NewGuid());
 

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/UsersControllerTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/UsersControllerTest.cs
@@ -1,0 +1,98 @@
+﻿using AutoMapper;
+using ConcordiaCurriculumManager.Controllers;
+using ConcordiaCurriculumManager.DTO;
+using ConcordiaCurriculumManager.Models.Users;
+using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace ConcordiaCurriculumManagerTest.UnitTests.Controller;
+
+[TestClass]
+public class UsersControllerTest
+{
+    private Mock<IUserService> userService = null!;
+    private UsersController usersController = null!;
+    private Mock<IMapper> mapper = null!;
+
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        userService = new Mock<IUserService>();
+        mapper = new Mock<IMapper>();
+
+        usersController = new UsersController(mapper.Object, userService.Object);
+    }
+
+    [TestMethod]
+    public async Task GetAllUsersAsync_WithNullGuid_CallsUserServiceWithEmptyGuid()
+    {
+        Guid expectedGuid = Guid.Empty;
+        userService.Setup(service => service.GetAllUsersPageableAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new List<User>()); 
+
+        mapper.Setup(mapper => mapper.Map<List<UserDTO>>(It.IsAny<List<User>>()))
+            .Returns(new List<UserDTO>());
+
+        var result = await usersController.GetAllUsersAsync(null) as OkObjectResult;
+
+        userService.Verify(service => service.GetAllUsersPageableAsync(expectedGuid), Times.Once);
+        Assert.IsInstanceOfType(result?.Value, typeof(List<UserDTO>));
+    }
+
+    [TestMethod]
+    public async Task GetAllUsersAsync_WithGuid_CallsUserServiceWithProvidedGuid()
+    {
+        Guid expectedGuid = Guid.NewGuid();
+        userService.Setup(service => service.GetAllUsersPageableAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new List<User>());
+
+        mapper.Setup(mapper => mapper.Map<List<UserDTO>>(It.IsAny<List<User>>()))
+            .Returns(new List<UserDTO>());
+
+        var result = await usersController.GetAllUsersAsync(expectedGuid) as OkObjectResult;
+
+        userService.Verify(service => service.GetAllUsersPageableAsync(expectedGuid), Times.Once);
+        Assert.IsInstanceOfType(result?.Value, typeof(List<UserDTO>));
+    }
+
+    [TestMethod]
+    public async Task SearchUsersByEmail_WithNullEmail_ReturnsBadRequestResult()
+    {
+        var result = await usersController.SearchUsersByEmail(null, null!);
+        Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+    }
+
+    [TestMethod]
+    public async Task SearchUsersByEmail_WithNullGuid_CallsUserServiceWithEmptyGuid()
+    {
+        Guid expectedGuid = Guid.Empty;
+        userService.Setup(service => service.GetUserLikeEmailAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<User>()); 
+
+        mapper.Setup(mapper => mapper.Map<List<UserDTO>>(It.IsAny<List<User>>()))
+            .Returns(new List<UserDTO>());
+
+        var result = await usersController.SearchUsersByEmail(null, "test@example.com") as OkObjectResult;
+
+        userService.Verify(service => service.GetUserLikeEmailAsync(expectedGuid, It.IsAny<string>()), Times.Once);
+        Assert.IsInstanceOfType(result?.Value, typeof(List<UserDTO>));
+    }
+
+    [TestMethod]
+    public async Task SearchUsersByEmail_WithValidGuid_CallsUserServiceWithValidGuid()
+    {
+        Guid validGuid = Guid.NewGuid();
+        userService.Setup(service => service.GetUserLikeEmailAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .ReturnsAsync(new List<User>()); 
+
+        mapper.Setup(mapper => mapper.Map<List<UserDTO>>(It.IsAny<List<User>>()))
+            .Returns(new List<UserDTO>());
+
+        var result = await usersController.SearchUsersByEmail(validGuid, "test@example.com") as OkObjectResult;
+
+        userService.Verify(service => service.GetUserLikeEmailAsync(validGuid, It.IsAny<string>()), Times.Once);
+        Assert.IsInstanceOfType(result?.Value, typeof(List<UserDTO>));
+    }
+}

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/UserServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/UserServiceTest.cs
@@ -1,0 +1,39 @@
+﻿using ConcordiaCurriculumManager.Repositories;
+using ConcordiaCurriculumManager.Services;
+using Moq;
+
+namespace ConcordiaCurriculumManagerTest.UnitTests.Services;
+
+[TestClass]
+public class UserServiceTest
+{
+    private Mock<IUserRepository> userRepositoryMock = null!;
+    private UserService userService = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        userRepositoryMock = new Mock<IUserRepository>();
+        userService = new UserService(userRepositoryMock.Object);
+    }
+
+    [TestMethod]
+    public async Task GetAllUsersPageableAsync_ShouldCallGetAllUsersPageableMethodOfRepository_WhenValidIdProvided()
+    {
+        Guid validId = Guid.NewGuid();
+
+        await userService.GetAllUsersPageableAsync(validId);
+
+        userRepositoryMock.Verify(repo => repo.GetAllUsersPageable(validId), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task GetUserLikeEmailPageableAsync_ShouldCallGetUsersLikeEmailMethodOfRepository_WhenValidIdAndEmailProvided()
+    {
+        Guid validId = Guid.NewGuid();
+        string validEmail = "test@example.com";
+
+        await userService.GetUserLikeEmailAsync(validId, validEmail);
+        userRepositoryMock.Verify(repo => repo.GetUsersLikeEmailPageable(validId, validEmail), Times.Once);
+    }
+}


### PR DESCRIPTION
This PR closes: #128 

A `UserService` was created instead of adding the methods in `UserAuthenticationService` to provide a separation of concern where `UserService` involves operations on the `User` that do not involve any authentication logic.