### PR TITLE
#146 implement policy based auth

### DIFF
--- a/Server/ConcordiaCurriculumManager/Controllers/GroupController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/GroupController.cs
@@ -5,13 +5,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Swashbuckle.AspNetCore.Annotations;
 using ConcordiaCurriculumManager.Security;
-using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace ConcordiaCurriculumManager.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("[controller]")]
-[Authorize]
 public class GroupController : Controller
 {
     private readonly IGroupService _groupService;
@@ -44,12 +44,12 @@ public class GroupController : Controller
         }
     }
 
-    [HttpGet("{id}")]
+    [HttpGet("{groupId}")]
     [SwaggerResponse(StatusCodes.Status200OK, "Group retrieved successfully")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Group not found")]
-    public async Task<IActionResult> GetGroupById(Guid id)
+    public async Task<IActionResult> GetGroupById([FromRoute, Required] Guid groupId)
     {
-        var group = await _groupService.GetGroupByIdAsync(id);
+        var group = await _groupService.GetGroupByIdAsync(groupId);
         if (group == null)
         {
             return NotFound();
@@ -67,31 +67,11 @@ public class GroupController : Controller
     }
 
     [HttpPost("{groupId}/users/{userId}")]
-    [Authorize]
+    [Authorize(Policies.IsGroupMasterOrAdmin)]
     [SwaggerResponse(StatusCodes.Status200OK, "User added to group successfully")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Error adding user to group")]
-    public async Task<IActionResult> AddUserToGroup(Guid groupId, Guid userId)
+    public async Task<IActionResult> AddUserToGroup([FromRoute, Required] Guid groupId, [FromRoute, Required] Guid userId)
     {
-        Guid currentUserId;
-        try
-        {
-            currentUserId = Guid.Parse(_userService.GetCurrentUserClaim(Claims.Id));
-        }
-        catch (Exception e)
-        {
-            var message = "Unexpected error occurred while retrieving user information.";
-            _logger.LogWarning($"${message}: {e.Message}");
-            return Problem(
-                title: message,
-                detail: e.Message,
-                statusCode: StatusCodes.Status500InternalServerError);
-        }
-
-        if (!await IsAdminOrGroupMaster(currentUserId, groupId))
-        {
-            return StatusCode(StatusCodes.Status403Forbidden, "You must be an admin or a group master to make changes to this group");
-        }
-
         var result = await _groupService.AddUserToGroup(userId, groupId);
         if (result)
         {
@@ -101,31 +81,11 @@ public class GroupController : Controller
     }
 
     [HttpDelete("{groupId}/users/{userId}")]
-    [Authorize]
+    [Authorize(Policies.IsGroupMasterOrAdmin)]
     [SwaggerResponse(StatusCodes.Status200OK, "User removed from group successfully")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Error removing user from group")]
-    public async Task<IActionResult> RemoveUserFromGroup(Guid groupId, Guid userId)
+    public async Task<IActionResult> RemoveUserFromGroup([FromRoute, Required] Guid groupId, [FromRoute, Required] Guid userId)
     {
-        Guid currentUserId;
-        try
-        {
-            currentUserId = Guid.Parse(_userService.GetCurrentUserClaim(Claims.Id));
-        }
-        catch (Exception e)
-        {
-            var message = "Unexpected error occured while retrieving user information.";
-            _logger.LogWarning($"${message}: {e.Message}");
-            return Problem(
-                title: message,
-                detail: e.Message,
-                statusCode: StatusCodes.Status500InternalServerError);
-        }
-
-        if (!await IsAdminOrGroupMaster(currentUserId, groupId))
-        {
-            return StatusCode(StatusCodes.Status403Forbidden, "You must be an admin or a group master to make changes to this group");
-        }
-
         var result = await _groupService.RemoveUserFromGroup(userId, groupId);
         if (result)
         {
@@ -135,31 +95,11 @@ public class GroupController : Controller
     }
 
     [HttpPost("{groupId}/masters/{userId}")]
-    [Authorize]
+    [Authorize(Policies.IsGroupMasterOrAdmin)]
     [SwaggerResponse(StatusCodes.Status200OK, "User added to group masters successfully")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "User is not a member of this group or is already a group master")]
-    public async Task<IActionResult> AddGroupMaster(Guid groupId, Guid userId)
+    public async Task<IActionResult> AddGroupMaster([FromRoute, Required] Guid groupId, [FromRoute, Required] Guid userId)
     {
-        Guid currentUserId;
-        try
-        {
-            currentUserId = Guid.Parse(_userService.GetCurrentUserClaim(Claims.Id));
-        }
-        catch (Exception e)
-        {
-            var message = "Unexpected error occured while retrieving user information.";
-            _logger.LogWarning($"${message}: {e.Message}");
-            return Problem(
-                title: message,
-                detail: e.Message,
-                statusCode: StatusCodes.Status500InternalServerError);
-        }
-
-        if (!await IsAdminOrGroupMaster(currentUserId, groupId))
-        {
-            return StatusCode(StatusCodes.Status403Forbidden, "You must be an admin or a group master to make changes to this group");
-        }
-
         var result = await _groupService.AddGroupMaster(userId, groupId);
         if (result)
         {
@@ -169,44 +109,16 @@ public class GroupController : Controller
     }
 
     [HttpDelete("{groupId}/masters/{userId}")]
-    [Authorize]
+    [Authorize(Policies.IsGroupMasterOrAdmin)]
     [SwaggerResponse(StatusCodes.Status200OK, "User removed from group masters successfully")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "User is not a member of this group or is not a group master")]
-    public async Task<IActionResult> RemoveGroupMaster(Guid groupId, Guid userId)
+    public async Task<IActionResult> RemoveGroupMaster([FromRoute, Required] Guid groupId, [FromRoute, Required] Guid userId)
     {
-        Guid currentUserId;
-        try
-        {
-            currentUserId = Guid.Parse(_userService.GetCurrentUserClaim(Claims.Id));
-        }
-        catch (Exception e)
-        {
-            var message = "Unexpected error occured while retrieving user information.";
-            _logger.LogWarning($"${message}: {e.Message}");
-            return Problem(
-                title: message,
-                detail: e.Message,
-                statusCode: StatusCodes.Status500InternalServerError);
-        }
-
-        if (!await IsAdminOrGroupMaster(currentUserId, groupId))
-        {
-            return StatusCode(StatusCodes.Status403Forbidden, "You must be an admin or a group master to make changes to this group");
-        }
-
         var result = await _groupService.RemoveGroupMaster(userId, groupId);
         if (result)
         {
             return Ok();
         }
         return NotFound();
-    }
-
-    [NonAction]
-    public async Task<bool> IsAdminOrGroupMaster(Guid currentUserId, Guid groupId)
-    {
-        bool isAdmin = User.IsInRole(RoleNames.Admin);
-        bool isGroupMaster = await _groupService.IsGroupMaster(currentUserId, groupId);
-        return isAdmin || isGroupMaster;
     }
 }

--- a/Server/ConcordiaCurriculumManager/DTO/Dossiers/EditDossierDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/Dossiers/EditDossierDTO.cs
@@ -3,8 +3,6 @@ namespace ConcordiaCurriculumManager.DTO.Dossiers
 {
     public class EditDossierDTO
     {
-        public required Guid Id { get; set; }
-
         public required Guid InitiatorId { get; set; }
 
         public required string Title { get; set; }

--- a/Server/ConcordiaCurriculumManager/Program.cs
+++ b/Server/ConcordiaCurriculumManager/Program.cs
@@ -58,6 +58,7 @@ public class Program
                 options.Events = new TokenValidation();
             });
 
+        builder.Services.AddAuthorizationHandlers();
         builder.Services.AddAuthorization(options => options.AddPolicies());
 
         var dbSetting = builder.Configuration

--- a/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
@@ -51,8 +51,8 @@ public class DossierRepository : IDossierRepository
 
     public async Task<Dossier?> GetDossierByDossierId(Guid dossierId) => await _dbContext.Dossiers
         .Select(ObjectSelectors.DossierSelector())
-        .Where(d => d.Id == dossierId).FirstOrDefaultAsync();
-
+        .Where(d => d.Id == dossierId)
+        .FirstOrDefaultAsync();
 
     public async Task<bool> SaveDossier(Dossier dossier)
     {

--- a/Server/ConcordiaCurriculumManager/Repositories/UserRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/UserRepository.cs
@@ -6,7 +6,7 @@ namespace ConcordiaCurriculumManager.Repositories;
 
 public interface IUserRepository
 {
-    ValueTask<User?> GetUserById(Guid id);
+    Task<User?> GetUserById(Guid id);
     Task<User?> GetUserByEmail(string email);
     Task<bool> SaveUser(User user);
     Task<IList<User>> GetAllUsersPageable(Guid id);
@@ -22,7 +22,10 @@ public class UserRepository : IUserRepository
         _dbContext = dbContext;
     }
 
-    public ValueTask<User?> GetUserById(Guid id) => _dbContext.Users.FindAsync(id);
+    public Task<User?> GetUserById(Guid id) => _dbContext.Users
+        .Where(user => Equals(user.Id, id))
+        .Select(ObjectSelectors.UserSelector())
+        .FirstOrDefaultAsync();
 
     public Task<User?> GetUserByEmail(string email) => _dbContext.Users
         .Where(user => string.Equals(user.Email.ToLower(), email.ToLower()))

--- a/Server/ConcordiaCurriculumManager/Security/AuthorizationPolicies.cs
+++ b/Server/ConcordiaCurriculumManager/Security/AuthorizationPolicies.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using ConcordiaCurriculumManager.Security.Requirements;
+using ConcordiaCurriculumManager.Security.Requirements.Handlers;
+using Microsoft.AspNetCore.Authorization;
 
 namespace ConcordiaCurriculumManager.Security;
 
@@ -6,6 +8,25 @@ public static class AuthorizationPolicies
 {
     public static void AddPolicies(this AuthorizationOptions options)
     {
+        options.AddPolicy(Policies.IsGroupMasterOrAdmin, policy =>
+        {
+            policy.AddRequirements(new GroupMasterOrAdminRequirement())
+            .RequireAuthenticatedUser()
+            .Build();
+        });
 
+        options.AddPolicy(Policies.IsOwnerOfDossier, policy =>
+        {
+            policy.AddRequirements(new OwnerOfDossierRequirement())
+            .RequireAuthenticatedUser()
+            .Build();
+        });
+    }
+
+    public static void AddAuthorizationHandlers(this IServiceCollection services)
+    {
+        services.AddScoped<IAuthorizationHandler, AdminHandler>();
+        services.AddScoped<IAuthorizationHandler, GroupMasterHandler>();
+        services.AddScoped<IAuthorizationHandler, OwnerOfDossierHanlder>();
     }
 }

--- a/Server/ConcordiaCurriculumManager/Security/AuthorizationPolicies.cs
+++ b/Server/ConcordiaCurriculumManager/Security/AuthorizationPolicies.cs
@@ -27,6 +27,6 @@ public static class AuthorizationPolicies
     {
         services.AddScoped<IAuthorizationHandler, AdminHandler>();
         services.AddScoped<IAuthorizationHandler, GroupMasterHandler>();
-        services.AddScoped<IAuthorizationHandler, OwnerOfDossierHanlder>();
+        services.AddScoped<IAuthorizationHandler, OwnerOfDossierHandler>();
     }
 }

--- a/Server/ConcordiaCurriculumManager/Security/Claims.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Claims.cs
@@ -20,8 +20,3 @@ public static class Claims
 
     public const string GroupMaster = "groupMaster";
 }
-
-public static class Policies
-{
-    public static string Initiator => RoleEnum.Initiator.ToString();
-}

--- a/Server/ConcordiaCurriculumManager/Security/Policies.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Policies.cs
@@ -1,0 +1,7 @@
+﻿namespace ConcordiaCurriculumManager.Security;
+
+public static class Policies
+{
+    public const string IsGroupMasterOrAdmin = nameof(IsGroupMasterOrAdmin);
+    public const string IsOwnerOfDossier = nameof(IsOwnerOfDossier);
+}

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/GroupMasterOrAdminRequirement.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/GroupMasterOrAdminRequirement.cs
@@ -1,0 +1,7 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace ConcordiaCurriculumManager.Security.Requirements;
+
+public class GroupMasterOrAdminRequirement : IAuthorizationRequirement
+{
+}

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/AdminHandler.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/AdminHandler.cs
@@ -1,0 +1,64 @@
+﻿using ConcordiaCurriculumManager.Models.Users;
+using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Authorization;
+
+namespace ConcordiaCurriculumManager.Security.Requirements.Handlers;
+
+public class AdminHandler : IAuthorizationHandler
+{
+    private readonly ILogger<AdminHandler> _logger;
+    private readonly IUserService _userService;
+
+    public AdminHandler(ILogger<AdminHandler> logger, IUserService userService)
+    {
+        _logger = logger;
+        _userService = userService;
+    }
+
+    public async Task HandleAsync(AuthorizationHandlerContext context)
+    {
+        var pendingRequirements = context.PendingRequirements.ToList();
+        var result = pendingRequirements.Select(requirement => CheckIfAdmin(context, requirement));
+        await Task.WhenAll(result);
+    }
+
+    private async Task CheckIfAdmin(AuthorizationHandlerContext context, IAuthorizationRequirement requirement)
+    {
+        if (requirement is not GroupMasterOrAdminRequirement)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Evaluting AdminHandler");
+
+        if (context.User.Identity is null || !context.User.Identity.IsAuthenticated)
+        {
+            context.Fail();
+            return;
+        }
+
+        var id = context.User.Claims.FirstOrDefault(c => c.Type.Equals(Claims.Id));
+
+        if (id is null || !Guid.TryParse(id.Value, out var parsedId))
+        {
+            _logger.LogWarning("User is authenticated without a valid Id claim");
+            context.Fail();
+            return;
+        }
+
+        var user = await _userService.GetUserById(parsedId);
+
+        if (user is null)
+        {
+            _logger.LogWarning("User is not authenticated but does not exist in the database");
+            context.Fail();
+            return;
+        }
+
+        if (user.Roles.Any(r => r.UserRole.Equals(RoleEnum.Admin)))
+        {
+            context.Succeed(requirement);
+        }
+
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/GroupMasterHandler.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/GroupMasterHandler.cs
@@ -25,7 +25,7 @@ public class GroupMasterHandler : AuthorizationHandler<GroupMasterOrAdminRequire
             || !Guid.TryParse(groupId?.ToString(), out var parsedGroupId))
         {
             // This is not an Http Request or there is no group Id. Abstain
-            _logger.LogWarning("GroupMasterHanlder is possibly called on a http endpoint that does not include a group id as a param");
+            _logger.LogWarning("GroupMasterHandler is possibly called on a http endpoint that does not include a group id as a param");
             return;
         }
 

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/GroupMasterHandler.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/GroupMasterHandler.cs
@@ -1,0 +1,54 @@
+﻿using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Authorization;
+
+namespace ConcordiaCurriculumManager.Security.Requirements.Handlers;
+
+public class GroupMasterHandler : AuthorizationHandler<GroupMasterOrAdminRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<GroupMasterHandler> _logger;
+    private readonly IGroupService _groupService;
+
+    public GroupMasterHandler(ILogger<GroupMasterHandler> logger, IGroupService groupService, IHttpContextAccessor contextAccessor)
+    {
+        _logger = logger;
+        _groupService = groupService;
+        _httpContextAccessor = contextAccessor;
+    }
+
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, GroupMasterOrAdminRequirement requirement)
+    {
+        _logger.LogInformation("Evaluting GroupMasterHanlder");
+
+        if (_httpContextAccessor.HttpContext is null
+            || !_httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue("groupId", out var groupId)
+            || !Guid.TryParse(groupId?.ToString(), out var parsedGroupId))
+        {
+            // This is not an Http Request or there is no group Id. Abstain
+            _logger.LogWarning("GroupMasterHanlder is possibly called on a http endpoint that does not include a group id as a param");
+            return;
+        }
+
+        if (context.User.Identity is null || !context.User.Identity.IsAuthenticated)
+        {
+            context.Fail();
+            return;
+        }
+
+        var userId = context.User.Claims.FirstOrDefault(c => c.Type.Equals(Claims.Id));
+
+        if (userId is null || !Guid.TryParse(userId.Value, out var parsedUserId))
+        {
+            _logger.LogWarning("User is authenticated without a valid Id claim");
+            context.Fail();
+            return;
+        }
+
+        var isGroupMaster = await _groupService.IsGroupMaster(parsedUserId, parsedGroupId);
+
+        if (isGroupMaster)
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
@@ -3,13 +3,13 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace ConcordiaCurriculumManager.Security.Requirements.Handlers;
 
-public class OwnerOfDossierHanlder : AuthorizationHandler<OwnerOfDossierRequirement>
+public class OwnerOfDossierHandler : AuthorizationHandler<OwnerOfDossierRequirement>
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly ILogger<OwnerOfDossierHanlder> _logger;
+    private readonly ILogger<OwnerOfDossierHandler> _logger;
     private readonly IDossierService _dossierService;
 
-    public OwnerOfDossierHanlder(IHttpContextAccessor httpContextAccessor, ILogger<OwnerOfDossierHanlder> logger, IDossierService dossierService)
+    public OwnerOfDossierHandler(IHttpContextAccessor httpContextAccessor, ILogger<OwnerOfDossierHandler> logger, IDossierService dossierService)
     {
         _httpContextAccessor = httpContextAccessor;
         _logger = logger;
@@ -25,7 +25,7 @@ public class OwnerOfDossierHanlder : AuthorizationHandler<OwnerOfDossierRequirem
             || !Guid.TryParse(dossierId?.ToString(), out var parsedDossierId))
         {
             // This is not an Http Request or there is no group Id. Abstain
-            _logger.LogWarning("OwnerOfDossierHanlder is possibly called on a http endpoint that does not include a dossier id as a param");
+            _logger.LogWarning("OwnerOfDossierHandler is possibly called on a http endpoint that does not include a dossier id as a param");
             return;
         }
 

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
@@ -1,0 +1,57 @@
+﻿using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Authorization;
+
+namespace ConcordiaCurriculumManager.Security.Requirements.Handlers;
+
+public class OwnerOfDossierHanlder : AuthorizationHandler<OwnerOfDossierRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<OwnerOfDossierHanlder> _logger;
+    private readonly IDossierService _dossierService;
+
+    public OwnerOfDossierHanlder(IHttpContextAccessor httpContextAccessor, ILogger<OwnerOfDossierHanlder> logger, IDossierService dossierService)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _logger = logger;
+        _dossierService = dossierService;
+    }
+
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, OwnerOfDossierRequirement requirement)
+    {
+        _logger.LogInformation("Evaluting OwnerOfDossierHanlder");
+
+        if (_httpContextAccessor.HttpContext is null
+            || !_httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue("dossierId", out var dossierId)
+            || !Guid.TryParse(dossierId?.ToString(), out var parsedDossierId))
+        {
+            // This is not an Http Request or there is no group Id. Abstain
+            _logger.LogWarning("OwnerOfDossierHanlder is possibly called on a http endpoint that does not include a dossier id as a param");
+            return;
+        }
+
+        if (context.User.Identity is null || !context.User.Identity.IsAuthenticated)
+        {
+            context.Fail();
+            return;
+        }
+
+        var userId = context.User.Claims.FirstOrDefault(c => c.Type.Equals(Claims.Id));
+
+        if (userId is null || !Guid.TryParse(userId.Value, out var parsedUserId))
+        {
+            _logger.LogWarning("User is authenticated without a valid Id claim");
+            context.Fail();
+            return;
+        }
+
+        var dossier = await _dossierService.GetDossierDetailsById(parsedDossierId);
+
+        if (dossier is null || !dossier.InitiatorId.Equals(parsedUserId))
+        {
+            context.Fail();
+            return;
+        }
+
+        context.Succeed(requirement);
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/OwnerOfDossierRequirement.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/OwnerOfDossierRequirement.cs
@@ -1,0 +1,7 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace ConcordiaCurriculumManager.Security.Requirements;
+
+public class OwnerOfDossierRequirement : IAuthorizationRequirement
+{
+}

--- a/Server/ConcordiaCurriculumManager/Services/DossierService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/DossierService.cs
@@ -11,9 +11,9 @@ public interface IDossierService
 {
     public Task<List<Dossier>> GetDossiersByID(Guid ID);
     public Task<Dossier> CreateDossierForUser(CreateDossierDTO dossier, User user);
-    public Task<Dossier> EditDossier(EditDossierDTO dossier, User user);
-    public Task DeleteDossier(Guid ID, User user);
-    public Task<Dossier> GetDossierDetailsById(Guid id);
+    public Task<Dossier> EditDossier(EditDossierDTO dossier, Guid dossierId);
+    public Task DeleteDossier(Guid dossierId);
+    public Task<Dossier?> GetDossierDetailsById(Guid id);
 }
 
 public class DossierService : IDossierService
@@ -54,20 +54,9 @@ public class DossierService : IDossierService
         return dossier;
     }
 
-    public async Task<Dossier> EditDossier(EditDossierDTO d, User user)
+    public async Task<Dossier> EditDossier(EditDossierDTO d, Guid dossierId)
     {
-        var dossier = await _dossierRepository.GetDossierByDossierId(d.Id);
-
-        if (dossier == null)
-        {
-            throw new ArgumentException("The dossier does not exist.");
-        }
-
-        if (dossier.InitiatorId != user.Id)
-        {
-            throw new ArgumentException("The dossier does not belong to " + user.FirstName + " " + user.LastName);
-        }
-
+        var dossier = await _dossierRepository.GetDossierByDossierId(dossierId) ?? throw new ArgumentException("The dossier does not exist.");
         dossier.Title = d.Title;
         dossier.Description = d.Description;
 
@@ -77,26 +66,15 @@ public class DossierService : IDossierService
             _logger.LogWarning($"Error editing ${typeof(Dossier)} ${dossier.Id}");
             throw new Exception("Error editing the dossier");
         }
+        
         _logger.LogInformation($"Edited ${typeof(Dossier)} ${dossier.Id}");
-
         return dossier;
     }
 
 
-    public async Task DeleteDossier(Guid ID, User user)
+    public async Task DeleteDossier(Guid dossierId)
     {
-        var dossier = await _dossierRepository.GetDossierByDossierId(ID);
-
-        if (dossier == null)
-        {
-            throw new ArgumentException("The dossier does not exist.");
-        }
-
-        if (dossier.InitiatorId != user.Id)
-        {
-            throw new ArgumentException("The dossier does not belong to " + user.FirstName + " " + user.LastName);
-        }
-
+        var dossier = await _dossierRepository.GetDossierByDossierId(dossierId) ?? throw new ArgumentException("The dossier does not exist.");
         bool editedDossier = await _dossierRepository.DeleteDossier(dossier);
         if (!editedDossier)
         {
@@ -106,14 +84,6 @@ public class DossierService : IDossierService
         _logger.LogInformation($"Deleted ${typeof(Dossier)} ${dossier.Id}");
     }
 
-    public async Task<Dossier> GetDossierDetailsById(Guid id)
-    {
-        var dossierDetails = await _dossierRepository.GetDossierByDossierId(id);
-        if (dossierDetails == null)
-            throw new ArgumentException("Dossier could not be found.");
-
-        return dossierDetails;
-
-    }
+    public async Task<Dossier?> GetDossierDetailsById(Guid id) => await _dossierRepository.GetDossierByDossierId(id);
 }
 

--- a/Server/ConcordiaCurriculumManager/Services/UserService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/UserService.cs
@@ -7,6 +7,7 @@ public interface IUserService
 {
     Task<IList<User>> GetUserLikeEmailAsync(Guid id, string email);
     Task<IList<User>> GetAllUsersPageableAsync(Guid id);
+    Task<User?> GetUserById(Guid id);
 }
 
 public class UserService : IUserService
@@ -21,4 +22,6 @@ public class UserService : IUserService
     public async Task<IList<User>> GetAllUsersPageableAsync(Guid id) => await _userRepository.GetAllUsersPageable(id);
 
     public async Task<IList<User>> GetUserLikeEmailAsync(Guid id, string email) => await _userRepository.GetUsersLikeEmailPageable(id, email);
+
+    public async Task<User?> GetUserById(Guid id) => await _userRepository.GetUserById(id);
 }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/DossierControllerTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/DossierControllerTest.cs
@@ -75,9 +75,9 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Services
             var editDossier = GetSampleEditDossierDTO();
 
             userService.Setup(u => u.GetCurrentUser()).ReturnsAsync(user);
-            dossierService.Setup(d => d.EditDossier(editDossier, user)).ReturnsAsync(dossier);
+            dossierService.Setup(d => d.EditDossier(editDossier, dossier.Id)).ReturnsAsync(dossier);
 
-            var actionResult = await dossierController.EditDossier(editDossier);
+            var actionResult = await dossierController.EditDossier(dossier.Id, editDossier);
             var objectResult = (ObjectResult)actionResult;
 
             Assert.AreEqual((int)HttpStatusCode.Created, objectResult.StatusCode);
@@ -87,9 +87,9 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Services
         [TestMethod]
         public async Task EditDossier_InvalidCall_Returns400()
         {
-            dossierService.Setup(d => d.EditDossier(It.IsAny<EditDossierDTO>(), It.IsAny<User>())).Throws(new ArgumentException());
+            dossierService.Setup(d => d.EditDossier(It.IsAny<EditDossierDTO>(), It.IsAny<Guid>())).Throws(new ArgumentException());
 
-            var actionResult = await dossierController.EditDossier(GetSampleEditDossierDTO());
+            var actionResult = await dossierController.EditDossier(Guid.NewGuid(), GetSampleEditDossierDTO());
             var objectResult = (ObjectResult)actionResult;
 
             Assert.AreEqual((int)HttpStatusCode.BadRequest, objectResult.StatusCode);
@@ -98,9 +98,9 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Services
         [TestMethod]
         public async Task EditDossier_ServerError_Returns500()
         {
-            dossierService.Setup(d => d.EditDossier(It.IsAny<EditDossierDTO>(), It.IsAny<User>())).Throws(new Exception());
+            dossierService.Setup(d => d.EditDossier(It.IsAny<EditDossierDTO>(), It.IsAny<Guid>())).Throws(new Exception());
 
-            var actionResult = await dossierController.EditDossier(GetSampleEditDossierDTO());
+            var actionResult = await dossierController.EditDossier(Guid.NewGuid(), GetSampleEditDossierDTO());
             var objectResult = (ObjectResult)actionResult;
 
             Assert.AreEqual((int)HttpStatusCode.InternalServerError, objectResult.StatusCode);
@@ -136,7 +136,7 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Services
         [TestMethod]
         public async Task DeleteDossier_InvalidCall_Returns400()
         {
-            dossierService.Setup(d => d.DeleteDossier(It.IsAny<Guid>(), It.IsAny<User>())).Throws(new ArgumentException());
+            dossierService.Setup(d => d.DeleteDossier(It.IsAny<Guid>())).Throws(new ArgumentException());
 
             var actionResult = await dossierController.DeleteDossier(GetSampleDeleteDossierDTO());
             var objectResult = (ObjectResult)actionResult;
@@ -147,7 +147,7 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Services
         [TestMethod]
         public async Task DeleteDossier_ServerError_Returns500()
         {
-            dossierService.Setup(d => d.DeleteDossier(It.IsAny<Guid>(), It.IsAny<User>())).Throws(new Exception());
+            dossierService.Setup(d => d.DeleteDossier(It.IsAny<Guid>())).Throws(new Exception());
 
             var actionResult = await dossierController.DeleteDossier(GetSampleDeleteDossierDTO());
             var objectResult = (ObjectResult)actionResult;
@@ -181,7 +181,6 @@ namespace ConcordiaCurriculumManagerTest.UnitTests.Services
         {
             return new EditDossierDTO
             {
-                Id = Guid.NewGuid(),
                 InitiatorId = Guid.NewGuid(),
                 Title = "test title",
                 Description = "test description"

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
@@ -62,6 +62,7 @@ public class DossierServiceTest
 
         var dossierDetails = await dossierService.GetDossierDetailsById(Guid.NewGuid());
 
+        Assert.IsNotNull(dossierDetails);
         Assert.AreEqual(dossier.Id, dossierDetails.Id);
     }
 

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
@@ -1,278 +1,242 @@
-﻿using Castle.Core.Logging;
-using ConcordiaCurriculumManager.DTO.Dossiers;
-using ConcordiaCurriculumManager.Models.Curriculum;
+﻿using ConcordiaCurriculumManager.DTO.Dossiers;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 using ConcordiaCurriculumManager.Models.Users;
 using ConcordiaCurriculumManager.Repositories;
 using ConcordiaCurriculumManager.Services;
-using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using Moq;
-using System;
-namespace ConcordiaCurriculumManagerTest.UnitTests.Services
+
+namespace ConcordiaCurriculumManagerTest.UnitTests.Services;
+
+[TestClass]
+public class DossierServiceTest
 {
-    [TestClass]
-    public class DossierServiceTest
+    private Mock<IDossierRepository> dossierRepository = null!;
+    private Mock<ILogger<DossierService>> logger = null!;
+    private DossierService dossierService = null!;
+
+    [TestInitialize]
+    public void TestInitialize()
     {
-        private Mock<IDossierRepository> dossierRepository = null!;
-        private Mock<ILogger<DossierService>> logger = null!;
-        private DossierService dossierService = null!;
+        logger = new Mock<ILogger<DossierService>>();
+        dossierRepository = new Mock<IDossierRepository>();
 
-        [TestInitialize]
-        public void TestInitialize()
+        dossierService = new DossierService(logger.Object, dossierRepository.Object);
+    }
+
+    [TestMethod]
+    public async Task GetDossiersByID_ValidCall_QueriesRepo()
+    {
+        await dossierService.GetDossiersByID(GetSampleUser().Id);
+
+        dossierRepository.Verify(d => d.GetDossiersByID(GetSampleUser().Id));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(Exception))]
+    public async Task CreateDossierForUser_DossierDoesNotSave_LogsAndThrowsException()
+    {
+        dossierRepository.Setup(d => d.SaveDossier(It.IsAny<Dossier>())).ReturnsAsync(false);
+
+        await dossierService.CreateDossierForUser(GetSampleCreateDossierDTO(), GetSampleUser());
+
+        logger.Verify(logger => logger.LogWarning(It.IsAny<string>()));
+    }
+
+    [TestMethod]
+    public async Task CreateDossierForUser_ValidInput_Succeeds()
+    {
+        dossierRepository.Setup(d => d.SaveDossier(It.IsAny<Dossier>())).ReturnsAsync(true);
+        var user = GetSampleUser();
+
+        var dossier = await dossierService.CreateDossierForUser(GetSampleCreateDossierDTO(), user);
+
+        Assert.AreEqual(user.Id, dossier.InitiatorId);
+    }
+
+    [TestMethod]
+    public async Task RetrieveDossierDetails_ValidInput_Succeeds()
+    {
+        var dossier = GetSampleDossier();
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
+
+        var dossierDetails = await dossierService.GetDossierDetailsById(Guid.NewGuid());
+
+        Assert.AreEqual(dossier.Id, dossierDetails.Id);
+    }
+
+    [TestMethod]
+    public async Task RetrieveDossierDetails_InvalidInput_ReturnsNull()
+    {
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync((Dossier)null!);
+
+        var result = await dossierService.GetDossierDetailsById(Guid.NewGuid());
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public async Task EditDossier_InvalidInput_ThrowsArgumentException()
+    {
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync((Dossier)null!);
+
+        await dossierService.EditDossier(GetSampleEditDossierDTO(), Guid.NewGuid());
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(Exception))]
+    public async Task Edit_DossierDoesNotUpdate_LogsAndThrowsException()
+    {
+        var user = GetSampleUser();
+        var dossier = new Dossier
         {
-            logger = new Mock<ILogger<DossierService>>();
-            dossierRepository = new Mock<IDossierRepository>();
+            InitiatorId = user.Id,
+            Title = "test title",
+            Description = "test description",
+            Published = false
+        };
 
-            dossierService = new DossierService(logger.Object, dossierRepository.Object);
-        }
-
-        [TestMethod]
-        public async Task GetDossiersByID_ValidCall_QueriesRepo()
+        var editDossier = new EditDossierDTO
         {
-            await dossierService.GetDossiersByID(GetSampleUser().Id);
+            InitiatorId = user.Id,
+            Title = "test title modified",
+            Description = "test description modified"
+        };
 
-            dossierRepository.Verify(d => d.GetDossiersByID(GetSampleUser().Id));
-        }
 
-        [TestMethod]
-        [ExpectedException(typeof(Exception))]
-        public async Task CreateDossierForUser_DossierDoesNotSave_LogsAndThrowsException()
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
+        dossierRepository.Setup(d => d.UpdateDossier(It.IsAny<Dossier>())).ReturnsAsync(false);
+
+        await dossierService.EditDossier(GetSampleEditDossierDTO(), Guid.NewGuid());
+
+        logger.Verify(logger => logger.LogWarning(It.IsAny<string>()));
+    }
+
+    [TestMethod]
+    public async Task EditDossierForUser_ValidInput_Succeeds()
+    {
+        var user = GetSampleUser();
+        var dossier = new Dossier
         {
-            dossierRepository.Setup(d => d.SaveDossier(It.IsAny<Dossier>())).ReturnsAsync(false);
+            InitiatorId = user.Id,
+            Title = "test title",
+            Description = "test description",
+            Published = false
+        };
 
-            await dossierService.CreateDossierForUser(GetSampleCreateDossierDTO(), GetSampleUser());
-
-            logger.Verify(logger => logger.LogWarning(It.IsAny<string>()));
-        }
-
-        [TestMethod]
-        public async Task CreateDossierForUser_ValidInput_Succeeds()
+        var editDossier = new EditDossierDTO
         {
-            dossierRepository.Setup(d => d.SaveDossier(It.IsAny<Dossier>())).ReturnsAsync(true);
-            var user = GetSampleUser();
+            InitiatorId = user.Id,
+            Title = "test title modified",
+            Description = "test description modified"
+        };
+       
 
-            var dossier = await dossierService.CreateDossierForUser(GetSampleCreateDossierDTO(), user);
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
+        dossierRepository.Setup(d => d.UpdateDossier(It.IsAny<Dossier>())).ReturnsAsync(true);
 
-            Assert.AreEqual(user.Id, dossier.InitiatorId);
-        }
+        var editedDossier = await dossierService.EditDossier(editDossier, Guid.NewGuid());
 
-        [TestMethod]
-        public async Task RetrieveDossierDetails_ValidInput_Succeeds()
+        Assert.AreEqual(editDossier.Title, editedDossier.Title);
+        Assert.AreEqual(editDossier.Description, editedDossier.Description);
+
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public async Task DeleteDossier_DoesNotExist_ThrowsArgumentException()
+    {
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync((Dossier?)null);
+
+        await dossierService.DeleteDossier(Guid.NewGuid());
+    }
+
+
+    [TestMethod]
+    [ExpectedException(typeof(Exception))]
+    public async Task DeleteDossier_DoesNotUpdate_LogsAndThrowsException()
+    {
+        var user = GetSampleUser();
+        var dossier = new Dossier
         {
-            var dossier = GetSampleDossier();
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
+            InitiatorId = user.Id,
+            Title = "test title",
+            Description = "test description",
+            Published = false
+        };
 
-            var dossierDetails = await dossierService.GetDossierDetailsById(Guid.NewGuid());
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
+        dossierRepository.Setup(d => d.DeleteDossier(It.IsAny<Dossier>())).ReturnsAsync(false);
 
-            Assert.AreEqual(dossier.Id, dossierDetails.Id);
-        }
+        await dossierService.DeleteDossier(Guid.NewGuid());
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public async Task RetrieveDossierDetails_InvalidInput_ThrowsArgumentException()
+        logger.Verify(logger => logger.LogWarning(It.IsAny<string>()));
+    }
+
+    [TestMethod]
+    public async Task DeleteDossierValidInput_Succeeds()
+    {
+        var user = GetSampleUser();
+        var dossier = new Dossier
         {
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync((Dossier)null!);
+            Id = Guid.NewGuid(),
+            InitiatorId = user.Id,
+            Title = "test title",
+            Description = "test description",
+            Published = false
+        };
 
-            await dossierService.GetDossierDetailsById(Guid.NewGuid());
-        }
+        var deletedDossier = dossier.Id;
 
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public async Task EditDossier_InvalidInput_ThrowsArgumentException()
+        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
+        dossierRepository.Setup(d => d.DeleteDossier(It.IsAny<Dossier>())).ReturnsAsync(true);
+
+        await dossierService.DeleteDossier(deletedDossier);
+
+        dossierRepository.Verify(r => r.DeleteDossier(dossier));
+    }
+
+    private User GetSampleUser()
+    {
+        return new User
         {
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync((Dossier)null!);
+            Id = new Guid(),
+            FirstName = "Joe",
+            LastName = "Smith",
+            Email = "jsmith@ccm.com",
+            Password = "Password123!"
+        };
+    }
 
-            await dossierService.EditDossier(GetSampleEditDossierDTO(), GetSampleUser());
-
-        }
-
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public async Task EditDossier_NotTheDossierOfTheUser_ThrowsArgumentException()
+    private CreateDossierDTO GetSampleCreateDossierDTO()
+    {
+        return new CreateDossierDTO
         {
-            var user = GetSampleUser();
-            var dossier = GetSampleDossier();
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
-            await dossierService.EditDossier(GetSampleEditDossierDTO(), GetSampleUser());
-        }
+            Title = "test title",
+            Description = "test description"
+        };
+    }
 
-        [TestMethod]
-        [ExpectedException(typeof(Exception))]
-        public async Task Edit_DossierDoesNotUpdate_LogsAndThrowsException()
+    private Dossier GetSampleDossier()
+    {
+        return new Dossier
         {
-            var user = GetSampleUser();
-            var dossier = new Dossier
-            {
-                InitiatorId = user.Id,
-                Title = "test title",
-                Description = "test description",
-                Published = false
-            };
+            InitiatorId = Guid.NewGuid(),
+            Published = false,
+            Title = "test title",
+            Description = "test description"
+        };
+    }
 
-            var editDossier = new EditDossierDTO
-            {
-                Id = Guid.NewGuid(),
-                InitiatorId = user.Id,
-                Title = "test title modified",
-                Description = "test description modified"
-            };
-
-
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
-            dossierRepository.Setup(d => d.UpdateDossier(It.IsAny<Dossier>())).ReturnsAsync(false);
-
-            await dossierService.EditDossier(GetSampleEditDossierDTO(), GetSampleUser());
-
-            logger.Verify(logger => logger.LogWarning(It.IsAny<string>()));
-        }
-
-        [TestMethod]
-        public async Task EditDossierForUser_ValidInput_Succeeds()
+    private EditDossierDTO GetSampleEditDossierDTO()
+    {
+        return new EditDossierDTO
         {
-            var user = GetSampleUser();
-            var dossier = new Dossier
-            {
-                InitiatorId = user.Id,
-                Title = "test title",
-                Description = "test description",
-                Published = false
-            };
-
-            var editDossier = new EditDossierDTO
-            {
-                Id = Guid.NewGuid(),
-                InitiatorId = user.Id,
-                Title = "test title modified",
-                Description = "test description modified"
-            };
-           
-
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
-            dossierRepository.Setup(d => d.UpdateDossier(It.IsAny<Dossier>())).ReturnsAsync(true);
-
-            var editedDossier = await dossierService.EditDossier(editDossier, user);
-
-            Assert.AreEqual(editDossier.Title, editedDossier.Title);
-            Assert.AreEqual(editDossier.Description, editedDossier.Description);
-
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public async Task DeleteDossier_DoesNotExist_ThrowsArgumentException()
-        {
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync((Dossier?)null);
-
-            await dossierService.DeleteDossier(GetSampleDeleteDossierDTO(), GetSampleUser());
-        }
-
-
-        [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
-        public async Task DeleteDossier_DossierDoesNotBelongToUser_ThrowsArgumentException()
-        {
-            var user = GetSampleUser();
-            var dossier = GetSampleDossier();
-
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
-
-            await dossierService.DeleteDossier(GetSampleDeleteDossierDTO(), GetSampleUser());
-        }
-
-        [TestMethod]
-        [ExpectedException(typeof(Exception))]
-        public async Task DeleteDossier_DoesNotUpdate_LogsAndThrowsException()
-        {
-            var user = GetSampleUser();
-            var dossier = new Dossier
-            {
-                InitiatorId = user.Id,
-                Title = "test title",
-                Description = "test description",
-                Published = false
-            };
-
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
-            dossierRepository.Setup(d => d.DeleteDossier(It.IsAny<Dossier>())).ReturnsAsync(false);
-
-            await dossierService.DeleteDossier(GetSampleDeleteDossierDTO(), GetSampleUser());
-
-            logger.Verify(logger => logger.LogWarning(It.IsAny<string>()));
-        }
-
-        [TestMethod]
-        public async Task DeleteDossierValidInput_Succeeds()
-        {
-            var user = GetSampleUser();
-            var dossier = new Dossier
-            {
-                Id = Guid.NewGuid(),
-                InitiatorId = user.Id,
-                Title = "test title",
-                Description = "test description",
-                Published = false
-            };
-
-            var deletedDossier = dossier.Id;
-
-            dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
-            dossierRepository.Setup(d => d.DeleteDossier(It.IsAny<Dossier>())).ReturnsAsync(true);
-
-            await dossierService.DeleteDossier(deletedDossier, GetSampleUser());
-
-            dossierRepository.Verify(r => r.DeleteDossier(dossier));
-        }
-
-        private User GetSampleUser()
-        {
-            return new User
-            {
-                Id = new Guid(),
-                FirstName = "Joe",
-                LastName = "Smith",
-                Email = "jsmith@ccm.com",
-                Password = "Password123!"
-            };
-        }
-
-        private CreateDossierDTO GetSampleCreateDossierDTO()
-        {
-            return new CreateDossierDTO
-            {
-                Title = "test title",
-                Description = "test description"
-            };
-        }
-
-        private Dossier GetSampleDossier()
-        {
-            return new Dossier
-            {
-                InitiatorId = Guid.NewGuid(),
-                Published = false,
-                Title = "test title",
-                Description = "test description"
-            };
-        }
-
-        private EditDossierDTO GetSampleEditDossierDTO()
-        {
-            return new EditDossierDTO
-            {
-                Id = Guid.NewGuid(),
-                InitiatorId = Guid.NewGuid(),
-                Title = "test title",
-                Description = "test description"
-            };
-        }
-
-        private Guid GetSampleDeleteDossierDTO()
-        {
-            return Guid.NewGuid();
-        }
+            InitiatorId = Guid.NewGuid(),
+            Title = "test title",
+            Description = "test description"
+        };
     }
 }
 


### PR DESCRIPTION
This PR closes: #146 

A brief explanation of the general notion of policies:
- A policy is composed of one or more requirements
- A requirement is handled by one or more authorization handlers
- For a policy to succeed, all requirements must succeed
- For a requirement to succeed, check the following table (assuming that the requirement is handled by two authorization handlers - the situation can be extrapolated to any number of authorization handlers).

| Authorization Handler 1 Result | Authorization Handler 1 Result | Requirement Result |
|:------------------------------:|:------------------------------:|:------------------:|
|              Fail              |                -               |        Fail        |
|             Abstain            |             Abstain            |        Fail        |
|             Succeed            |             Succeed            |       Succeed      |
|             Succeed            |             Abstain            |       Succeed      |


Note, that since the authorization handlers are using the services that under the hood use the dbContext, they must be registered as `Scoped` or `Transient`. If it is not the case, they should be registered as a `Singleton`.

Also please note that in some cases, the route value must have the same name.