### PR TITLE
Removes user from group masters when removed from group

### DIFF
--- a/Server/ConcordiaCurriculumManager/Repositories/GroupRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/GroupRepository.cs
@@ -54,7 +54,10 @@ public class GroupRepository : IGroupRepository
 
     public async Task<bool> RemoveUserFromGroup(Guid userId, Guid groupId)
     {
-        var group = await _dbContext.Groups.Include(g => g.Members).FirstOrDefaultAsync(g => g.Id == groupId);
+        var group = await _dbContext.Groups
+                                    .Include(g => g.Members)
+                                    .Include(g => g.GroupMasters)
+                                    .FirstOrDefaultAsync(g => g.Id == groupId);
         var user = group?.Members.FirstOrDefault(u => u.Id == userId);
         if (group != null && user != null)
         {

--- a/Server/ConcordiaCurriculumManager/Repositories/GroupRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/GroupRepository.cs
@@ -59,6 +59,7 @@ public class GroupRepository : IGroupRepository
         if (group != null && user != null)
         {
             group.Members.Remove(user);
+            group.GroupMasters.Remove(user);
             return await _dbContext.SaveChangesAsync() > 0;
         }
         return false;

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/GroupRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/GroupRepositoryTests.cs
@@ -83,4 +83,109 @@ public class GroupRepositoryTests
 
         Assert.IsTrue(result);
     }
+
+    [TestMethod]
+    public async Task RemoveUserFromGroup_UserIsMemberAndGroupExists_ReturnsTrue()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john.doe@example.com",
+            Password = "hashedpassword"
+        };
+
+        var group = new Group
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Group",
+            Members = new List<User> { user },
+            GroupMasters = new List<User> { user }
+        };
+
+        dbContext.Groups.Add(group);
+        await dbContext.SaveChangesAsync();
+
+        var result = await groupRepository.RemoveUserFromGroup(userId, group.Id);
+
+        Assert.IsTrue(result);
+        var updatedGroup = await dbContext.Groups
+            .Include(g => g.Members)
+            .Include(g => g.GroupMasters)
+            .FirstOrDefaultAsync(g => g.Id == group.Id);
+
+        Assert.IsFalse(updatedGroup.Members.Any(u => u.Id == userId));
+        Assert.IsFalse(updatedGroup.GroupMasters.Any(u => u.Id == userId));
+    }
+
+    [TestMethod]
+    public async Task RemoveUserFromGroup_UserIsNotMember_ReturnsFalse()
+    {
+        var userId = Guid.NewGuid();
+        var group = new Group
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Group",
+            Members = new List<User>(),
+            GroupMasters = new List<User>()
+        };
+        dbContext.Groups.Add(group);
+        await dbContext.SaveChangesAsync();
+
+        var result = await groupRepository.RemoveUserFromGroup(userId, group.Id);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task RemoveUserFromGroup_GroupDoesNotExist_ReturnsFalse()
+    {
+        var userId = Guid.NewGuid();
+        var groupId = Guid.NewGuid();
+
+        var result = await groupRepository.RemoveUserFromGroup(userId, groupId);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task RemoveUserFromGroup_UserIsGroupMasterAndMember_ReturnsTrueAndRemovesFromBoth()
+    {
+        var userId = Guid.NewGuid();
+        var user = new User
+        {
+            Id = userId,
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john.doe@example.com",
+            Password = "hashedpassword"
+        };
+
+        dbContext.Users.Add(user);
+
+        var group = new Group
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Group",
+            Members = new List<User> { user },
+            GroupMasters = new List<User> { user }
+        };
+
+        dbContext.Groups.Add(group);
+        await dbContext.SaveChangesAsync();
+
+        var result = await groupRepository.RemoveUserFromGroup(userId, group.Id);
+
+        Assert.IsTrue(result);
+        var updatedGroup = await dbContext.Groups
+            .Include(g => g.Members)
+            .Include(g => g.GroupMasters)
+            .FirstOrDefaultAsync(g => g.Id == group.Id);
+
+        Assert.IsFalse(updatedGroup.Members.Any(u => u.Id == userId));
+        Assert.IsFalse(updatedGroup.GroupMasters.Any(u => u.Id == userId));
+    }
+
 }

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/GroupRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/GroupRepositoryTests.cs
@@ -116,6 +116,7 @@ public class GroupRepositoryTests
             .Include(g => g.GroupMasters)
             .FirstOrDefaultAsync(g => g.Id == group.Id);
 
+        Assert.IsNotNull(updatedGroup);
         Assert.IsFalse(updatedGroup.Members.Any(u => u.Id == userId));
         Assert.IsFalse(updatedGroup.GroupMasters.Any(u => u.Id == userId));
     }
@@ -184,6 +185,7 @@ public class GroupRepositoryTests
             .Include(g => g.GroupMasters)
             .FirstOrDefaultAsync(g => g.Id == group.Id);
 
+        Assert.IsNotNull(updatedGroup);
         Assert.IsFalse(updatedGroup.Members.Any(u => u.Id == userId));
         Assert.IsFalse(updatedGroup.GroupMasters.Any(u => u.Id == userId));
     }


### PR DESCRIPTION
If a user is both a member and a master, when removing them from the members, they are automatically removed from the masters. This PR closes #165 