### PR TITLE
237 reject dossier

### DIFF
--- a/App/src/models/dossier.ts
+++ b/App/src/models/dossier.ts
@@ -1,3 +1,4 @@
+import DossierDetails from "../pages/dossier/DossierDetails";
 import { CourseCreationRequest, CourseDeletionRequest, CourseModificationRequest } from "./course";
 
 export interface DossierDTO {
@@ -5,7 +6,7 @@ export interface DossierDTO {
     initiatorId: string;
     title: string | null;
     description: string | null;
-    published: boolean;
+    state: DossierStateEnum;
 }
 
 export interface DossierDetailsDTO {
@@ -13,7 +14,7 @@ export interface DossierDetailsDTO {
     initiatorId: string;
     title: string | null;
     description: string | null;
-    published: boolean;
+    state: DossierStateEnum;
     createdDate: Date;
     modifiedDate: Date;
     courseCreationRequests: CourseCreationRequest[];
@@ -32,3 +33,22 @@ export interface GetMyDossiersResponse {
 export interface DossierDetailsResponse {
     data: DossierDetailsDTO;
 }
+
+export enum DossierStateEnum {
+    Created = 0,
+    InReview = 1,
+    Rejected = 2,
+    Approved = 3
+}
+
+export function dossierStateToString(dossier: DossierDTO | DossierDetailsDTO | null): string {
+    if (!dossier) return "Created";
+
+    if (dossier.state === DossierStateEnum.InReview) return "In Review";
+    if (dossier.state === DossierStateEnum.Rejected) return "Rejected";
+    if (dossier.state === DossierStateEnum.Approved) return "Approved";
+
+    return "Created";
+}
+
+

--- a/App/src/models/dossier.ts
+++ b/App/src/models/dossier.ts
@@ -1,4 +1,3 @@
-import DossierDetails from "../pages/dossier/DossierDetails";
 import { CourseCreationRequest, CourseDeletionRequest, CourseModificationRequest } from "./course";
 
 export interface DossierDTO {
@@ -38,7 +37,7 @@ export enum DossierStateEnum {
     Created = 0,
     InReview = 1,
     Rejected = 2,
-    Approved = 3
+    Approved = 3,
 }
 
 export function dossierStateToString(dossier: DossierDTO | DossierDetailsDTO | null): string {
@@ -50,5 +49,3 @@ export function dossierStateToString(dossier: DossierDTO | DossierDetailsDTO | n
 
     return "Created";
 }
-
-

--- a/App/src/pages/dossier/DossierDetails.tsx
+++ b/App/src/pages/dossier/DossierDetails.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { DossierDetailsDTO, DossierDetailsResponse } from "../../models/dossier";
+import { DossierDetailsDTO, DossierDetailsResponse, dossierStateToString } from "../../models/dossier";
 import { getDossierDetails } from "../../services/dossier";
 import { useNavigate, useParams } from "react-router-dom";
 import {
@@ -224,7 +224,7 @@ export default function DossierDetails() {
                 <Heading color={"brandRed"}>{dossierDetails?.title}</Heading>
                 <Kbd>{dossierDetails?.id}</Kbd>
                 <Text>{dossierDetails?.description}</Text>
-                <Text>published: {dossierDetails?.published ? "yes" : "no"}</Text>
+                <Text>state: {dossierStateToString(dossierDetails)}</Text>
                 <Text>created: {dossierDetails?.createdDate?.toString()}</Text>
                 <Text>updated: {dossierDetails?.modifiedDate?.toString()}</Text>
             </div>

--- a/App/src/pages/dossier/DossierModal.tsx
+++ b/App/src/pages/dossier/DossierModal.tsx
@@ -70,7 +70,7 @@ export default function DossierModal(props: DossierModalProps) {
                 title: data.title,
                 description: data.description,
                 initiatorId: props.dossier?.initiatorId,
-                published: props.dossier?.published,
+                state: props.dossier?.state,
             };
             editDossier(dossier).then(
                 () => {

--- a/App/src/pages/dossier/Dossiers.tsx
+++ b/App/src/pages/dossier/Dossiers.tsx
@@ -33,7 +33,7 @@ import React from "react";
 import Button from "../../components/Button";
 import { UserRoles } from "../../models/user";
 import { showToast } from "../../utils/toastUtils";
-import { DossierDTO, GetMyDossiersResponse } from "../../models/dossier";
+import { DossierDTO, GetMyDossiersResponse, dossierStateToString } from "../../models/dossier";
 import { BaseRoutes } from "../../constants";
 import { useNavigate } from "react-router-dom";
 
@@ -186,7 +186,7 @@ export default function Dossiers() {
                                         Description
                                     </Th>
                                     <Th minW={"120px"} maxW={"120px"}>
-                                        Published
+                                        State
                                     </Th>
                                     <Th width={"25%"}></Th>
                                 </Tr>
@@ -203,7 +203,7 @@ export default function Dossiers() {
                                             </Text>
                                         </Td>
                                         <Td minW={"120px"} maxW={"120px"}>
-                                            {dossier.published ? "Yes" : "No"}
+                                            {dossierStateToString(dossier)}
                                         </Td>
 
                                         <Td width={"25%"}>

--- a/Server/ConcordiaCurriculumManager/Controllers/DossierReviewController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/DossierReviewController.cs
@@ -35,4 +35,16 @@ public class DossierReviewController : Controller
 
         return Ok();
     }
+
+    [HttpPut(nameof(RejectDossier) + "/{dossierId}")]
+    [Authorize(Policies.IsDossierReviewMaster)]
+    [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Dossier successfully rejected")]
+    public async Task<ActionResult> RejectDossier([FromRoute, Required] Guid dossierId)
+    {
+        await _dossierReviewService.RejectDossier(dossierId);
+
+        return Ok();
+    }
 }

--- a/Server/ConcordiaCurriculumManager/DTO/Dossiers/DossierDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/Dossiers/DossierDTO.cs
@@ -1,6 +1,4 @@
-﻿using ConcordiaCurriculumManager.Models.Users;
-using System;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 
 namespace ConcordiaCurriculumManager.DTO.Dossiers;
 
@@ -14,7 +12,5 @@ public class DossierDTO
 
     public required string Description { get; set; }
 
-    public required bool Published { get; set; }
+    public required DossierStateEnum State { get; set; }
 }
-
-

--- a/Server/ConcordiaCurriculumManager/DTO/Dossiers/DossierDetailsDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/Dossiers/DossierDetailsDTO.cs
@@ -13,7 +13,7 @@ public class DossierDetailsDTO
 
     public required string Description { get; set; }
 
-    public required bool Published { get; set; }
+    public required DossierStateEnum State { get; set; }
 
     public List<CourseCreationRequest> CourseCreationRequests { get; set; } = new List<CourseCreationRequest>();
 

--- a/Server/ConcordiaCurriculumManager/Migrations/20231209005718_CreateDossierStates.Designer.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20231209005718_CreateDossierStates.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConcordiaCurriculumManager.Migrations
 {
     [DbContext(typeof(CCMDbContext))]
-    partial class CCMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231209005718_CreateDossierStates")]
+    partial class CreateDossierStates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/ConcordiaCurriculumManager/Migrations/20231209005718_CreateDossierStates.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20231209005718_CreateDossierStates.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcordiaCurriculumManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateDossierStates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Published",
+                table: "Dossiers");
+
+            migrationBuilder.AddColumn<int>(
+                name: "State",
+                table: "Dossiers",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "State",
+                table: "Dossiers");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Published",
+                table: "Dossiers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
@@ -1,6 +1,7 @@
 ﻿using ConcordiaCurriculumManager.DTO.Dossiers;
 using ConcordiaCurriculumManager.Models.Curriculum;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
+using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Models.Users;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
@@ -26,6 +27,7 @@ public interface IDossierRepository
     public Task<bool> DeleteCourseCreationRequest(CourseCreationRequest courseCreationRequest);
     public Task<bool> DeleteCourseModificationRequest(CourseModificationRequest courseModificationRequest);
     public Task<bool> DeleteCourseDeletionRequest(CourseDeletionRequest courseDeletionRequest);
+    public Task<IList<User>> GetCurrentlyReviewingGroupMasters(Guid dossierId);
 }
 
 public class DossierRepository : IDossierRepository
@@ -157,5 +159,16 @@ public class DossierRepository : IDossierRepository
         _dbContext.CourseDeletionRequests.Remove(courseDeletionRequest);
         var result = await _dbContext.SaveChangesAsync();
         return result > 0;
+    }
+
+    public async Task<IList<User>> GetCurrentlyReviewingGroupMasters(Guid dossierId)
+    {
+        var stage = await _dbContext.ApprovalStages
+            .Where(stage => stage.DossierId.Equals(dossierId) && stage.IsCurrentStage)
+            .Include(stage => stage.Group)
+            .ThenInclude(group => group!.GroupMasters)
+            .FirstOrDefaultAsync();
+
+        return stage!.Group!.GroupMasters;
     }
 }

--- a/Server/ConcordiaCurriculumManager/Repositories/DossierReviewRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DossierReviewRepository.cs
@@ -1,12 +1,15 @@
-﻿using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
+﻿using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
+using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using EFCore.BulkExtensions;
+using Microsoft.EntityFrameworkCore;
 
 namespace ConcordiaCurriculumManager.Repositories;
 
 public interface IDossierReviewRepository
 {
     Task<bool> SaveApprovalStages(IList<ApprovalStage> stages);
+    Task<Dossier?> GetDossierWithApprovalStages(Guid dossierId);
 }
 
 public class DossierReviewRepository : IDossierReviewRepository
@@ -23,5 +26,13 @@ public class DossierReviewRepository : IDossierReviewRepository
         _dbContext.BulkInsert(stages);
         var result = await _dbContext.SaveChangesAsync();
         return result > 0;
+    }
+
+    public async Task<Dossier?> GetDossierWithApprovalStages(Guid dossierId)
+    {
+        return await _dbContext.Dossiers
+            .Where(dossier => dossier.Id.Equals(dossierId))
+            .Include(dossier => dossier.ApprovalStages)
+            .FirstOrDefaultAsync();
     }
 }

--- a/Server/ConcordiaCurriculumManager/Repositories/ObjectSelectors.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/ObjectSelectors.cs
@@ -74,7 +74,7 @@ public static class ObjectSelectors
         ModifiedDate = dossier.ModifiedDate,
         Title = dossier.Title,
         Description = dossier.Description,
-        Published = dossier.Published,
+        State = dossier.State,
         InitiatorId = dossier.InitiatorId,
         CourseCreationRequests = (List<CourseCreationRequest>)dossier.CourseCreationRequests.Select(request => new CourseCreationRequest
         {

--- a/Server/ConcordiaCurriculumManager/Security/AuthorizationPolicies.cs
+++ b/Server/ConcordiaCurriculumManager/Security/AuthorizationPolicies.cs
@@ -21,6 +21,13 @@ public static class AuthorizationPolicies
             .RequireAuthenticatedUser()
             .Build();
         });
+
+        options.AddPolicy(Policies.IsDossierReviewMaster, policy =>
+        {
+            policy.AddRequirements(new DossierReviewMasterRequirement())
+            .RequireAuthenticatedUser()
+            .Build();
+        });
     }
 
     public static void AddAuthorizationHandlers(this IServiceCollection services)
@@ -28,5 +35,6 @@ public static class AuthorizationPolicies
         services.AddScoped<IAuthorizationHandler, AdminHandler>();
         services.AddScoped<IAuthorizationHandler, GroupMasterHandler>();
         services.AddScoped<IAuthorizationHandler, OwnerOfDossierHandler>();
+        services.AddScoped<IAuthorizationHandler, DossierReviewMasterHandler>();
     }
 }

--- a/Server/ConcordiaCurriculumManager/Security/Policies.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Policies.cs
@@ -4,4 +4,5 @@ public static class Policies
 {
     public const string IsGroupMasterOrAdmin = nameof(IsGroupMasterOrAdmin);
     public const string IsOwnerOfDossier = nameof(IsOwnerOfDossier);
+    public const string IsDossierReviewMaster = nameof(IsDossierReviewMaster);
 }

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/DossierReviewMasterRequirement.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/DossierReviewMasterRequirement.cs
@@ -1,0 +1,7 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace ConcordiaCurriculumManager.Security.Requirements;
+
+public class DossierReviewMasterRequirement : IAuthorizationRequirement
+{
+}

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/DossierReviewMasterHandler.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/DossierReviewMasterHandler.cs
@@ -1,0 +1,70 @@
+﻿using ConcordiaCurriculumManager.Models.Users;
+using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
+
+namespace ConcordiaCurriculumManager.Security.Requirements.Handlers;
+
+public class DossierReviewMasterHandler : AuthorizationHandler<DossierReviewMasterRequirement>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ILogger<GroupMasterHandler> _logger;
+    private readonly IDossierService _dossierService;
+
+    public DossierReviewMasterHandler(
+        ILogger<GroupMasterHandler> logger,
+        IDossierService dossierService,
+        IHttpContextAccessor contextAccessor)
+    {
+        _logger = logger;
+        _dossierService = dossierService;
+        _httpContextAccessor = contextAccessor;
+    }
+
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, DossierReviewMasterRequirement requirement)
+    {
+        _logger.LogInformation("Evaluting DossierReviewMasterHandler");
+
+        if (_httpContextAccessor.HttpContext is null)
+        {
+            // This is not an Http Request or there is no group Id. Abstain
+            _logger.LogWarning("Context is null");
+            return;
+        }
+
+        if (context.User.Identity is null || !context.User.Identity.IsAuthenticated)
+        {
+            context.Fail();
+            return;
+        }
+
+        if (_httpContextAccessor.HttpContext is null
+            || !_httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue("dossierId", out var dossierId)
+            || !Guid.TryParse(dossierId?.ToString(), out var parsedDossierId))
+        {
+            // This is not an Http Request or there is no dossier Id. Abstain
+            _logger.LogWarning("DossierReviewMasterHandler is possibly called on a http endpoint that does not include a dossier id as a param");
+            return;
+        }
+
+        var userId = context.User.Claims.FirstOrDefault(c => c.Type.Equals(Claims.Id));
+
+        if (userId is null || !Guid.TryParse(userId.Value, out var parsedUserId))
+        {
+            _logger.LogWarning("User is authenticated without a valid Id claim");
+            context.Fail();
+            return;
+        }
+
+        IList<User> groupMasters = await _dossierService.GetCurrentlyReviewingGroupMasters(parsedDossierId);
+
+        // Check if requesting user is not a master of the current reviewing group
+        if (groupMasters.Where(master => master.Id.Equals(parsedUserId)).IsNullOrEmpty())
+        {
+            context.Fail();
+            return;
+        }
+
+        context.Succeed(requirement);
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
@@ -24,7 +24,7 @@ public class OwnerOfDossierHandler : AuthorizationHandler<OwnerOfDossierRequirem
             || !_httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue("dossierId", out var dossierId)
             || !Guid.TryParse(dossierId?.ToString(), out var parsedDossierId))
         {
-            // This is not an Http Request or there is no group Id. Abstain
+            // This is not an Http Request or there is no dossier Id. Abstain
             _logger.LogWarning("OwnerOfDossierHandler is possibly called on a http endpoint that does not include a dossier id as a param");
             return;
         }

--- a/Server/ConcordiaCurriculumManager/Services/DossierService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/DossierService.cs
@@ -20,6 +20,7 @@ public interface IDossierService
     public Task<CourseCreationRequest> GetCourseCreationRequest(Guid courseRequestId);
     public Task<CourseModificationRequest> GetCourseModificationRequest(Guid courseRequestId);
     public Task<CourseDeletionRequest> GetCourseDeletionRequest(Guid courseRequestId);
+    public Task<IList<User>> GetCurrentlyReviewingGroupMasters(Guid dossierId);
 }
 
 public class DossierService : IDossierService
@@ -52,7 +53,7 @@ public class DossierService : IDossierService
             InitiatorId = user.Id,
             Title = d.Title,
             Description = d.Description,
-            Published = false
+            State = DossierStateEnum.Created
         };
 
         bool dossierCreated = await _dossierRepository.SaveDossier(dossier);
@@ -159,5 +160,10 @@ public class DossierService : IDossierService
     {
         var courseDeletionRequest = await _dossierRepository.GetCourseDeletionRequest(courseRequestId) ?? throw new NotFoundException($"Error retrieving the course deletion request with id ${typeof(CourseDeletionRequest)} ${courseRequestId}");
         return courseDeletionRequest;
+    }
+
+    public async Task<IList<User>> GetCurrentlyReviewingGroupMasters(Guid dossierId)
+    {
+        return await _dossierRepository.GetCurrentlyReviewingGroupMasters(dossierId);
     }
 }

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/DossierRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/DossierRepositoryTests.cs
@@ -53,8 +53,7 @@ namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories
                 InitiatorId = Guid.NewGuid(),
                 Title = "test title",
                 Description = "test description",
-                Published = false
-
+                State = DossierStateEnum.Created
             };
 
             dbContext.Users.Add(user);
@@ -75,7 +74,7 @@ namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories
                 InitiatorId = Guid.NewGuid(),
                 Title = "test title",
                 Description = "test description",
-                Published = false
+                State = DossierStateEnum.Created
             };
 
             dbContext.Dossiers.Add(dossier);
@@ -94,7 +93,7 @@ namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories
                 InitiatorId = Guid.NewGuid(),
                 Title = "test title",
                 Description = "test description",
-                Published = false
+                State = DossierStateEnum.Created
             };
 
             var result = await dossierRepository.SaveDossier(dossier);
@@ -143,7 +142,7 @@ namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories
                 InitiatorId = Guid.NewGuid(),
                 Title = "test title",
                 Description = "test description",
-                Published = false
+                State = DossierStateEnum.Created
             };
 
             var newTitle = "test title modified";
@@ -167,7 +166,7 @@ namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories
                 InitiatorId = Guid.NewGuid(),
                 Title = "test title",
                 Description = "test description",
-                Published = false
+                State = DossierStateEnum.Created
             };
 
             dbContext.Dossiers.Add(dossier);

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/DossierReviewControllerTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/DossierReviewControllerTest.cs
@@ -1,0 +1,43 @@
+﻿using AutoMapper;
+using ConcordiaCurriculumManager.Controllers;
+using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests.InputDTOs;
+using ConcordiaCurriculumManager.Repositories;
+using ConcordiaCurriculumManager.Services;
+using ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConcordiaCurriculumManagerTest.UnitTests.Controller;
+
+[TestClass]
+public class DossierReviewControllerTest
+{
+    private Mock<IDossierReviewService> dossierReviewService = null!;
+    private DossierReviewController dossierReviewController = null!;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        dossierReviewService = new Mock<IDossierReviewService>();
+
+        dossierReviewController = new DossierReviewController(dossierReviewService.Object);
+    }
+
+    [TestMethod]
+    public async Task RejectDossier_ValidCall_ReturnsOk()
+    {
+        dossierReviewService.Setup(drs => drs.RejectDossier(It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        var dossierId = Guid.NewGuid();
+
+        var actionResult = await dossierReviewController.RejectDossier(dossierId);
+
+        dossierReviewService.Verify(mock => mock.RejectDossier(dossierId), Times.Once());
+    }
+}

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
@@ -123,7 +123,7 @@ public class DossierServiceTest
             InitiatorId = user.Id,
             Title = "test title",
             Description = "test description",
-            Published = false
+            State = DossierStateEnum.Created
         };
 
         var editDossier = new EditDossierDTO
@@ -151,7 +151,7 @@ public class DossierServiceTest
             InitiatorId = user.Id,
             Title = "test title",
             Description = "test description",
-            Published = false
+            State = DossierStateEnum.Created
         };
 
         var editDossier = new EditDossierDTO
@@ -192,7 +192,7 @@ public class DossierServiceTest
             InitiatorId = user.Id,
             Title = "test title",
             Description = "test description",
-            Published = false
+            State = DossierStateEnum.Created
         };
 
         dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
@@ -213,7 +213,7 @@ public class DossierServiceTest
             InitiatorId = user.Id,
             Title = "test title",
             Description = "test description",
-            Published = false
+            State = DossierStateEnum.Created
         };
 
         var deletedDossier = dossier.Id;

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
@@ -299,7 +299,7 @@ public static class TestData
         return new Dossier
         {
             InitiatorId = Guid.NewGuid(),
-            Published = false,
+            State = DossierStateEnum.Created,
             Title = "test title",
             Description = "test description"
         };
@@ -313,7 +313,7 @@ public static class TestData
             InitiatorId = user.Id,
             Title = "Dossier 1",
             Description = "Text description of a dossier.",
-            Published = false,
+            State = DossierStateEnum.Created,
         };
     }
 


### PR DESCRIPTION
Create backend endpoint for rejecting a dossier. This PR closes #237 

- Rejected dossiers can not be re-submitted for review. The initiator has to make a new dossier for that. This can easily be changed at a later time if the requirements demand.
- Only the group masters of the currently reviewing group can reject a dossier. A new policy has been created to match this authorization need.