### PR TITLE
241 return dossier

### DIFF
--- a/Server/ConcordiaCurriculumManager/Controllers/DossierReviewController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/DossierReviewController.cs
@@ -48,6 +48,18 @@ public class DossierReviewController : Controller
         return NoContent();
     }
 
+    [HttpPut(nameof(ReturnDossier) + "/{dossierId}")]
+    [Authorize(Policies.IsDossierReviewMaster)]
+    [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Dossier successfully returned")]
+    public async Task<ActionResult> ReturnDossier([FromRoute, Required] Guid dossierId)
+    {
+        await _dossierReviewService.ReturnDossier(dossierId);
+
+        return NoContent();
+    }
+
     [HttpPut(nameof(ForwardDossier) + "/{dossierId}")]
     [Authorize(Policies.IsDossierReviewMaster)]
     [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/DossierReview/ApprovalStage.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/DossierReview/ApprovalStage.cs
@@ -17,4 +17,6 @@ public class ApprovalStage : BaseModel
     public required bool IsCurrentStage { get; set; }
 
     public required bool IsFinalStage { get; set; }
+
+    public bool IsInitialStage() => StageIndex == 0;
 }

--- a/Server/ConcordiaCurriculumManager/Services/DossierReviewService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/DossierReviewService.cs
@@ -9,6 +9,7 @@ public interface IDossierReviewService
 {
     public Task SubmitDossierForReview(DossierSubmissionDTO dto);
     public Task RejectDossier(Guid dossierId);
+    public Task ReturnDossier(Guid dossierId);
     public Task ForwardDossier(Guid dossierId);
     public Task<Dossier> GetDossierWithApprovalStagesOrThrow(Guid dossierId);
     public Task<Dossier> GetDossierWithApprovalStagesAndRequestsOrThrow(Guid dossierId);
@@ -67,6 +68,19 @@ public class DossierReviewService : IDossierReviewService
             _logger.LogInformation($"Dossier {dossier.Id} successfully rejected from the review process");
         else
             _logger.LogError($"Encountered error attempting to reject dossier {dossier.Id} from the review process");
+    }
+
+    public async Task ReturnDossier(Guid dossierId)
+    {
+        Dossier dossier = await GetDossierWithApprovalStagesOrThrow(dossierId);
+
+        dossier.MarkAsReturned();
+
+        var isDossierSaved = await _dossierRepository.UpdateDossier(dossier);
+        if (isDossierSaved)
+            _logger.LogInformation($"Dossier {dossier.Id} successfully returned to the previous group in the review process");
+        else
+            _logger.LogError($"Encountered error attempting to return dossier {dossier.Id} to the previous group in the review process");
     }
 
     public async Task ForwardDossier(Guid dossierId)

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/DossierReviewControllerTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/DossierReviewControllerTest.cs
@@ -42,6 +42,17 @@ public class DossierReviewControllerTest
     }
 
     [TestMethod]
+    public async Task ReturnDossier_ValidCall_ReturnsOk()
+    {
+        dossierReviewService.Setup(drs => drs.ReturnDossier(It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        var dossierId = Guid.NewGuid();
+
+        var actionResult = await dossierReviewController.ReturnDossier(dossierId);
+
+        dossierReviewService.Verify(mock => mock.ReturnDossier(dossierId), Times.Once());
+    }
+
+    [TestMethod]
     public async Task ForwardDossier_ValidCall_ReturnsOk()
     {
         dossierReviewService.Setup(drs => drs.ForwardDossier(It.IsAny<Guid>())).Returns(Task.CompletedTask);

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/ApprovalStageTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/ApprovalStageTest.cs
@@ -1,0 +1,27 @@
+﻿using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConcordiaCurriculumManagerTest.UnitTests.Models;
+
+[TestClass]
+public class ApprovalStageTest
+{
+    [DataTestMethod]
+    [DataRow(-1, false)]
+    [DataRow(0, true)]
+    [DataRow(1, false)]
+    public void VerifyCourseData_WithValidState_DoesNotThrow(int index, bool expected)
+    {
+        var stage = TestData.GetSampleApprovalStage();
+        stage.StageIndex = index;
+
+        var actual = stage.IsInitialStage();
+
+        Assert.AreEqual(expected, actual);
+    }
+}

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/DossierTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/DossierTest.cs
@@ -121,4 +121,29 @@ public class DossierTest
 
         dossier.MarkAsAccepted(TestData.GetSampleCourseVersionCollection());
     }
+
+    [TestMethod]
+    public void ReturnDossier_ThatIsInNonInitialStage_MarksReturned()
+    {
+        var dossier = TestData.GetSampleDossierInFinalStage();
+
+        var currentStage = dossier.ApprovalStages.Where(stage => stage.IsCurrentStage).First();
+
+        dossier.MarkAsReturned();
+
+        var previousStage = dossier.ApprovalStages.Where(stage => stage.IsCurrentStage).First();
+
+        Assert.AreEqual(previousStage.StageIndex, currentStage.StageIndex - 1);
+        Assert.AreEqual(true, previousStage.IsCurrentStage);
+        Assert.AreEqual(false, currentStage.IsCurrentStage);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(BadRequestException))]
+    public void ReturnDossier_ThatIsInInitialStage_Throws()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+
+        dossier.MarkAsReturned();
+    }
 }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierReviewServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierReviewServiceTest.cs
@@ -137,6 +137,29 @@ public class DossierReviewServiceTest
     }
 
     [TestMethod]
+    public async Task ReturnDossier_WithFinalApprovalStage_Returns()
+    {
+        var dossier = TestData.GetSampleDossierInFinalStage();
+
+        dossierReviewRepository.Setup(drr => drr.GetDossierWithApprovalStages(dossier.Id)).ReturnsAsync(dossier);
+
+        await dossierReviewService.ReturnDossier(dossier.Id);
+
+        dossierRepository.Verify(mock => mock.UpdateDossier(dossier), Times.Once());
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(BadRequestException))]
+    public async Task ReturnDossier_InInitialApprovalStage_Throws()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+
+        dossierReviewRepository.Setup(drr => drr.GetDossierWithApprovalStages(dossier.Id)).ReturnsAsync(dossier);
+
+        await dossierReviewService.ReturnDossier(dossier.Id);
+    }
+
+    [TestMethod]
     public async Task ForwardDossier_WithInitialApprovalStage_Forwards()
     {
         var dossier = TestData.GetSampleDossierInInitialStage();
@@ -150,7 +173,7 @@ public class DossierReviewServiceTest
     }
 
     [TestMethod]
-    public async Task ForwardDossier_WithFinalApprovalStage_Forwards()
+    public async Task ForwardDossier_WithFinalApprovalStage_Accepts()
     {
         var dossier = TestData.GetSampleDossierInFinalStage();
 

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
@@ -423,6 +423,18 @@ public static class TestData
         };
     }
 
+    public static ApprovalStage GetSampleApprovalStage()
+    {
+        return new ApprovalStage
+        {
+            DossierId = Guid.NewGuid(),
+            GroupId = Guid.NewGuid(),
+            StageIndex = 3,
+            IsCurrentStage = true,
+            IsFinalStage = false
+        };
+    }
+
     // GROUPS
     public static Group GetSampleGroup()
     {


### PR DESCRIPTION
Implement logic to return a dossier to the previous approval stage. Dossiers that are currently in the initial approval stage cannot be returned and an error message is shown to the caller should they attempt it. Closes #241 