### PR TITLE
#253 incorporate approval logic in owner policy

### DIFF
--- a/Server/ConcordiaCurriculumManager/Program.cs
+++ b/Server/ConcordiaCurriculumManager/Program.cs
@@ -13,6 +13,7 @@ using Serilog;
 using Swashbuckle.AspNetCore.Filters;
 using System.Reflection;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace ConcordiaCurriculumManager;
 
@@ -31,7 +32,7 @@ public class Program
         {
             builder.Configuration.AddEnvironmentVariables();
         }
-        
+
         var identitySettings = builder.Configuration
                             .GetSection(IdentitySettings.SectionName)
                             .Get<IdentitySettings>();
@@ -72,7 +73,8 @@ public class Program
                        .Validate(dbSettings => dbSettings.ConnectionString is not null);
 
         var dbDataSource = new NpgsqlDataSourceBuilder(dbSetting!.ConnectionString).Build();
-        builder.Services.AddDbContext<CCMDbContext>((options) => {
+        builder.Services.AddDbContext<CCMDbContext>((options) =>
+        {
             options.UseNpgsql(dbDataSource);
         });
 
@@ -82,14 +84,18 @@ public class Program
             .ReadFrom.Configuration(context.Configuration)
             .Enrich.FromLogContext();
         });
-        
+
         AddServices(builder.Services);
 
         builder.Services.AddMemoryCache();
         builder.Services.AddAutoMapper(typeof(Program));
 
-        builder.Services.AddControllers(options => {
+        builder.Services.AddControllers(options =>
+        {
             options.Filters.Add<ExceptionHandlerFilter>();
+        }).AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
         });
 
         builder.Services.AddEndpointsApiExplorer();

--- a/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
@@ -67,8 +67,14 @@ public class DossierRepository : IDossierRepository
     }
 
     public async Task<Dossier?> GetDossierByDossierId(Guid dossierId) => await _dbContext.Dossiers
-        .Select(ObjectSelectors.DossierSelector())
         .Where(d => d.Id == dossierId)
+        .Include(d => d.CourseCreationRequests)
+        .Include(d => d.CourseDeletionRequests)
+        .Include(d => d.CourseModificationRequests)
+        .Include(d => d.ApprovalStages)
+        .ThenInclude(a => a.Group == null ? null : a.Group.Members)
+        .Include(d => d.ApprovalStages)
+        .ThenInclude(a => a.Group == null ? null : a.Group.GroupMasters)
         .FirstOrDefaultAsync();
 
     public async Task<bool> SaveDossier(Dossier dossier)

--- a/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
@@ -69,8 +69,11 @@ public class DossierRepository : IDossierRepository
     public async Task<Dossier?> GetDossierByDossierId(Guid dossierId) => await _dbContext.Dossiers
         .Where(d => d.Id == dossierId)
         .Include(d => d.CourseCreationRequests)
+        .ThenInclude(c => c.NewCourse)
         .Include(d => d.CourseDeletionRequests)
+        .ThenInclude(c => c.Course)
         .Include(d => d.CourseModificationRequests)
+        .ThenInclude(c => c.Course)
         .Include(d => d.ApprovalStages)
         .ThenInclude(a => a.Group == null ? null : a.Group.Members)
         .Include(d => d.ApprovalStages)

--- a/Server/ConcordiaCurriculumManager/Repositories/ObjectSelectors.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/ObjectSelectors.cs
@@ -67,62 +67,6 @@ public static class ObjectSelectors
         })
     };
 
-    public static Expression<Func<Dossier, Dossier>> DossierSelector() => dossier => new Dossier
-    {
-        Id = dossier.Id,
-        CreatedDate = dossier.CreatedDate,
-        ModifiedDate = dossier.ModifiedDate,
-        Title = dossier.Title,
-        Description = dossier.Description,
-        State = dossier.State,
-        InitiatorId = dossier.InitiatorId,
-        CourseCreationRequests = (List<CourseCreationRequest>)dossier.CourseCreationRequests.Select(request => new CourseCreationRequest
-        {
-            Id = request.Id,
-            CreatedDate = request.CreatedDate,
-            ModifiedDate = request.ModifiedDate,
-            NewCourseId = request.NewCourseId,
-            NewCourse = request.NewCourse,
-            DossierId = request.DossierId,
-            ResourceImplication = request.ResourceImplication,
-            Rationale = request.Rationale,
-            Comment = request.Comment
-        }),
-        CourseModificationRequests = (List<CourseModificationRequest>)dossier.CourseModificationRequests.Select(request => new CourseModificationRequest
-        {
-            Id = request.Id,
-            CreatedDate = request.CreatedDate,
-            ModifiedDate = request.ModifiedDate,
-            CourseId = request.CourseId,
-            Course = request.Course,
-            DossierId = request.DossierId,
-            ResourceImplication = request.ResourceImplication,
-            Rationale = request.Rationale,
-            Comment = request.Comment
-        }),
-        CourseDeletionRequests = (List<CourseDeletionRequest>)dossier.CourseDeletionRequests.Select(request => new CourseDeletionRequest
-        {
-            Id = request.Id,
-            CreatedDate = request.CreatedDate,
-            ModifiedDate = request.ModifiedDate,
-            CourseId = request.CourseId,
-            Course = request.Course,
-            DossierId = request.DossierId,
-            ResourceImplication = request.ResourceImplication,
-            Rationale = request.Rationale,
-            Comment = request.Comment
-        }),
-        ApprovalStages = (List<ApprovalStage>)dossier.ApprovalStages.Select(stage => new ApprovalStage
-        {
-            Id = stage.Id,
-            GroupId = stage.GroupId,
-            DossierId = stage.DossierId,
-            StageIndex = stage.StageIndex,
-            IsCurrentStage = stage.IsCurrentStage,
-            IsFinalStage = stage.IsFinalStage
-        })
-    };
-
     public static Expression<Func<Course, Course>> CourseSelector() => course => new Course
     {
         Id = course.Id,

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
@@ -55,16 +55,22 @@ public class OwnerOfDossierHandler : AuthorizationHandler<OwnerOfDossierRequirem
         }
 
         var isDossierPublished = !dossier.State.Equals(DossierStateEnum.Created);
-        
-        if (!isDossierPublished && dossier.InitiatorId.Equals(parsedUserId))
+
+        if (!isDossierPublished)
         {
-            context.Succeed(requirement);
+            if (dossier.InitiatorId.Equals(parsedUserId))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            context.Fail();
             return;
         }
 
         var currentApprovalStage = dossier.ApprovalStages.Where(stage => stage.IsCurrentStage).FirstOrDefault();
         var reviewingGroup = currentApprovalStage?.Group;
-        
+
         if (reviewingGroup is null)
         {
             context.Fail();

--- a/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
+++ b/Server/ConcordiaCurriculumManager/Security/Requirements/Handlers/OwnerOfDossierHanlder.cs
@@ -1,4 +1,5 @@
-﻿using ConcordiaCurriculumManager.Services;
+﻿using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
+using ConcordiaCurriculumManager.Services;
 using Microsoft.AspNetCore.Authorization;
 
 namespace ConcordiaCurriculumManager.Security.Requirements.Handlers;
@@ -46,8 +47,33 @@ public class OwnerOfDossierHandler : AuthorizationHandler<OwnerOfDossierRequirem
 
         var dossier = await _dossierService.GetDossierDetailsById(parsedDossierId);
 
-        if (dossier is null || !dossier.InitiatorId.Equals(parsedUserId))
+        if (dossier is null)
         {
+            _logger.LogWarning("User is authenticated without a valid Id claim");
+            context.Fail();
+            return;
+        }
+
+        var isDossierPublished = !dossier.State.Equals(DossierStateEnum.Created);
+        
+        if (!isDossierPublished && dossier.InitiatorId.Equals(parsedUserId))
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
+        var currentApprovalStage = dossier.ApprovalStages.Where(stage => stage.IsCurrentStage).FirstOrDefault();
+        var reviewingGroup = currentApprovalStage?.Group;
+        
+        if (reviewingGroup is null)
+        {
+            context.Fail();
+            return;
+        }
+
+        if (isDossierPublished && !reviewingGroup.Members.Exists(m => m.Id.Equals(parsedUserId)))
+        {
+            _logger.LogWarning($"User {userId} attempted to access a dossier they are not currently reviewing");
             context.Fail();
             return;
         }


### PR DESCRIPTION
This PR closes: #253 

Currently, the IsOwnerOfDossier policy succeeds if:
1. The dossier is unpublished and the initiator of the dossier created the request
2. The dossier is published and a member of the current approving group created the request

`include` statements were used instead of `select` due to tracking issues. Another PR will be created to fully transfer from the `select` to `include` in other repositories.