### PR TITLE
#270 Fix versioning for created courses

### DIFF
--- a/Server/ConcordiaCurriculumManager/DTO/Courses/CourseDataDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/Courses/CourseDataDTO.cs
@@ -30,6 +30,8 @@ namespace ConcordiaCurriculumManager.DTO.Courses
 
         public required CourseStateEnum CourseState { get; set; }
 
+        public int? Version { get; set; }
+
         public required Dictionary<ComponentCodeEnum, int?> ComponentCodes { get; set; }
 
         public required Dictionary<string, string> SupportingFiles { get; set; }

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/CourseCreationRequest.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/CourseCreationRequest.cs
@@ -8,10 +8,23 @@ public class CourseCreationRequest : CourseRequest
 
     public Course? NewCourse { get; set; }
 
-    public void MarkAsAccepted()
+    public void MarkAsAccepted(ICollection<CourseVersion> currentVersions)
     {
         if (NewCourse == null) throw new NotFoundException($"The creation request for {NewCourseId} is not correctly loaded");
 
-        NewCourse.MarkAsAccepted(1);
+        var nextVersion = GetNextCourseVersion(NewCourse.Subject, NewCourse.Catalog, currentVersions);
+
+        NewCourse.MarkAsAccepted(nextVersion);
+    }
+
+    private int GetNextCourseVersion(string subject, string catalog, ICollection<CourseVersion> currentVersions)
+    {
+        CourseVersion? currentVersion = currentVersions
+            .Where(cv => cv.Subject == subject && cv.Catalog == catalog)
+            .FirstOrDefault();
+
+        var nextVersion = currentVersion == null ? 1 : currentVersion.Version + 1;
+
+        return nextVersion;
     }
 }

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/CourseRequest.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/CourseRequest.cs
@@ -1,4 +1,5 @@
 ﻿using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests;
+using ConcordiaCurriculumManager.Filters.Exceptions;
 
 namespace ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/Dossier.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/Dossier.cs
@@ -74,14 +74,14 @@ namespace ConcordiaCurriculumManager.Models.Curriculum.Dossiers
 
             State = DossierStateEnum.Approved;
 
-            foreach (var request in CourseCreationRequests)
-                request.MarkAsAccepted();
+            foreach (var creationRequest in CourseCreationRequests)
+                creationRequest.MarkAsAccepted(currentVersions);
 
-            foreach (var request in CourseModificationRequests)
-                request.MarkAsAccepted(currentVersions);
+            foreach (var modificationRequest in CourseModificationRequests)
+                modificationRequest.MarkAsAccepted(currentVersions);
 
-            foreach (var request in CourseDeletionRequests)
-                request.MarkAsDeleted(currentVersions);
+            foreach (var deletionRequest in CourseDeletionRequests)
+                deletionRequest.MarkAsDeleted(currentVersions);
         }
 
         public IList<ApprovalStage> PrepareForPublishing(DossierSubmissionDTO dto)

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
@@ -71,10 +71,11 @@ public class CourseRepository : ICourseRepository
         .OrderByDescending(course => course.Version)
         .FirstOrDefaultAsync();
 
-    public async Task<int?> GetCurrentCourseVersion(string catalog, string subject) => await _dbContext.Courses
+    public async Task<int?> GetCurrentCourseVersion(string subject, string catalog) => await _dbContext.Courses
         .Where(course =>
             course.Subject == subject
-            && course.Catalog == catalog)
+            && course.Catalog == catalog
+            && course.Version != null)
         .OrderByDescending(course => course.Version)
         .Select(course => course.Version)
         .FirstOrDefaultAsync();

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/CourseRequests/CourseCreationRequestTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/CourseRequests/CourseCreationRequestTest.cs
@@ -14,7 +14,7 @@ public class CourseCreationRequestTest
         var course = TestData.GetSampleCourse();
         request.NewCourse = course;
 
-        request.MarkAsAccepted();
+        request.MarkAsAccepted(new List<CourseVersion>());
 
         Assert.AreEqual(CourseStateEnum.Accepted, request.NewCourse.CourseState);
     }
@@ -26,6 +26,20 @@ public class CourseCreationRequestTest
         var request = TestData.GetSampleCourseCreationRequest();
         request.NewCourse = null;
 
-        request.MarkAsAccepted();
+        request.MarkAsAccepted(new List<CourseVersion>());
+    }
+
+    [TestMethod]
+    public void MarkAsAccepted_WithDeletedCourse_MarksCorrectly()
+    {
+        var request = TestData.GetSampleCourseCreationRequest();
+        var course = TestData.GetSampleCourse();
+        request.NewCourse = course;
+        var versions = TestData.GetSampleCourseVersionCollection();
+        versions.Add(TestData.GetSampleCourseVersion());
+
+        request.MarkAsAccepted(versions);
+
+        Assert.AreEqual(CourseStateEnum.Accepted, request.NewCourse.CourseState);
     }
 }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/CourseRequests/CourseRequestOnExistingCourseTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/CourseRequests/CourseRequestOnExistingCourseTest.cs
@@ -48,7 +48,7 @@ public class CourseRequestOnExistingCourseTest
 
     [TestMethod]
     [ExpectedException(typeof(InvalidOperationException))]
-    public void MarkAsAccepeted_WithCourseNotFound_Throws()
+    public void MarkAsAccepted_WithCourseNotFound_Throws()
     {
         var collection = TestData.GetSampleCourseVersionCollection();
         var request = TestData.GetSampleCourseModificationRequest();


### PR DESCRIPTION
Fix versioning for created courses such that they have version 1 if they are brand new, otherwise they increment on previously deleted courses for the subject/catalog pair. This PR closes #270 