### PR TITLE
#277 Setup Curriculums

### DIFF
--- a/Seeder/src/data/CourseGroupings.json
+++ b/Seeder/src/data/CourseGroupings.json
@@ -1,0 +1,630 @@
+{
+  "TableName": "CourseGroupings, CourseGroupingReferences, and CourseGroupingCourseIdentifier",
+  "AutoGenerateCreatedDate": true,
+  "AutoGenerateModifiedDate": true,
+  "Data": [
+    {
+      "Id": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+      "CommonIdentifier": "88ca0d2c-284a-4d58-aa95-bd9afabb65b1",
+      "Name": "Humanities General Education Electives for Engineering and Computer Science Students",
+      "RequiredCredits": "N/A",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [],
+      "CourseGroupingCourseIdentifier": [
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "25baf426-5d4d-4e81-b0c8-71bdc6b35c20"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "8b640af1-69e0-4651-8022-41aad63a9328"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "53a2db75-4f37-4b8d-925e-1021acfa29a4"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "459452f7-474c-4120-896e-01d4ecdb49bc"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "5ead40ed-64e5-49cb-9052-0baa46831b8c"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "02140bde-6852-4dc9-973d-dc512b6385e9"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "455d71a7-a971-4e0a-be59-fe8b89133ccc"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "9712f3a2-5fa7-4a7c-89ed-0944697358ac"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "3f276f5b-b6ab-41a1-bae7-4183e8daafc5"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "782e9cd9-17d4-495f-9a3e-46a0fdd0fc67"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "001935e9-4474-475c-81a8-87881f4bd3fb"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "5bb1996e-14b7-4a6f-8f88-8171bd229dfc"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "7ecdeb5f-43ab-40c6-a4fb-287f23da3b35"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "34c1be62-322b-4cdb-9730-f9843a442e74"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "b01e7629-9239-4af9-9143-2b438c0a111f"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "80351a7e-3a62-4b22-8658-d94aced2249d"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "b42f30b4-4a93-4bf1-9f69-6b5346f2cd30"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "40d97a06-eebc-45c0-85fe-d02696b339d0"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "16934c1e-2af4-4af8-8998-6dc7c46f42a5"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "7597d425-6456-4aea-949f-e87fa1fd409b"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "cf1277fb-5927-4666-bd6a-e2a6aaedc5ca"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "928fc204-3e21-46a1-9955-915297c7c474"
+        },
+        {
+          "CourseGroupingId": "e12777d3-8127-4d77-9d3d-1ac98ff2c04a",
+          "CourseIdentifiersId": "f1b14ae3-0589-42c2-81ae-35724c2c6217"
+        }
+      ]
+    },
+    {
+      "Id": "5c1c2a03-7501-4117-bf68-18956da04922",
+      "CommonIdentifier": "6118d80f-a5f5-467b-9504-2004e517cad8",
+      "Name": "Social Sciences General Education Electives for Engineering and Computer Science Students",
+      "RequiredCredits": "N/A",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [],
+      "CourseGroupingCourseIdentifier": [
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "9c0996bc-403a-40de-a85b-ffe258513fdb"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "8ebeb05d-a164-4973-8742-f76ff8311c4c"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "f1db623e-d594-4fcc-8554-9f40f2d5edc7"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "952ef1fe-b62f-4230-8c5f-2447d992412d"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "b7a372fa-8bae-4c31-ae6f-5894817e0cfe"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "655644b7-8d84-4e92-9c4f-fb436047c020"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "1390f7f4-e419-4c12-abfd-e21db42fb40f"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "ba0f036b-a117-463c-8543-7ad6a553ab87"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "a28004bb-e8f8-4a8d-98fe-6041ffcec3b0"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "76da6812-a8fe-44c1-b6c6-d7dede0a39bd"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "05df0161-ce3b-45c5-baac-e55a151c58bd"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "922e2621-7a2e-40a0-86b3-8a16171c3007"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "fda55a94-4d26-4732-9919-8df7075d9d37"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "7c569b56-1983-4020-90eb-73ad1893ccde"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "88d84e1f-6bdd-40db-904f-4f87b6cc08eb"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "21c985cb-424e-419f-9b13-747bb26807cf"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "a0ecc5db-94de-4220-b9ef-39ae15741ecb"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "57fad6e6-8c06-462a-96bc-f5936c0088b6"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "47010e0c-48fb-46df-96ad-266c29a56a44"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "75c3659b-fa27-45aa-9632-60c9fa3b5bd4"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "73403e4b-da50-46a8-9d04-ed65a662f0b1"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "e9758837-5ef0-4164-b633-545c349b5da2"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "28e6f58e-a568-4497-b862-e9974c5c715f"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "43d47d3d-f913-4f03-a746-8fa32d7235e0"
+        },
+        {
+          "CourseGroupingId": "5c1c2a03-7501-4117-bf68-18956da04922",
+          "CourseIdentifiersId": "ff0f8ca7-a27a-4243-bfd8-f30f713e2641"
+        }
+      ]
+    },
+    {
+      "Id": "c414b8b0-dd74-4743-bba0-e6d3e2aa16ca",
+      "CommonIdentifier": "48ba74d1-0eb2-4197-bbd2-836b7dbc7b56",
+      "Name": "Other Complementary Studies General Education Electives for Engineering and Computer Science Students",
+      "RequiredCredits": "N/A",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [],
+      "CourseGroupingCourseIdentifier": [
+        {
+          "CourseGroupingId": "c414b8b0-dd74-4743-bba0-e6d3e2aa16ca",
+          "CourseIdentifiersId": "71a2f5f9-50cb-4f87-90c4-aa74e52dc8f0"
+        },
+        {
+          "CourseGroupingId": "c414b8b0-dd74-4743-bba0-e6d3e2aa16ca",
+          "CourseIdentifiersId": "2cc479ec-6428-428e-a620-58517c337144"
+        },
+        {
+          "CourseGroupingId": "c414b8b0-dd74-4743-bba0-e6d3e2aa16ca",
+          "CourseIdentifiersId": "7bcd6399-1614-4aab-a684-dd97fd82c096"
+        },
+        {
+          "CourseGroupingId": "c414b8b0-dd74-4743-bba0-e6d3e2aa16ca",
+          "CourseIdentifiersId": "2367e1d3-df52-4603-8227-4e27b91f971c"
+        }
+      ]
+    },
+    {
+      "Id": "e110ad49-7334-4927-95a8-56abe2129556",
+      "CommonIdentifier": "bb4079f3-5542-4436-aaeb-4ff40d0c4d6c",
+      "Name": "General Education Electives",
+      "RequiredCredits": "3.00",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "To fulfill the requirements of the General Education Elective or General Electives, students may choose the courses from the three lists below:",
+      "Notes": "In some instances, students may have to complete specific prerequisites before taking any of the following courses. Those prerequisite courses are not counted towards their program unless they are specifically listed on the student’s offer of admission or listed as courses required for the completion of their programs. The relevant prerequisites in each case are stated in the departmental course descriptions.\nPrior to registering, students who do not have any specified prerequisites for a course must obtain permission of the relevant Department.\nAn ESL course or an introductory course that deals with the acquisition of a language will not be considered as a General Education elective or a General Elective.\nShould students wish to take a course not listed below, they must receive written permission from the Student Academic Services Office of the Gina Cody School of Engineering and Computer Science prior to taking the course.\nStudents in the Extended Credit Program (ECP) or the Mature Entry Program (MEP) (see Section 14.2.3 Gina Cody School of Engineering and Computer Science under Section 14.2 Program Requirements) or any other students who have been assigned credits in Humanities and Social Sciences must select those credits from the two corresponding lists below. Those credits cannot be chosen from the list of Other Complementary Studies.",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [
+        {
+          "Id": "71d1324f-785f-4ec0-97e3-40d0e27323d6",
+          "ChildGroupCommonIdentifier": "88ca0d2c-284a-4d58-aa95-bd9afabb65b1",
+          "GroupingType": 0
+        },
+        {
+          "Id": "7bdf8f09-d2f9-44a0-b875-81b5db9f9e72",
+          "ChildGroupCommonIdentifier": "6118d80f-a5f5-467b-9504-2004e517cad8",
+          "GroupingType": 0
+        },
+        {
+          "Id": "6e961b47-9f5c-4d89-8b61-c7fa4e35da97",
+          "ChildGroupCommonIdentifier": "48ba74d1-0eb2-4197-bbd2-836b7dbc7b56",
+          "GroupingType": 0
+        }
+      ],
+      "CourseGroupingCourseIdentifier": []
+    },
+    {
+      "Id": "60f21159-dc45-498c-a71f-19fbce2de52c",
+      "CommonIdentifier": "86072b4b-c98e-458b-8f8e-230eca367fe3",
+      "Name": "Engineering Core",
+      "RequiredCredits": "30.50",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "To be recommended for the degree of BEng, students must satisfactorily complete the courses of the Engineering Core as well as those specified for their particular program in subsequent sections in accordance with the graduation requirements in Section 71.10.5 Graduation Regulations.",
+      "Notes": "(1) The Engineering Core credits for students in the BEng in Building Engineering are reduced from 30.5 credits to 29 credits since Building Engineering students are not required to take ENGR 202 in their program. (2) The Engineering Core credits for students in the BEng in Mechanical Engineering, BEng in Industrial Engineering and BEng in Aerospace Engineering programs are reduced from 30.5 credits to 27 credits since Mechanical, Industrial and Aerospace Engineering students are not required to take ELEC 275 in their program. Students in the BEng in Electrical Engineering and the BEng in Computer Engineering shall replace ELEC 275 with ELEC 273. (3) Students in the BEng in Software Engineering may replace ENGR 391 with COMP 361. (4) Students in BEng in Building Engineering shall replace ENGR 392 with BLDG 482. (5) Students must select three General Education elective credits from one of the lists in Section 71.110 Complementary Studies for Engineering and Computer Science Students. Students in the BEng in Industrial Engineering shall take ACCO 220 as their General Education elective.",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [
+        {
+          "Id": "ae2302c8-90ad-42bd-bf51-a5d5d82fd111",
+          "ChildGroupCommonIdentifier": "bb4079f3-5542-4436-aaeb-4ff40d0c4d6c",
+          "GroupingType": 0
+        }
+      ],
+      "CourseGroupingCourseIdentifier": [
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "16185114-d578-49e3-b7ce-79a9a3362b0b"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "9ac96095-e7fe-4ffc-b6b7-648a0589f757"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "722dd728-5309-4d77-946e-0f1a7fdfe1a6"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "1ce69831-efd2-4e91-8396-5b283ad0d75b"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "98538f31-15df-4dac-9ae7-9221b7f083d6"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "2eae373e-899a-41de-9bfd-d39968c2c629"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "848d17f5-219b-4a00-ae52-e2c79fac66b9"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "1806c778-1733-4736-97cd-c8d363c6a705"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "4ed7f416-ff91-41e9-9bcb-cc15b4b50a24"
+        },
+        {
+          "CourseGroupingId": "60f21159-dc45-498c-a71f-19fbce2de52c",
+          "CourseIdentifiersId": "11a1467e-d43b-44c6-b3ca-ce75dd3e7c3a"
+        }
+      ]
+    },
+    {
+      "Id": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+      "CommonIdentifier": "73112808-947c-40b1-aef6-ba7739b27031",
+      "Name": "Industrial Engineering Core",
+      "RequiredCredits": "81.00",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "",
+      "Notes": "Students may replace INDU 490 with ENGR 490 if they are interested in a multidisciplinary project that requires collaboration with students from other engineering departments. In order for students to register in ENGR 490, their projects must be approved by the ENGR 490 Design Committee before the start of the fall term.",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [],
+      "CourseGroupingCourseIdentifier": [
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "e7786719-d5e0-4006-9653-aab11a76bd55"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "e6ceeb10-6905-415b-aa91-82f9dcdbc39a"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "a981618e-7f4d-4646-bcd5-161b329ef7fc"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "0c00de90-f6b1-466c-9fd5-753878f8a438"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "fddc4ce6-a8a0-4881-8c3a-c27492f14510"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "08dcf7cc-d743-4741-8ae6-03ac66320328"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "b43eb496-4974-4fe6-a15f-568a6c898331"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "b33c1fa4-720a-460f-a861-53312cce036d"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "3a147000-f30c-4a94-9e2d-141a829ce17b"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "2c1b264d-01ba-4800-93ea-6cfdcc3294fb"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "6d9ca0de-3701-439c-8524-78ce8ac60df0"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "c97a4ff8-d7f0-4d2e-a838-24420801c3f3"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "99c2692b-9daa-43da-91a0-95680460a6d7"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "353c94c5-1b5b-4ec3-b54f-24fa7ee0efd6"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "c9703f8b-aa9c-46b5-84d3-9dbc42a0a6f4"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "7ad07c3e-1606-4875-9fcc-599a5baa985b"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "00532040-52ef-4cd6-b7fa-eedd7817c619"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "068c286d-4dc4-4b13-b625-c62d41436270"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "ac8d080c-5497-42f9-88b8-f1d9213c6322"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "64d5c61a-54b2-49a5-a2f3-a5b21debc80b"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "c0b7d20d-0f75-4794-a0b9-9a9bb869077b"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "512c3424-7e35-4d39-a0f5-4d7fa934d7f7"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "50614887-7096-4dc4-9e94-503f55d7f0d9"
+        },
+        {
+          "CourseGroupingId": "a08103a9-3705-4c8e-a584-28a82c2924ee",
+          "CourseIdentifiersId": "b3b60d06-d134-4a34-83af-1ac88034d265"
+        }
+      ]
+    },
+    {
+      "Id": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+      "CommonIdentifier": "bc580104-0e03-4af7-85a9-6d68230d4071",
+      "Name": "INDU Courses",
+      "RequiredCredits": "N/A",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "Students must take at least three courses from the following list:",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [],
+      "CourseGroupingCourseIdentifier": [
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "f6369301-7817-4959-9bb6-30a6a1c4d6df"
+        },
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "570cd2db-dbd8-468f-943e-8ae45624a9b2"
+        },
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "7df3cd5a-23ae-45fd-b3d3-99b039b31364"
+        },
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "d70eb659-13f6-41ca-b1cc-d582ebc6e4f7"
+        },
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "656ab16e-33b7-487f-b74d-a91cae9f6cca"
+        },
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "c6538538-fe45-44c3-910d-8d81ddda5645"
+        },
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "8a12ddab-ac41-4065-8d47-994b5be2d32e"
+        },
+        {
+          "CourseGroupingId": "8d33564f-3681-451a-bdd7-a8c42c6ae88b",
+          "CourseIdentifiersId": "10f78adf-d6c5-4300-b85e-d007fa0e7c8a"
+        }
+      ]
+    },
+    {
+      "Id": "e601e777-c152-4e2d-a59f-fdbea66ac4de",
+      "CommonIdentifier": "21c1277f-dcf4-4796-9455-cf18562a2a7b",
+      "Name": "Other Industrial Engineering Elective Courses",
+      "RequiredCredits": "N/A",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "Students may take no more than one course from the following list:",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [],
+      "CourseGroupingCourseIdentifier": [
+        {
+          "CourseGroupingId": "e601e777-c152-4e2d-a59f-fdbea66ac4de",
+          "CourseIdentifiersId": "9d182e66-4f2a-479c-9cbf-470d5441a3ed"
+        },
+        {
+          "CourseGroupingId": "e601e777-c152-4e2d-a59f-fdbea66ac4de",
+          "CourseIdentifiersId": "924a043e-0278-47f9-a821-fec3ad8cb63c"
+        },
+        {
+          "CourseGroupingId": "e601e777-c152-4e2d-a59f-fdbea66ac4de",
+          "CourseIdentifiersId": "b9074685-fd72-4a22-8f66-56ca067e41e6"
+        },
+        {
+          "CourseGroupingId": "e601e777-c152-4e2d-a59f-fdbea66ac4de",
+          "CourseIdentifiersId": "96ac755b-6fa3-4c3e-ace4-ed280476708a"
+        },
+        {
+          "CourseGroupingId": "e601e777-c152-4e2d-a59f-fdbea66ac4de",
+          "CourseIdentifiersId": "7bcd6399-1614-4aab-a684-dd97fd82c096"
+        }
+      ]
+    },
+    {
+      "Id": "e550eccf-3393-4073-9a85-dfb540fb174d",
+      "CommonIdentifier": "623e9718-54ee-4179-986c-4b664b998e9b",
+      "Name": "Engineering Core for Industrial Engineering",
+      "RequiredCredits": "27.00",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [
+        {
+          "Id": "f1f87a9b-a489-4932-8daf-0ee089b3019d",
+          "ChildGroupCommonIdentifier": "86072b4b-c98e-458b-8f8e-230eca367fe3",
+          "GroupingType": 0
+        }
+      ],
+      "CourseGroupingCourseIdentifier": []
+    },
+    {
+      "Id": "5594b354-d1cc-4b47-b55b-c873ffc671a6",
+      "CommonIdentifier": "4a8a12cd-1555-4d69-931b-40bae1951c18",
+      "Name": "Industrial Engineering Electives",
+      "RequiredCredits": "12.00",
+      "IsTopLevel": false,
+      "School": 0,
+      "Description": "12 credits minimum chosen from at least three INDU Courses Students may take no more than one course from the Other Industrial Engineering Elective Courses list.",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [
+        {
+          "Id": "05d02846-9226-4f36-ad71-8e49668df97f",
+          "ChildGroupCommonIdentifier": "bc580104-0e03-4af7-85a9-6d68230d4071",
+          "GroupingType": 0
+        },
+        {
+          "Id": "cc6494bf-c3d1-4dd4-b123-cbdee8aa9b41",
+          "ChildGroupCommonIdentifier": "21c1277f-dcf4-4796-9455-cf18562a2a7b",
+          "GroupingType": 0
+        }
+      ],
+      "CourseGroupingCourseIdentifier": []
+    },
+    {
+      "Id": "bdc47eed-7567-4d80-8e93-d5b41fa2059e",
+      "CommonIdentifier": "188ae971-1256-4b87-9939-47a2763893ff",
+      "Name": "BEng in Industrial Engineering",
+      "RequiredCredits": "120.00",
+      "IsTopLevel": true,
+      "School": 0,
+      "Description": "The program in Industrial Engineering consists of the Engineering Core, the Industrial Engineering Core, and elective credits as shown below. The minimum length of the program is 120 credits.",
+      "Notes": "",
+      "State": 0,
+      "Version": 1,
+      "Published": true,
+      "CourseGroupingReferences": [
+        {
+          "Id": "f436869f-606b-401c-9b22-5b1fdcb7abb1",
+          "ChildGroupCommonIdentifier": "623e9718-54ee-4179-986c-4b664b998e9b",
+          "GroupingType": 0
+        },
+        {
+          "Id": "cdc5abc5-5607-4a43-b530-7523f62e50f5",
+          "ChildGroupCommonIdentifier": "73112808-947c-40b1-aef6-ba7739b27031",
+          "GroupingType": 0
+        },
+        {
+          "Id": "2280c5cd-d461-4765-a343-7447682d927d",
+          "ChildGroupCommonIdentifier": "4a8a12cd-1555-4d69-931b-40bae1951c18",
+          "GroupingType": 0
+        }
+      ],
+      "CourseGroupingCourseIdentifier": []
+    }
+  ]
+}

--- a/Seeder/src/data/CourseIdentifiers.json
+++ b/Seeder/src/data/CourseIdentifiers.json
@@ -1,0 +1,30071 @@
+{
+  "TableName": "CourseIdentifiers",
+  "AutoGenerateCreatedDate": true,
+  "AutoGenerateModifiedDate": true,
+  "Data": [
+    {
+      "Id": "d41865d9-9ada-4d2f-a1c8-24cfaae73cae",
+      "ConcordiaCourseId": "000026"
+    },
+    {
+      "Id": "4b12ed3b-73cd-422d-b944-197d8cc57dd4",
+      "ConcordiaCourseId": "000027"
+    },
+    {
+      "Id": "985ae085-3c1e-461b-a31a-2dde0e1dcebb",
+      "ConcordiaCourseId": "000028"
+    },
+    {
+      "Id": "04677b7f-81a0-4c79-8957-31b899d89e46",
+      "ConcordiaCourseId": "000035"
+    },
+    {
+      "Id": "5768b7a2-4e3f-405d-9815-4f4b43170893",
+      "ConcordiaCourseId": "000043"
+    },
+    {
+      "Id": "d8eb0321-4871-4e75-9c5e-123bed578761",
+      "ConcordiaCourseId": "000053"
+    },
+    {
+      "Id": "91fedddd-216b-4fdf-96f2-dfc0e80b4ebe",
+      "ConcordiaCourseId": "000055"
+    },
+    {
+      "Id": "145b1eae-e6db-41dd-ba1d-0d156afbc779",
+      "ConcordiaCourseId": "000057"
+    },
+    {
+      "Id": "db288c6c-b779-4546-b85c-f532c102726b",
+      "ConcordiaCourseId": "000058"
+    },
+    {
+      "Id": "0755120c-459f-4a74-bfb6-0ffa32428e29",
+      "ConcordiaCourseId": "000059"
+    },
+    {
+      "Id": "a8e9d2a6-a328-4bca-a93a-1fca77036171",
+      "ConcordiaCourseId": "000060"
+    },
+    {
+      "Id": "1659db9b-d39d-4e36-bf6c-e738d23d7fd2",
+      "ConcordiaCourseId": "000086"
+    },
+    {
+      "Id": "29c00f98-c2b8-47b9-8337-f1d04f280d96",
+      "ConcordiaCourseId": "000089"
+    },
+    {
+      "Id": "58e1ded5-da29-4065-b8ea-746adf02c4d9",
+      "ConcordiaCourseId": "000092"
+    },
+    {
+      "Id": "9ea62dc0-671e-4b9b-be37-c8d09b87a14a",
+      "ConcordiaCourseId": "000097"
+    },
+    {
+      "Id": "5ba3b8a8-f01e-4f4e-8eb0-00277c9716a6",
+      "ConcordiaCourseId": "000098"
+    },
+    {
+      "Id": "30c756c2-4cf9-4566-954e-786f4fa9a3af",
+      "ConcordiaCourseId": "000104"
+    },
+    {
+      "Id": "bcdaa341-d9cc-4785-bf06-04db0478209a",
+      "ConcordiaCourseId": "000106"
+    },
+    {
+      "Id": "58e0a2f6-f93c-4781-9fef-f551c5d4fab4",
+      "ConcordiaCourseId": "000109"
+    },
+    {
+      "Id": "9b9f2e07-e1da-4d8c-995b-19414ac40f2f",
+      "ConcordiaCourseId": "000173"
+    },
+    {
+      "Id": "72f08b9e-0aaa-4a46-b04c-50717da696fd",
+      "ConcordiaCourseId": "000174"
+    },
+    {
+      "Id": "df8c90ed-6687-4a0c-9886-49139d5e8511",
+      "ConcordiaCourseId": "000178"
+    },
+    {
+      "Id": "18f920ac-370b-47b4-857e-ff735f6ca54b",
+      "ConcordiaCourseId": "000182"
+    },
+    {
+      "Id": "48c61192-cdd9-40bb-babf-199bc39c6903",
+      "ConcordiaCourseId": "000185"
+    },
+    {
+      "Id": "8864f8b3-c7b1-42ae-9631-95c93ad0aef7",
+      "ConcordiaCourseId": "000186"
+    },
+    {
+      "Id": "92b21ecc-82d6-4b04-8144-799d8b352301",
+      "ConcordiaCourseId": "000187"
+    },
+    {
+      "Id": "c656570d-b73a-44ab-9ae0-a4d9bd7eb930",
+      "ConcordiaCourseId": "000189"
+    },
+    {
+      "Id": "8f37d047-940d-4ca6-9d4b-b407b2923e1a",
+      "ConcordiaCourseId": "000190"
+    },
+    {
+      "Id": "0a56021f-eeb5-4232-8ee9-b428a75de885",
+      "ConcordiaCourseId": "000191"
+    },
+    {
+      "Id": "634be501-8279-427f-b89a-87cd092eca65",
+      "ConcordiaCourseId": "040004"
+    },
+    {
+      "Id": "3b7dc48a-336d-42b1-a06c-f0f14be95757",
+      "ConcordiaCourseId": "040005"
+    },
+    {
+      "Id": "77e753bd-6ab4-4a72-8ae1-662b188f4474",
+      "ConcordiaCourseId": "043001"
+    },
+    {
+      "Id": "e77f80ac-7ac3-4b58-863d-dd149c20117d",
+      "ConcordiaCourseId": "044001"
+    },
+    {
+      "Id": "a22823f8-c373-44fd-b57d-05ba6e25a163",
+      "ConcordiaCourseId": "044002"
+    },
+    {
+      "Id": "c474d18b-38b9-4a54-8da0-e6f8b3b83db3",
+      "ConcordiaCourseId": "044003"
+    },
+    {
+      "Id": "2f6edc18-75db-4b36-9ee4-c42082e58ed2",
+      "ConcordiaCourseId": "044004"
+    },
+    {
+      "Id": "51073466-2078-46e5-ac55-f2731adcef16",
+      "ConcordiaCourseId": "045085"
+    },
+    {
+      "Id": "60dbe40f-d106-4cab-a431-33423afec0df",
+      "ConcordiaCourseId": "045114"
+    },
+    {
+      "Id": "37f95c10-2b8f-43dd-8cc9-499019b316e3",
+      "ConcordiaCourseId": "045884"
+    },
+    {
+      "Id": "bb3605ce-57ea-4d1d-9923-6de8954e4d50",
+      "ConcordiaCourseId": "045885"
+    },
+    {
+      "Id": "bf39a7e0-adb4-4a6e-8095-eb36d08d58d5",
+      "ConcordiaCourseId": "046442"
+    },
+    {
+      "Id": "8c260825-177c-4baf-a6fc-6b887e550b27",
+      "ConcordiaCourseId": "046443"
+    },
+    {
+      "Id": "3776f12e-24d8-467d-9557-0c618bae25b0",
+      "ConcordiaCourseId": "046444"
+    },
+    {
+      "Id": "06599a40-af3a-43e4-9d76-36a07fab64b2",
+      "ConcordiaCourseId": "047353"
+    },
+    {
+      "Id": "5a98b9ee-b55d-45bd-9864-f13707c139a9",
+      "ConcordiaCourseId": "047354"
+    },
+    {
+      "Id": "cbdde1b8-f320-493c-92ac-86532b3d9484",
+      "ConcordiaCourseId": "047360"
+    },
+    {
+      "Id": "22950897-644e-430a-b7da-041ae112382d",
+      "ConcordiaCourseId": "047361"
+    },
+    {
+      "Id": "67601819-936e-4505-a2f6-e4f7e9b4f372",
+      "ConcordiaCourseId": "047363"
+    },
+    {
+      "Id": "18d034f3-a1ba-49d2-808f-a5ec356b8ef5",
+      "ConcordiaCourseId": "047364"
+    },
+    {
+      "Id": "a7d40894-a689-4724-a75d-f85411dfd435",
+      "ConcordiaCourseId": "047367"
+    },
+    {
+      "Id": "a516f826-90e7-4009-a33f-b5689eb09f89",
+      "ConcordiaCourseId": "047368"
+    },
+    {
+      "Id": "d63e88b9-f5f8-4877-95e8-bbc13ee1d74d",
+      "ConcordiaCourseId": "047369"
+    },
+    {
+      "Id": "88e7415f-f8de-4e61-a843-1370e8b49d83",
+      "ConcordiaCourseId": "047370"
+    },
+    {
+      "Id": "dc564dbe-e539-47ae-8752-1e866f583703",
+      "ConcordiaCourseId": "047371"
+    },
+    {
+      "Id": "507ae0ef-61a8-448b-b378-d4b03b4bdf3b",
+      "ConcordiaCourseId": "047372"
+    },
+    {
+      "Id": "40445045-2c2d-4e2f-89be-afca1a8b11c6",
+      "ConcordiaCourseId": "048073"
+    },
+    {
+      "Id": "2ec492e3-1bdb-4a4c-8360-01f411077833",
+      "ConcordiaCourseId": "048544"
+    },
+    {
+      "Id": "ee092a5b-c0e5-4e16-8d04-33ebc67b4554",
+      "ConcordiaCourseId": "048619"
+    },
+    {
+      "Id": "7752ea7f-70b8-4e22-9b1b-8e3454ffd31a",
+      "ConcordiaCourseId": "048720"
+    },
+    {
+      "Id": "26be3b80-0212-42f6-b7e2-794a4f1067ce",
+      "ConcordiaCourseId": "048817"
+    },
+    {
+      "Id": "b3a01efa-09e6-4ad2-a864-6b4bb282c53a",
+      "ConcordiaCourseId": "048824"
+    },
+    {
+      "Id": "5404ec33-357b-4e91-b18d-55fa94fdbe2e",
+      "ConcordiaCourseId": "048825"
+    },
+    {
+      "Id": "ea5b1564-1cc5-476c-9558-6744150b901e",
+      "ConcordiaCourseId": "048826"
+    },
+    {
+      "Id": "1e786ffd-52dc-4429-a79c-4f62fb3934b9",
+      "ConcordiaCourseId": "048827"
+    },
+    {
+      "Id": "bc3d8ce2-84c6-4842-a616-0b52c58745d9",
+      "ConcordiaCourseId": "048828"
+    },
+    {
+      "Id": "af60a713-d6c6-4ef4-b148-b294420bbaff",
+      "ConcordiaCourseId": "048829"
+    },
+    {
+      "Id": "528e2675-8929-4850-9e0a-c6324aa6ad87",
+      "ConcordiaCourseId": "048830"
+    },
+    {
+      "Id": "047ea8fd-9c80-4c6b-adae-45264d830cda",
+      "ConcordiaCourseId": "048831"
+    },
+    {
+      "Id": "9fc6e4cc-b388-4413-b043-7cd4f7f6f778",
+      "ConcordiaCourseId": "050726"
+    },
+    {
+      "Id": "67040415-2e48-4554-ac4b-1abe7c304fbb",
+      "ConcordiaCourseId": "047731"
+    },
+    {
+      "Id": "29374d94-ad1c-4c4c-8fdb-322d24b66f3f",
+      "ConcordiaCourseId": "047732"
+    },
+    {
+      "Id": "65da1de2-96ac-4cda-9e26-26a78370a460",
+      "ConcordiaCourseId": "047733"
+    },
+    {
+      "Id": "364adc8a-2f54-4089-b996-8bd17d95eabe",
+      "ConcordiaCourseId": "047734"
+    },
+    {
+      "Id": "3a71830a-4135-4c49-9bc3-5d3e5b171ba1",
+      "ConcordiaCourseId": "047735"
+    },
+    {
+      "Id": "a763c8c1-541b-42c8-95e5-8ea5a5c684e2",
+      "ConcordiaCourseId": "047738"
+    },
+    {
+      "Id": "47ff7f4f-69e1-4cec-be91-c70e81192184",
+      "ConcordiaCourseId": "047740"
+    },
+    {
+      "Id": "b4e6df98-2c3b-4499-b0da-26fd6e869d83",
+      "ConcordiaCourseId": "047741"
+    },
+    {
+      "Id": "d3fbba81-2fca-462d-a6fe-de562792b3d5",
+      "ConcordiaCourseId": "047760"
+    },
+    {
+      "Id": "2cbf72e4-b668-4eb3-aa81-c4fe31a70ed2",
+      "ConcordiaCourseId": "047761"
+    },
+    {
+      "Id": "fe6b6cf2-b0e4-466c-9ac4-fc3b10bc1527",
+      "ConcordiaCourseId": "047848"
+    },
+    {
+      "Id": "e0bc3127-1532-4d6e-99b3-04706457d03d",
+      "ConcordiaCourseId": "047849"
+    },
+    {
+      "Id": "4ffd60d2-9e38-4d5f-bee8-cd508a374ebf",
+      "ConcordiaCourseId": "047850"
+    },
+    {
+      "Id": "f3190bd7-2a1e-48d9-8cb0-20c3a50629e1",
+      "ConcordiaCourseId": "047851"
+    },
+    {
+      "Id": "08b2b8bd-4c4b-42d5-9ea9-15dc0f1f8929",
+      "ConcordiaCourseId": "047852"
+    },
+    {
+      "Id": "a969eb37-f366-4521-bc5b-5abbde3d8b77",
+      "ConcordiaCourseId": "047854"
+    },
+    {
+      "Id": "5ef94beb-d992-4351-bf26-ff472fd8d27a",
+      "ConcordiaCourseId": "047855"
+    },
+    {
+      "Id": "fed91fcb-318a-4901-88ee-764281f27986",
+      "ConcordiaCourseId": "047856"
+    },
+    {
+      "Id": "c950a7aa-0f58-4d6e-ab8e-85f8293cf18b",
+      "ConcordiaCourseId": "047857"
+    },
+    {
+      "Id": "0601cc3c-cb22-43f9-8b6e-b1948bf0bd49",
+      "ConcordiaCourseId": "047858"
+    },
+    {
+      "Id": "42df18d7-09c9-44b9-9e99-ac8a44e9fe08",
+      "ConcordiaCourseId": "047859"
+    },
+    {
+      "Id": "3486a54f-7e6e-4e52-902e-17c4be2bdf97",
+      "ConcordiaCourseId": "047860"
+    },
+    {
+      "Id": "f5b0e180-3c1b-4aef-9d0d-c4ad47c3ca3d",
+      "ConcordiaCourseId": "047861"
+    },
+    {
+      "Id": "9afe2fae-f04d-4baa-9236-3857a772eeb5",
+      "ConcordiaCourseId": "047862"
+    },
+    {
+      "Id": "d2fe8621-988c-4175-b582-8c0ffec8f98c",
+      "ConcordiaCourseId": "047863"
+    },
+    {
+      "Id": "57ccb39a-01e3-4633-b3bc-a7285cb06efa",
+      "ConcordiaCourseId": "047864"
+    },
+    {
+      "Id": "8524bd6e-9740-496f-9a0d-1a06b38fab6c",
+      "ConcordiaCourseId": "047865"
+    },
+    {
+      "Id": "402c77fe-5229-4d3c-87db-5081ef0da93b",
+      "ConcordiaCourseId": "047866"
+    },
+    {
+      "Id": "14e75577-5143-41b7-a29e-ff532fc92ce7",
+      "ConcordiaCourseId": "048916"
+    },
+    {
+      "Id": "80dd2911-b290-4b90-8aff-503bac78a838",
+      "ConcordiaCourseId": "048917"
+    },
+    {
+      "Id": "915b9550-b50f-47cc-8580-367eef74e44e",
+      "ConcordiaCourseId": "048922"
+    },
+    {
+      "Id": "16e85800-cfec-49ec-9d77-5362dbeb7227",
+      "ConcordiaCourseId": "048923"
+    },
+    {
+      "Id": "61df5f5b-58b2-4684-bdd4-044c5bd901bc",
+      "ConcordiaCourseId": "050411"
+    },
+    {
+      "Id": "f45b294e-0ba8-495f-9e8d-2cde48d5650e",
+      "ConcordiaCourseId": "000235"
+    },
+    {
+      "Id": "d64a0fee-8314-4322-b13f-c1eb7a977f6a",
+      "ConcordiaCourseId": "000236"
+    },
+    {
+      "Id": "64d5cb7e-65a3-4758-8bd2-dcd83e4e227f",
+      "ConcordiaCourseId": "000237"
+    },
+    {
+      "Id": "c33ee030-8acd-43d3-beb1-db4d709d665d",
+      "ConcordiaCourseId": "000238"
+    },
+    {
+      "Id": "9a371965-7a01-4845-894a-b1a472d680c7",
+      "ConcordiaCourseId": "000239"
+    },
+    {
+      "Id": "d4585b56-8466-413c-a48d-2b16a4c66eb2",
+      "ConcordiaCourseId": "000241"
+    },
+    {
+      "Id": "b99bc1d1-ddcf-4373-a281-ba71bb6db242",
+      "ConcordiaCourseId": "000242"
+    },
+    {
+      "Id": "a86c98ff-3936-411d-b231-5390236eb31d",
+      "ConcordiaCourseId": "000243"
+    },
+    {
+      "Id": "9a9d3a21-491d-4780-8a2b-21a16e4071b3",
+      "ConcordiaCourseId": "000244"
+    },
+    {
+      "Id": "27008293-5e7e-4d18-b34e-0c3f394c0ee6",
+      "ConcordiaCourseId": "000245"
+    },
+    {
+      "Id": "88e2e2dc-1ee6-4baf-9644-8832cd2724c2",
+      "ConcordiaCourseId": "046445"
+    },
+    {
+      "Id": "ab43a25e-9042-46f3-b65e-1c44718c1047",
+      "ConcordiaCourseId": "046446"
+    },
+    {
+      "Id": "8c037137-9c2d-49da-b54a-bce2ec5d6ecc",
+      "ConcordiaCourseId": "000246"
+    },
+    {
+      "Id": "4006f341-61e8-4667-9d7c-45b0a550b595",
+      "ConcordiaCourseId": "000247"
+    },
+    {
+      "Id": "aad32d5b-dcd3-45c9-a6ba-15a403a51443",
+      "ConcordiaCourseId": "000248"
+    },
+    {
+      "Id": "9d9e641c-d038-4873-b7ef-dd1ed1139d74",
+      "ConcordiaCourseId": "000251"
+    },
+    {
+      "Id": "2d110ef9-5bd7-4e2b-965a-d4d420ab3fae",
+      "ConcordiaCourseId": "000253"
+    },
+    {
+      "Id": "9128a741-3cde-49f7-b0f9-56697e6b8c01",
+      "ConcordiaCourseId": "000254"
+    },
+    {
+      "Id": "5eb49798-750d-4c66-b296-b0ee49309fa6",
+      "ConcordiaCourseId": "000257"
+    },
+    {
+      "Id": "ac14cb7a-b7b1-45d6-ad4f-ca6e339ceea0",
+      "ConcordiaCourseId": "000258"
+    },
+    {
+      "Id": "a32ed471-e18e-460b-a623-bfd0a592fb8d",
+      "ConcordiaCourseId": "000260"
+    },
+    {
+      "Id": "ac798bf4-2fea-403f-bb42-8dfd224ff190",
+      "ConcordiaCourseId": "000273"
+    },
+    {
+      "Id": "0918ccf6-e5cf-491f-9782-afd9829d1bd2",
+      "ConcordiaCourseId": "000274"
+    },
+    {
+      "Id": "b3a6fc8f-f83b-48cd-a7d3-ee5f6094f055",
+      "ConcordiaCourseId": "000277"
+    },
+    {
+      "Id": "8bef17ed-0956-4e32-a48d-4f845c7274a4",
+      "ConcordiaCourseId": "046447"
+    },
+    {
+      "Id": "46b3f64a-09f2-4122-ad58-fdba6a83fb94",
+      "ConcordiaCourseId": "046448"
+    },
+    {
+      "Id": "e7ba68b5-cc35-45cf-9d43-f64fa0ca7681",
+      "ConcordiaCourseId": "046449"
+    },
+    {
+      "Id": "bcd3b993-84e6-4d9a-9d55-863736f9fafb",
+      "ConcordiaCourseId": "046450"
+    },
+    {
+      "Id": "19252c57-18d1-41e7-a10a-960179be2411",
+      "ConcordiaCourseId": "000316"
+    },
+    {
+      "Id": "17434b53-7f0f-4e6f-8b9f-7ac8684a52ff",
+      "ConcordiaCourseId": "000317"
+    },
+    {
+      "Id": "bef0ee1b-5689-47f3-9407-0c8987a2ae19",
+      "ConcordiaCourseId": "000318"
+    },
+    {
+      "Id": "609670ca-a0fe-4cac-811c-f0194f02b4ad",
+      "ConcordiaCourseId": "000319"
+    },
+    {
+      "Id": "86be6020-d248-4c37-9637-9a7c42380fcf",
+      "ConcordiaCourseId": "000320"
+    },
+    {
+      "Id": "daf907a8-127f-4a2f-9e0f-30e276dd3b84",
+      "ConcordiaCourseId": "000323"
+    },
+    {
+      "Id": "d3061e78-7649-43bf-b7ab-948b31ebfac9",
+      "ConcordiaCourseId": "000325"
+    },
+    {
+      "Id": "1eb84e1f-b1fb-494c-963f-b26ca62da1d1",
+      "ConcordiaCourseId": "000326"
+    },
+    {
+      "Id": "3a40d61d-a890-4c79-a406-20e957af0ca4",
+      "ConcordiaCourseId": "000327"
+    },
+    {
+      "Id": "c8447564-9949-452a-92de-257e58b878db",
+      "ConcordiaCourseId": "000328"
+    },
+    {
+      "Id": "7f971549-c920-446d-9afe-b8c392c282ab",
+      "ConcordiaCourseId": "000329"
+    },
+    {
+      "Id": "fcc7a2af-0c13-44c6-9a39-10d86c9c96a1",
+      "ConcordiaCourseId": "000333"
+    },
+    {
+      "Id": "6105b022-b25f-45c2-810e-1cde5f27b9cf",
+      "ConcordiaCourseId": "000334"
+    },
+    {
+      "Id": "9f6a3c04-085f-48e0-afc9-c943e87f0c67",
+      "ConcordiaCourseId": "000335"
+    },
+    {
+      "Id": "5d47ac78-ef13-4671-93ec-dc592812c23b",
+      "ConcordiaCourseId": "000337"
+    },
+    {
+      "Id": "321ac21b-1edc-4ad4-9b09-0c37e2c7fc4a",
+      "ConcordiaCourseId": "000345"
+    },
+    {
+      "Id": "280ee398-e2ce-42e6-b0d2-1f2dccfb9b17",
+      "ConcordiaCourseId": "037543"
+    },
+    {
+      "Id": "7ad9a143-6e38-448d-87c9-851cbc0660af",
+      "ConcordiaCourseId": "040012"
+    },
+    {
+      "Id": "63ba6a6a-c87e-4352-904e-e18c0c3af9ea",
+      "ConcordiaCourseId": "040013"
+    },
+    {
+      "Id": "1ee461dd-4c7c-4fca-a1de-1667af20132e",
+      "ConcordiaCourseId": "040014"
+    },
+    {
+      "Id": "c49cd15a-2d81-4baa-b301-9ca00bc88cc4",
+      "ConcordiaCourseId": "040015"
+    },
+    {
+      "Id": "ac80a4c4-3294-4fe0-8cfc-11e394f98298",
+      "ConcordiaCourseId": "046451"
+    },
+    {
+      "Id": "eab68946-d89c-4bbd-bd09-d396c0a00cee",
+      "ConcordiaCourseId": "000360"
+    },
+    {
+      "Id": "cd828536-ba57-4a1d-864d-6bd1d7c6257d",
+      "ConcordiaCourseId": "000361"
+    },
+    {
+      "Id": "9fc9dc4e-e8c2-4c94-bbc1-4e268ee61bb8",
+      "ConcordiaCourseId": "000384"
+    },
+    {
+      "Id": "0157954d-9651-4bae-b69e-39965633a91e",
+      "ConcordiaCourseId": "000409"
+    },
+    {
+      "Id": "4ad5ee4e-b229-4023-8955-6bb21aabfdc2",
+      "ConcordiaCourseId": "000428"
+    },
+    {
+      "Id": "fc7cee09-36d4-4be5-bf9c-c8963facb4c8",
+      "ConcordiaCourseId": "000448"
+    },
+    {
+      "Id": "ad5e80cf-22bf-4df4-b1b2-5805de1a5cd3",
+      "ConcordiaCourseId": "000505"
+    },
+    {
+      "Id": "30a7d1fa-dba6-49b8-8d04-926d96a3877b",
+      "ConcordiaCourseId": "000522"
+    },
+    {
+      "Id": "1ab5d5a5-a11a-4e0b-9bdf-ae4ec5bc0785",
+      "ConcordiaCourseId": "000537"
+    },
+    {
+      "Id": "0f5de1d5-55b8-40ce-8b57-d096a3a9bc23",
+      "ConcordiaCourseId": "000547"
+    },
+    {
+      "Id": "c1b21a52-ee1d-49fe-85ea-ad002a7b8602",
+      "ConcordiaCourseId": "000586"
+    },
+    {
+      "Id": "0ebc06a9-4c7b-4b05-b076-1cdb9f39b31e",
+      "ConcordiaCourseId": "000605"
+    },
+    {
+      "Id": "d5eec79a-7c16-4f7c-ab39-3b75e5d8e812",
+      "ConcordiaCourseId": "000627"
+    },
+    {
+      "Id": "a3a6a939-c1f6-4304-94bb-d1dc7902bbcf",
+      "ConcordiaCourseId": "000649"
+    },
+    {
+      "Id": "c586b554-a379-4b2e-bbce-20cfac2dc848",
+      "ConcordiaCourseId": "000650"
+    },
+    {
+      "Id": "3bc18ed6-5ea6-42ef-8a00-cde514d1f3c5",
+      "ConcordiaCourseId": "000676"
+    },
+    {
+      "Id": "336dab9f-d852-471d-b7b3-f31e0814ca74",
+      "ConcordiaCourseId": "000677"
+    },
+    {
+      "Id": "a218bb99-8386-4e92-ada1-1e2f948ad2f2",
+      "ConcordiaCourseId": "000679"
+    },
+    {
+      "Id": "7b4a9912-7faa-444e-b2bf-f1c0e83e5274",
+      "ConcordiaCourseId": "000680"
+    },
+    {
+      "Id": "ad1780ea-31d7-44fb-b7a4-393191e37f04",
+      "ConcordiaCourseId": "046452"
+    },
+    {
+      "Id": "559f47b6-918a-452e-8d7a-8f09c3c6dc8b",
+      "ConcordiaCourseId": "046453"
+    },
+    {
+      "Id": "299bc81c-4cfa-43b5-8b78-59663695dba3",
+      "ConcordiaCourseId": "046454"
+    },
+    {
+      "Id": "5a7e04b1-b7b6-44a7-acc1-a32e22244fd5",
+      "ConcordiaCourseId": "046455"
+    },
+    {
+      "Id": "a9f0ab4f-5e8b-4140-a9a2-0c1990f5abb8",
+      "ConcordiaCourseId": "046456"
+    },
+    {
+      "Id": "517d22b8-0370-4216-9b17-3008c700355d",
+      "ConcordiaCourseId": "046457"
+    },
+    {
+      "Id": "e2bf56ea-867d-43d0-8334-04e73e7809cc",
+      "ConcordiaCourseId": "048415"
+    },
+    {
+      "Id": "9543dab1-01b4-4a60-baa2-1e79fcd72710",
+      "ConcordiaCourseId": "048416"
+    },
+    {
+      "Id": "aa8a67ef-dc76-4992-b096-4105ed558dda",
+      "ConcordiaCourseId": "048417"
+    },
+    {
+      "Id": "4a4ebbe9-b185-4ce1-9b67-8102fc2a1c55",
+      "ConcordiaCourseId": "048418"
+    },
+    {
+      "Id": "b7214bc7-2fc9-49dd-80db-e8a9ef7e90a6",
+      "ConcordiaCourseId": "048419"
+    },
+    {
+      "Id": "ff157063-bf4a-45b8-94ac-8c0414af0143",
+      "ConcordiaCourseId": "048909"
+    },
+    {
+      "Id": "2dc7b186-6086-4cc8-b777-1932c2c59810",
+      "ConcordiaCourseId": "048910"
+    },
+    {
+      "Id": "262a64a4-1018-4e94-9b95-0acfa2110baa",
+      "ConcordiaCourseId": "048911"
+    },
+    {
+      "Id": "3c867be6-8801-4747-b3e0-8661b17b1532",
+      "ConcordiaCourseId": "050138"
+    },
+    {
+      "Id": "4e31cdcb-6fb5-4bbe-a1a2-2706edb1a690",
+      "ConcordiaCourseId": "050596"
+    },
+    {
+      "Id": "c2bbddbd-d313-4602-8f0d-b626e9d838fa",
+      "ConcordiaCourseId": "050597"
+    },
+    {
+      "Id": "578c6aaa-1df3-4971-930c-8eed422129b5",
+      "ConcordiaCourseId": "050598"
+    },
+    {
+      "Id": "a8c91272-dac3-40cf-a0be-c7cdf88a2208",
+      "ConcordiaCourseId": "050599"
+    },
+    {
+      "Id": "3e09c2bf-52d6-4a29-b20a-1c396017bd0d",
+      "ConcordiaCourseId": "050604"
+    },
+    {
+      "Id": "6354194d-cb7f-4f14-8e5f-e500accbd2ee",
+      "ConcordiaCourseId": "050605"
+    },
+    {
+      "Id": "53c129ba-b4e4-449c-9460-59b71971082f",
+      "ConcordiaCourseId": "050606"
+    },
+    {
+      "Id": "11e4673a-dda5-4c29-825d-269224e21c9d",
+      "ConcordiaCourseId": "050607"
+    },
+    {
+      "Id": "b10c1a72-d3a4-452b-a399-1204142cdf8a",
+      "ConcordiaCourseId": "050608"
+    },
+    {
+      "Id": "f35f8013-192a-491b-97cc-dd64b271f72b",
+      "ConcordiaCourseId": "050609"
+    },
+    {
+      "Id": "cdfd24b1-bde2-4293-bf34-fc9e42496068",
+      "ConcordiaCourseId": "050610"
+    },
+    {
+      "Id": "afd1a882-34f8-4748-a6c0-d8773f456581",
+      "ConcordiaCourseId": "050611"
+    },
+    {
+      "Id": "3b58febe-fe6b-4d4c-8eaf-fe349fbc33b9",
+      "ConcordiaCourseId": "050612"
+    },
+    {
+      "Id": "b41ad51e-aa1c-435e-a570-ffdbdde107ac",
+      "ConcordiaCourseId": "050613"
+    },
+    {
+      "Id": "f781abab-69bf-4df0-b5a2-db5ea7943097",
+      "ConcordiaCourseId": "050614"
+    },
+    {
+      "Id": "89e802ec-c268-4850-947d-b8c4def536c2",
+      "ConcordiaCourseId": "050616"
+    },
+    {
+      "Id": "bcae3ddd-9692-43ba-9e94-3982c0d0576a",
+      "ConcordiaCourseId": "050617"
+    },
+    {
+      "Id": "70a39f15-b601-45fa-b8aa-2eec6812d44f",
+      "ConcordiaCourseId": "000705"
+    },
+    {
+      "Id": "9c120fd7-11f0-4cd7-a9d9-6b5d27583f98",
+      "ConcordiaCourseId": "000706"
+    },
+    {
+      "Id": "537a194b-dad3-46f3-b062-557917eeb9cc",
+      "ConcordiaCourseId": "000707"
+    },
+    {
+      "Id": "20ea375e-d7be-4583-9b1d-1d3f8223320b",
+      "ConcordiaCourseId": "000708"
+    },
+    {
+      "Id": "38f20944-20b7-46fe-9993-a3ed0807174c",
+      "ConcordiaCourseId": "000709"
+    },
+    {
+      "Id": "f5fc6cb3-beee-4307-b3ca-32a810116133",
+      "ConcordiaCourseId": "000710"
+    },
+    {
+      "Id": "845c788d-1b95-4f42-9650-73e03da587a8",
+      "ConcordiaCourseId": "000711"
+    },
+    {
+      "Id": "ed3c1e02-896f-4f42-b021-8626f9ba6350",
+      "ConcordiaCourseId": "000712"
+    },
+    {
+      "Id": "d6bf513c-c12a-4533-81f1-fec7c3e13331",
+      "ConcordiaCourseId": "000713"
+    },
+    {
+      "Id": "42be8a0a-f489-47d6-9474-85cc0b22d6c9",
+      "ConcordiaCourseId": "000714"
+    },
+    {
+      "Id": "d8df08ff-8d95-4f93-a19d-24d9b760211e",
+      "ConcordiaCourseId": "025371"
+    },
+    {
+      "Id": "c5a9a898-0444-4d4d-add3-cf52877ec884",
+      "ConcordiaCourseId": "047199"
+    },
+    {
+      "Id": "0c660b2d-28b4-47d0-b6c8-caa84316ab82",
+      "ConcordiaCourseId": "047200"
+    },
+    {
+      "Id": "9e1eea22-1b9d-4d5c-9168-90e66dc30a48",
+      "ConcordiaCourseId": "047218"
+    },
+    {
+      "Id": "2c7dc005-c168-4469-b410-231bf4271896",
+      "ConcordiaCourseId": "048354"
+    },
+    {
+      "Id": "620bc67d-c9f8-4fd7-9634-61c0c3f150fa",
+      "ConcordiaCourseId": "048356"
+    },
+    {
+      "Id": "82c19458-6389-466e-a8cb-2245108e7b09",
+      "ConcordiaCourseId": "048357"
+    },
+    {
+      "Id": "24e7d586-df10-440f-af15-c5c377a238b9",
+      "ConcordiaCourseId": "048358"
+    },
+    {
+      "Id": "bf4106dd-29fc-4e5c-be8f-1b7a18f7dd41",
+      "ConcordiaCourseId": "048359"
+    },
+    {
+      "Id": "d14afae6-f4eb-4aca-9ff8-b701326c5237",
+      "ConcordiaCourseId": "049313"
+    },
+    {
+      "Id": "86fb3540-286f-4e77-a25d-859db77f7570",
+      "ConcordiaCourseId": "049708"
+    },
+    {
+      "Id": "8215160a-09e3-4328-93c7-91b6e32b3611",
+      "ConcordiaCourseId": "049711"
+    },
+    {
+      "Id": "1340e769-026d-452e-9d11-c0d90d17a80c",
+      "ConcordiaCourseId": "000715"
+    },
+    {
+      "Id": "2daecb0a-28c5-4c1e-bf8f-6884be8342ec",
+      "ConcordiaCourseId": "000716"
+    },
+    {
+      "Id": "c63ba6f7-9016-4ce9-814e-440ef95ecae3",
+      "ConcordiaCourseId": "000717"
+    },
+    {
+      "Id": "cbbb064b-9071-4d3f-923d-5645987cbae4",
+      "ConcordiaCourseId": "000718"
+    },
+    {
+      "Id": "99869ec0-bc63-45e9-8875-7c06cdecabc9",
+      "ConcordiaCourseId": "000719"
+    },
+    {
+      "Id": "c91241ed-1df4-4273-b342-c27405292767",
+      "ConcordiaCourseId": "000720"
+    },
+    {
+      "Id": "9168b989-de3e-4da9-82eb-b3fe241b5a21",
+      "ConcordiaCourseId": "000721"
+    },
+    {
+      "Id": "ad7dcec5-6f6f-4e52-a275-a7e0e29c00c1",
+      "ConcordiaCourseId": "000726"
+    },
+    {
+      "Id": "ca6d821d-1bdb-447b-82de-97d05335e3a1",
+      "ConcordiaCourseId": "000727"
+    },
+    {
+      "Id": "08261413-3852-48c8-afdb-c23da8f0a571",
+      "ConcordiaCourseId": "000728"
+    },
+    {
+      "Id": "0d2ea4d4-4e4f-4989-ac36-d23643e25dc4",
+      "ConcordiaCourseId": "000729"
+    },
+    {
+      "Id": "2baadf90-bc52-4bf2-926c-880e6eadd160",
+      "ConcordiaCourseId": "000737"
+    },
+    {
+      "Id": "5a42a364-c2b9-4663-b2d6-9a5877a419ab",
+      "ConcordiaCourseId": "000738"
+    },
+    {
+      "Id": "9ebc058a-ab01-4fd7-9f44-1e1e72331dc7",
+      "ConcordiaCourseId": "000739"
+    },
+    {
+      "Id": "608a1f37-bb24-4921-9055-c1098cf73f08",
+      "ConcordiaCourseId": "000740"
+    },
+    {
+      "Id": "d7a949eb-bc1e-422a-81c6-352eb00b13d7",
+      "ConcordiaCourseId": "000741"
+    },
+    {
+      "Id": "f53825c6-08e7-4a97-866a-cb4dffe63e16",
+      "ConcordiaCourseId": "000742"
+    },
+    {
+      "Id": "537f1211-6975-4442-b05b-99b74c269e08",
+      "ConcordiaCourseId": "000743"
+    },
+    {
+      "Id": "20ff122d-c0bf-42ce-888d-cc724d296ee3",
+      "ConcordiaCourseId": "000744"
+    },
+    {
+      "Id": "c1fc35b3-d228-4126-b9aa-90e666e8279d",
+      "ConcordiaCourseId": "000745"
+    },
+    {
+      "Id": "1d4d7c8a-7374-4b97-b576-b983dc3d1703",
+      "ConcordiaCourseId": "000746"
+    },
+    {
+      "Id": "337d4e27-7049-4bd8-bd63-d294b8d68b97",
+      "ConcordiaCourseId": "000747"
+    },
+    {
+      "Id": "c969aaa0-f446-4c14-8bcc-37bae260c922",
+      "ConcordiaCourseId": "000748"
+    },
+    {
+      "Id": "d00ac929-ee8f-44be-bab7-f0740a5e7979",
+      "ConcordiaCourseId": "000749"
+    },
+    {
+      "Id": "e0bca4a9-ea27-4e3f-8ecb-ba5a46bcbee6",
+      "ConcordiaCourseId": "000750"
+    },
+    {
+      "Id": "691df5aa-a342-4ca3-987c-31476c823243",
+      "ConcordiaCourseId": "000752"
+    },
+    {
+      "Id": "89b5e8e9-d8ac-415f-9bf4-edd9053d1cb7",
+      "ConcordiaCourseId": "000754"
+    },
+    {
+      "Id": "211af27e-be5c-42f8-91d1-716d61b4c58c",
+      "ConcordiaCourseId": "000755"
+    },
+    {
+      "Id": "8426a633-3a9c-46b7-8d61-3af72c694dd9",
+      "ConcordiaCourseId": "000756"
+    },
+    {
+      "Id": "bcc50d04-4605-486f-8f25-97ad1af2d881",
+      "ConcordiaCourseId": "000757"
+    },
+    {
+      "Id": "af496ee2-5804-4c91-aba3-76ba117262ec",
+      "ConcordiaCourseId": "000758"
+    },
+    {
+      "Id": "e58cae17-1065-4553-ba7d-553772d27209",
+      "ConcordiaCourseId": "000760"
+    },
+    {
+      "Id": "483c28a3-25ed-4ecf-aa63-095ba9dcc119",
+      "ConcordiaCourseId": "000761"
+    },
+    {
+      "Id": "bb369d26-545b-48a7-853a-13df822e6bde",
+      "ConcordiaCourseId": "000762"
+    },
+    {
+      "Id": "987def3f-b96d-4f37-91e6-fee2ff96d751",
+      "ConcordiaCourseId": "000763"
+    },
+    {
+      "Id": "e11296e9-0cb1-481e-a445-0a7f3a2d6ce1",
+      "ConcordiaCourseId": "000764"
+    },
+    {
+      "Id": "b49058d6-46cb-4850-9dc7-a5abc7aba5d3",
+      "ConcordiaCourseId": "000783"
+    },
+    {
+      "Id": "4e40a916-e311-4af1-8954-9fb6ceffd67a",
+      "ConcordiaCourseId": "000784"
+    },
+    {
+      "Id": "71ac25db-0abb-4c72-b960-a912cec6aadf",
+      "ConcordiaCourseId": "000785"
+    },
+    {
+      "Id": "9b6a05ab-0ece-45ec-a503-f093a9eb7b6b",
+      "ConcordiaCourseId": "000786"
+    },
+    {
+      "Id": "429b0a89-0da9-4253-87dc-54b7bab982af",
+      "ConcordiaCourseId": "000787"
+    },
+    {
+      "Id": "260268de-54dc-4546-9e19-8468777f051b",
+      "ConcordiaCourseId": "000788"
+    },
+    {
+      "Id": "cd11a279-7bcc-4ed9-99db-bb7cdea7d47b",
+      "ConcordiaCourseId": "000789"
+    },
+    {
+      "Id": "9cb8ac49-f4d9-4c6d-8e6d-8987dd80deb7",
+      "ConcordiaCourseId": "000790"
+    },
+    {
+      "Id": "b86e9285-cb36-4226-bc35-488f3dd9d782",
+      "ConcordiaCourseId": "000791"
+    },
+    {
+      "Id": "89d556d0-7d7b-4a91-aed7-a316b885ec8a",
+      "ConcordiaCourseId": "000792"
+    },
+    {
+      "Id": "e52789a0-ad8e-4d16-8ed8-2c032db4e51e",
+      "ConcordiaCourseId": "000793"
+    },
+    {
+      "Id": "759514e2-a190-4dc2-9c63-a5b8a56f19af",
+      "ConcordiaCourseId": "000794"
+    },
+    {
+      "Id": "70767f50-e1d6-48ee-83f1-b77291d27a16",
+      "ConcordiaCourseId": "000796"
+    },
+    {
+      "Id": "3c9ccfd6-4d44-4063-8913-bc25ee049dc3",
+      "ConcordiaCourseId": "000797"
+    },
+    {
+      "Id": "ec0f6db9-55ac-47a8-bb7e-3ea0538bacd5",
+      "ConcordiaCourseId": "000798"
+    },
+    {
+      "Id": "279769b4-7026-4a74-8085-52b6f8208361",
+      "ConcordiaCourseId": "000799"
+    },
+    {
+      "Id": "935d1725-85da-4829-a132-7c1f38a2f01f",
+      "ConcordiaCourseId": "000800"
+    },
+    {
+      "Id": "ee3a66f3-a7b6-4613-904e-590ea4dfc74c",
+      "ConcordiaCourseId": "000801"
+    },
+    {
+      "Id": "edec9ccf-bbaa-47ee-8a7b-b2337d8f1b6b",
+      "ConcordiaCourseId": "000802"
+    },
+    {
+      "Id": "4758a457-bfff-48ee-90d2-742c6451b7e9",
+      "ConcordiaCourseId": "000804"
+    },
+    {
+      "Id": "730c076d-14cb-4e0b-8069-84a0eae6508e",
+      "ConcordiaCourseId": "000805"
+    },
+    {
+      "Id": "ea1bc753-298b-4b6d-9c15-628240789b9f",
+      "ConcordiaCourseId": "000818"
+    },
+    {
+      "Id": "27a1270b-3e0b-4554-95a7-f024c9a3f539",
+      "ConcordiaCourseId": "000819"
+    },
+    {
+      "Id": "96a12a82-2fac-4fdb-bd2e-3db8caa6ff12",
+      "ConcordiaCourseId": "000820"
+    },
+    {
+      "Id": "d9b24f8c-b5f2-46d3-a7be-9c939d3f711f",
+      "ConcordiaCourseId": "000821"
+    },
+    {
+      "Id": "b3a5a5c8-27c6-4d14-917a-cc152c1308ed",
+      "ConcordiaCourseId": "000822"
+    },
+    {
+      "Id": "56fb6ede-508a-426b-96d4-9f625b496d96",
+      "ConcordiaCourseId": "000823"
+    },
+    {
+      "Id": "d2d11bd0-3300-42d5-b489-1dc534bd75b4",
+      "ConcordiaCourseId": "000824"
+    },
+    {
+      "Id": "93caff00-0a7b-4aad-850d-50445d345fcb",
+      "ConcordiaCourseId": "000825"
+    },
+    {
+      "Id": "d9b70335-abf2-45dd-af13-9d37b503a6ff",
+      "ConcordiaCourseId": "000827"
+    },
+    {
+      "Id": "cee4d91d-3dc1-4fe4-a3c9-908f86973135",
+      "ConcordiaCourseId": "000828"
+    },
+    {
+      "Id": "dd1668a8-2b23-4cda-a401-184df0a3212b",
+      "ConcordiaCourseId": "000829"
+    },
+    {
+      "Id": "ba4d79e2-9e3b-4ea8-83a3-980078629174",
+      "ConcordiaCourseId": "000830"
+    },
+    {
+      "Id": "685b1248-9e55-407c-a57e-8745c805d701",
+      "ConcordiaCourseId": "000831"
+    },
+    {
+      "Id": "c2d27067-3b68-4d16-9e8e-5b3b7b838da3",
+      "ConcordiaCourseId": "000832"
+    },
+    {
+      "Id": "fbe1cf52-5017-4a87-9cf5-4e82c8cd3c02",
+      "ConcordiaCourseId": "000833"
+    },
+    {
+      "Id": "5e863f0a-75be-45b5-aa60-8a410915ff50",
+      "ConcordiaCourseId": "000840"
+    },
+    {
+      "Id": "074bb7b8-4e84-4ed9-8fe5-e0e8e85889c7",
+      "ConcordiaCourseId": "000845"
+    },
+    {
+      "Id": "c5d3202a-9653-4182-9487-93210981d4ba",
+      "ConcordiaCourseId": "040043"
+    },
+    {
+      "Id": "90016fba-0510-4c3d-9409-f9c2a975806c",
+      "ConcordiaCourseId": "040044"
+    },
+    {
+      "Id": "c0167868-450d-478e-bf66-6d60bab5f21f",
+      "ConcordiaCourseId": "040045"
+    },
+    {
+      "Id": "c56254f8-a9cb-4ae3-93c2-6e7465708fcc",
+      "ConcordiaCourseId": "040046"
+    },
+    {
+      "Id": "7b91ed62-0c98-4655-a95f-40c969595898",
+      "ConcordiaCourseId": "040047"
+    },
+    {
+      "Id": "064d97b8-1547-47c2-9ed4-5b794c9715a5",
+      "ConcordiaCourseId": "046458"
+    },
+    {
+      "Id": "18e5676c-9ae3-4124-b196-a9c5d72f5910",
+      "ConcordiaCourseId": "046459"
+    },
+    {
+      "Id": "f03772b9-2f3f-405b-93f4-91f2549ea3de",
+      "ConcordiaCourseId": "046460"
+    },
+    {
+      "Id": "11cc6f5f-03dd-4eea-9bc6-20803ed094ad",
+      "ConcordiaCourseId": "046461"
+    },
+    {
+      "Id": "fa20faa1-158d-4df1-896e-7c74c61d78a2",
+      "ConcordiaCourseId": "046462"
+    },
+    {
+      "Id": "e1dc4f11-3c91-4e3b-b4d0-b75ef4d0094e",
+      "ConcordiaCourseId": "046463"
+    },
+    {
+      "Id": "9c8a43fb-f37e-4e79-a656-e794e5a8ec4c",
+      "ConcordiaCourseId": "047272"
+    },
+    {
+      "Id": "d97f5d97-162c-4988-8679-2dc7147c1df5",
+      "ConcordiaCourseId": "047273"
+    },
+    {
+      "Id": "7964de84-cd11-4d44-8b43-3819ddd3d3f0",
+      "ConcordiaCourseId": "047274"
+    },
+    {
+      "Id": "e408fde5-5b21-419b-81ce-03420c957008",
+      "ConcordiaCourseId": "047275"
+    },
+    {
+      "Id": "a0d15c75-529f-405d-ba47-7de9bd7d8dcd",
+      "ConcordiaCourseId": "047815"
+    },
+    {
+      "Id": "a11c2693-177d-4d25-914b-8f5cf59cd8a0",
+      "ConcordiaCourseId": "047816"
+    },
+    {
+      "Id": "3341720a-64e8-4483-9973-01ccf88b5fa1",
+      "ConcordiaCourseId": "048157"
+    },
+    {
+      "Id": "51558dc9-6ac5-460f-b6fe-b4894cbc92b5",
+      "ConcordiaCourseId": "048158"
+    },
+    {
+      "Id": "2c975b96-9bbe-49e3-a8cd-adae3ffa8174",
+      "ConcordiaCourseId": "048159"
+    },
+    {
+      "Id": "b24319c8-d3f2-42dc-9b34-e21068477294",
+      "ConcordiaCourseId": "048160"
+    },
+    {
+      "Id": "cbe02e3e-980d-4aa4-8e6e-4b6344eee98e",
+      "ConcordiaCourseId": "048162"
+    },
+    {
+      "Id": "f1654ed9-610a-4b84-b2e2-681ff5f75f92",
+      "ConcordiaCourseId": "048163"
+    },
+    {
+      "Id": "a5c18a51-1529-4abb-9ea5-37feb088e335",
+      "ConcordiaCourseId": "048164"
+    },
+    {
+      "Id": "f943cd01-288c-45a5-b060-f194697b2815",
+      "ConcordiaCourseId": "048368"
+    },
+    {
+      "Id": "32109841-fdf3-43a2-97c8-46ef21c02398",
+      "ConcordiaCourseId": "048369"
+    },
+    {
+      "Id": "fb0291c8-8640-4a4b-bd9b-f2e7b3418684",
+      "ConcordiaCourseId": "048408"
+    },
+    {
+      "Id": "5d8123d9-9ece-4d66-887f-d8e7b4a71333",
+      "ConcordiaCourseId": "048743"
+    },
+    {
+      "Id": "527dbbb0-b1be-4fb5-8b60-468e6a9a3589",
+      "ConcordiaCourseId": "048744"
+    },
+    {
+      "Id": "2bf94d25-de13-43c2-b0b8-84b917990d5b",
+      "ConcordiaCourseId": "048745"
+    },
+    {
+      "Id": "e6f9ca7f-8d5d-46fa-9801-0262c768cbbf",
+      "ConcordiaCourseId": "048746"
+    },
+    {
+      "Id": "d2bf9401-c70d-495d-a2a6-f71deaba4fe2",
+      "ConcordiaCourseId": "048747"
+    },
+    {
+      "Id": "774b8587-497e-495f-813b-444c341707d8",
+      "ConcordiaCourseId": "048748"
+    },
+    {
+      "Id": "4e8224e3-6e71-497d-b19e-f0e5e89fbc61",
+      "ConcordiaCourseId": "048819"
+    },
+    {
+      "Id": "5d368eef-8bc0-41aa-9dcb-82ba3da1584a",
+      "ConcordiaCourseId": "050438"
+    },
+    {
+      "Id": "efed7463-e082-432f-b2ac-0b03256ab9fb",
+      "ConcordiaCourseId": "050677"
+    },
+    {
+      "Id": "e47da8de-ac69-48d7-bfcd-8b78dba5a3dc",
+      "ConcordiaCourseId": "050678"
+    },
+    {
+      "Id": "ca7ede45-afed-46d1-84d6-b34f048a8cca",
+      "ConcordiaCourseId": "050679"
+    },
+    {
+      "Id": "a5213b5d-c947-4091-acb7-ef2111c8e64a",
+      "ConcordiaCourseId": "050680"
+    },
+    {
+      "Id": "4edc697f-a5e1-47a8-88ed-92616e2138de",
+      "ConcordiaCourseId": "050681"
+    },
+    {
+      "Id": "bc5da555-1ebb-4f1e-970a-c2d0f106f543",
+      "ConcordiaCourseId": "050682"
+    },
+    {
+      "Id": "440afed1-3a68-4210-a5a3-a40575a54386",
+      "ConcordiaCourseId": "046464"
+    },
+    {
+      "Id": "8fe3b911-ad27-45a7-ad06-25c954ec39d6",
+      "ConcordiaCourseId": "000924"
+    },
+    {
+      "Id": "f6e5ed68-5e00-4090-8a1c-fca2ac44e159",
+      "ConcordiaCourseId": "046465"
+    },
+    {
+      "Id": "7dd46972-97f2-46bc-850a-677d287c4cf1",
+      "ConcordiaCourseId": "046466"
+    },
+    {
+      "Id": "328f7928-71c5-4540-87fa-bc496ce314be",
+      "ConcordiaCourseId": "046467"
+    },
+    {
+      "Id": "58ae8a5f-913d-4e75-be17-e7df61f66389",
+      "ConcordiaCourseId": "046468"
+    },
+    {
+      "Id": "2d4ac791-ded4-440f-9e71-10fdb0f1faa3",
+      "ConcordiaCourseId": "046469"
+    },
+    {
+      "Id": "9c0996bc-403a-40de-a85b-ffe258513fdb",
+      "ConcordiaCourseId": "000981"
+    },
+    {
+      "Id": "5e137d00-cf3f-4939-89b7-7781591d2d5f",
+      "ConcordiaCourseId": "000982"
+    },
+    {
+      "Id": "5d599742-8ff3-41a3-8069-7eb231a78c7b",
+      "ConcordiaCourseId": "000983"
+    },
+    {
+      "Id": "64f7a2f3-44c1-4550-bf45-747e8654c0e1",
+      "ConcordiaCourseId": "000985"
+    },
+    {
+      "Id": "4bd54bd7-675e-4fee-b302-3059d57d9f46",
+      "ConcordiaCourseId": "000986"
+    },
+    {
+      "Id": "525d7cc7-d6ff-4f34-938a-9ea08318de51",
+      "ConcordiaCourseId": "000987"
+    },
+    {
+      "Id": "753b4912-8882-4be3-9a8e-d4cd68f593ed",
+      "ConcordiaCourseId": "000988"
+    },
+    {
+      "Id": "5fe45a7e-0205-439e-ad1a-eb9b16c9ddf9",
+      "ConcordiaCourseId": "000989"
+    },
+    {
+      "Id": "c87524a4-4ecf-45a7-8017-de88c32a2097",
+      "ConcordiaCourseId": "000994"
+    },
+    {
+      "Id": "4c2773c4-4c92-4863-afc1-a475d9580671",
+      "ConcordiaCourseId": "000995"
+    },
+    {
+      "Id": "208be806-d2e7-4c86-8cb1-3a7dd3fe4c7e",
+      "ConcordiaCourseId": "000996"
+    },
+    {
+      "Id": "dd5dc36a-b0e6-4dd7-bf12-8e2b0a591a3c",
+      "ConcordiaCourseId": "001000"
+    },
+    {
+      "Id": "7ea5d3d6-0913-4b4e-a004-2ec0f88af0cd",
+      "ConcordiaCourseId": "001004"
+    },
+    {
+      "Id": "d99229e6-ba02-4266-9616-b49b936332f3",
+      "ConcordiaCourseId": "001005"
+    },
+    {
+      "Id": "eb76893a-c319-4f70-9506-eb8461889214",
+      "ConcordiaCourseId": "001006"
+    },
+    {
+      "Id": "0d894445-a3e7-41b3-a25f-b851646f99e4",
+      "ConcordiaCourseId": "001008"
+    },
+    {
+      "Id": "8db74f25-3cc0-483c-b82c-238bdcaf11fd",
+      "ConcordiaCourseId": "001010"
+    },
+    {
+      "Id": "67fb837b-1386-439c-82d7-e85565381607",
+      "ConcordiaCourseId": "001011"
+    },
+    {
+      "Id": "ece715fd-ccb4-47d5-a896-5f897b968a39",
+      "ConcordiaCourseId": "001012"
+    },
+    {
+      "Id": "76393d58-c9cf-4d77-83fd-63fddb827d37",
+      "ConcordiaCourseId": "001013"
+    },
+    {
+      "Id": "54cc26f4-ff58-4cd0-b83f-edb6acf9ab0d",
+      "ConcordiaCourseId": "001014"
+    },
+    {
+      "Id": "d123cf5e-b01c-46c3-8200-3567657d08c6",
+      "ConcordiaCourseId": "001016"
+    },
+    {
+      "Id": "249b331b-b498-4ddf-90dc-a722970eb44b",
+      "ConcordiaCourseId": "001017"
+    },
+    {
+      "Id": "dee29995-194e-4f43-b1b3-f6aacbd2d6c3",
+      "ConcordiaCourseId": "001023"
+    },
+    {
+      "Id": "d4a2f6ac-dccd-45c3-9856-8555b56633f4",
+      "ConcordiaCourseId": "001024"
+    },
+    {
+      "Id": "f87c970b-20c9-45a3-8917-e90eba7907de",
+      "ConcordiaCourseId": "001025"
+    },
+    {
+      "Id": "c777cb3e-2886-4386-a714-bc97ed90c684",
+      "ConcordiaCourseId": "001026"
+    },
+    {
+      "Id": "48186a86-5e17-4fad-a9d1-276a0be31ed6",
+      "ConcordiaCourseId": "001066"
+    },
+    {
+      "Id": "21a7a02f-5176-4f00-8198-a3c712f049b6",
+      "ConcordiaCourseId": "001067"
+    },
+    {
+      "Id": "378fdbec-f826-49db-8260-893b7bf1f9d4",
+      "ConcordiaCourseId": "001068"
+    },
+    {
+      "Id": "60718fb1-4cf8-485d-836b-8bd5ac8b486b",
+      "ConcordiaCourseId": "001070"
+    },
+    {
+      "Id": "d6aff354-a2b6-49c4-8b06-04b693b07475",
+      "ConcordiaCourseId": "001071"
+    },
+    {
+      "Id": "0ca6feed-fea0-45c7-bfef-851ab03857b1",
+      "ConcordiaCourseId": "001072"
+    },
+    {
+      "Id": "bd1cb15a-22a2-49c0-9ae2-76d65d681882",
+      "ConcordiaCourseId": "001073"
+    },
+    {
+      "Id": "83defa77-c950-4130-9c48-86f2bf647e80",
+      "ConcordiaCourseId": "001076"
+    },
+    {
+      "Id": "b34c8115-baf9-41fc-b483-0217beb06f72",
+      "ConcordiaCourseId": "001081"
+    },
+    {
+      "Id": "541adaae-7937-4c45-8b51-912333afa7d1",
+      "ConcordiaCourseId": "001082"
+    },
+    {
+      "Id": "3bfe8c8e-1c37-462b-9da1-2a3803c307a0",
+      "ConcordiaCourseId": "001084"
+    },
+    {
+      "Id": "793c114a-1594-43e0-b6c2-b645f70db74f",
+      "ConcordiaCourseId": "001085"
+    },
+    {
+      "Id": "2502e403-8390-4fb6-946f-de3f570eac0c",
+      "ConcordiaCourseId": "001086"
+    },
+    {
+      "Id": "5bb54c9d-5549-4adf-b2ab-a6f2c5fb0c34",
+      "ConcordiaCourseId": "001089"
+    },
+    {
+      "Id": "d39c6c6a-7afb-4e70-87f6-5e0e7aca59fa",
+      "ConcordiaCourseId": "001133"
+    },
+    {
+      "Id": "ea43cca3-b81a-466c-ac81-beeb35085a6c",
+      "ConcordiaCourseId": "001134"
+    },
+    {
+      "Id": "53719d72-8e55-4508-8f8d-0f072a5d186f",
+      "ConcordiaCourseId": "001135"
+    },
+    {
+      "Id": "7442671b-a164-408c-89dd-535ac527b42a",
+      "ConcordiaCourseId": "001136"
+    },
+    {
+      "Id": "b0fc8d77-13a2-4427-84ab-37f9bf305c2a",
+      "ConcordiaCourseId": "001138"
+    },
+    {
+      "Id": "bf0d8bc4-073c-4b68-9fde-7b73896451ff",
+      "ConcordiaCourseId": "001139"
+    },
+    {
+      "Id": "eda02a8b-4e3a-4b93-ab18-d437474990b0",
+      "ConcordiaCourseId": "001145"
+    },
+    {
+      "Id": "070a3ad2-12a3-4238-9f68-1dc9351f5fd9",
+      "ConcordiaCourseId": "001146"
+    },
+    {
+      "Id": "79c3e378-b5c9-41c9-907d-6292e7bebfbc",
+      "ConcordiaCourseId": "001147"
+    },
+    {
+      "Id": "70d80352-8a63-4b48-8897-820ad4c18743",
+      "ConcordiaCourseId": "001148"
+    },
+    {
+      "Id": "66c0cb71-a86f-4b8d-8366-3ce2182758c8",
+      "ConcordiaCourseId": "013985"
+    },
+    {
+      "Id": "64b1a3c3-abac-4a99-a8d0-b4142f78dd8c",
+      "ConcordiaCourseId": "031440"
+    },
+    {
+      "Id": "9c887679-dcdc-45e0-8c52-29df292f1765",
+      "ConcordiaCourseId": "031505"
+    },
+    {
+      "Id": "b22184ca-9d49-4bdd-bf59-8147610b3b6e",
+      "ConcordiaCourseId": "031510"
+    },
+    {
+      "Id": "a4ca9466-c529-4032-9865-68e58ee27ece",
+      "ConcordiaCourseId": "031512"
+    },
+    {
+      "Id": "ceedb1b5-0021-4e7c-b833-8dd3bb4a0a74",
+      "ConcordiaCourseId": "031523"
+    },
+    {
+      "Id": "7d0e4901-91b1-494e-825b-3ab8a9c79e3e",
+      "ConcordiaCourseId": "031525"
+    },
+    {
+      "Id": "3f055fd3-e476-45bc-a282-e5aadc6ce371",
+      "ConcordiaCourseId": "031607"
+    },
+    {
+      "Id": "5716cf83-128f-4ae9-9afc-3d11eb099e27",
+      "ConcordiaCourseId": "031615"
+    },
+    {
+      "Id": "5982b6c2-2504-4143-9141-f1e26444da30",
+      "ConcordiaCourseId": "031626"
+    },
+    {
+      "Id": "97afc244-51e6-43fb-97fd-6d2d91751b3c",
+      "ConcordiaCourseId": "031627"
+    },
+    {
+      "Id": "2108b767-e73b-4fcd-8d41-70961d8dbdb3",
+      "ConcordiaCourseId": "031760"
+    },
+    {
+      "Id": "681adab6-214b-4dd9-912b-c261af0dfada",
+      "ConcordiaCourseId": "040048"
+    },
+    {
+      "Id": "bd6c1675-bea1-4f6b-b57f-ffefae680e61",
+      "ConcordiaCourseId": "040059"
+    },
+    {
+      "Id": "767e1f11-0fef-4d77-8a11-1c5f2243d349",
+      "ConcordiaCourseId": "046470"
+    },
+    {
+      "Id": "c3a31845-663a-4600-b776-255e1eb656ce",
+      "ConcordiaCourseId": "046471"
+    },
+    {
+      "Id": "acccf0c3-2127-4a1b-bc5d-a93dc7a9d80d",
+      "ConcordiaCourseId": "046472"
+    },
+    {
+      "Id": "512e8c90-8c05-4863-aa77-ff60809674a4",
+      "ConcordiaCourseId": "046473"
+    },
+    {
+      "Id": "d59981ac-8ef0-4f35-9cd4-efb328b49484",
+      "ConcordiaCourseId": "046474"
+    },
+    {
+      "Id": "798abd69-6a54-4b1a-a85e-81ae9b13a376",
+      "ConcordiaCourseId": "046475"
+    },
+    {
+      "Id": "9956210b-1344-4cc6-8ca8-808a4f6f1c37",
+      "ConcordiaCourseId": "046476"
+    },
+    {
+      "Id": "bd19f6eb-f285-4325-9bd3-a1809354c804",
+      "ConcordiaCourseId": "046477"
+    },
+    {
+      "Id": "bda6c926-5623-420a-9bd6-51b1064e4c6b",
+      "ConcordiaCourseId": "046478"
+    },
+    {
+      "Id": "17649b8b-cccc-4b7c-8605-2bc6a074fc61",
+      "ConcordiaCourseId": "047227"
+    },
+    {
+      "Id": "96257d87-43f1-4ba0-a163-b2c195358225",
+      "ConcordiaCourseId": "047243"
+    },
+    {
+      "Id": "58a1251f-44ef-4a67-8194-7856173f54a9",
+      "ConcordiaCourseId": "047244"
+    },
+    {
+      "Id": "f214d049-fb59-4034-b336-55379799f5ce",
+      "ConcordiaCourseId": "047800"
+    },
+    {
+      "Id": "e7f0989d-5f58-48a2-8c1d-0792744282ab",
+      "ConcordiaCourseId": "048300"
+    },
+    {
+      "Id": "6c92e2b2-242a-49ea-8d12-76c7b7930848",
+      "ConcordiaCourseId": "048317"
+    },
+    {
+      "Id": "e707a566-3f54-4af0-bb07-bcf21922f18e",
+      "ConcordiaCourseId": "048333"
+    },
+    {
+      "Id": "13f927dc-d705-434e-8bdc-4b414c629dd6",
+      "ConcordiaCourseId": "048818"
+    },
+    {
+      "Id": "976ea22a-581d-4e77-8661-f6a51d845a89",
+      "ConcordiaCourseId": "049173"
+    },
+    {
+      "Id": "abfd8637-1927-4871-9348-fe4e3e3bded3",
+      "ConcordiaCourseId": "049174"
+    },
+    {
+      "Id": "ce00d82f-59f3-4b87-90a1-c6173a565d6a",
+      "ConcordiaCourseId": "049185"
+    },
+    {
+      "Id": "ddaa3af8-76a4-46a4-acb1-a286c3798352",
+      "ConcordiaCourseId": "049187"
+    },
+    {
+      "Id": "df362425-c373-44df-a2c3-41131730154d",
+      "ConcordiaCourseId": "049506"
+    },
+    {
+      "Id": "de9c44e1-10eb-437b-b7cd-4b5ace151dce",
+      "ConcordiaCourseId": "049577"
+    },
+    {
+      "Id": "c74f6c6b-f773-4165-a86d-1c13c875a877",
+      "ConcordiaCourseId": "049628"
+    },
+    {
+      "Id": "e1aad955-74de-463d-89a5-0f7edebe3714",
+      "ConcordiaCourseId": "050014"
+    },
+    {
+      "Id": "379399ed-60a5-4269-989e-d673d3ae8ee2",
+      "ConcordiaCourseId": "050302"
+    },
+    {
+      "Id": "a438e35d-d3a6-46bd-8c34-dcb5698615a8",
+      "ConcordiaCourseId": "050629"
+    },
+    {
+      "Id": "1b477223-940c-4b21-a5c9-954d1d69b051",
+      "ConcordiaCourseId": "050630"
+    },
+    {
+      "Id": "a513dfc1-9539-434f-8806-edd49c16942b",
+      "ConcordiaCourseId": "050665"
+    },
+    {
+      "Id": "54674ede-5256-4cd5-98b1-71721fd63d42",
+      "ConcordiaCourseId": "050666"
+    },
+    {
+      "Id": "e299c269-d64c-41e0-94c5-5fc1357dbf47",
+      "ConcordiaCourseId": "050667"
+    },
+    {
+      "Id": "fe11da2c-3073-46d2-9d8e-38924a50a9b4",
+      "ConcordiaCourseId": "050668"
+    },
+    {
+      "Id": "8f68aca3-eda8-4a7d-8964-be66b7d477eb",
+      "ConcordiaCourseId": "001217"
+    },
+    {
+      "Id": "12413422-8784-47ca-b10f-b6c5ede08539",
+      "ConcordiaCourseId": "001219"
+    },
+    {
+      "Id": "65bde63b-7d44-4551-b6ae-12c3bb638566",
+      "ConcordiaCourseId": "001221"
+    },
+    {
+      "Id": "4decf216-6d6b-4344-89e3-406180a56296",
+      "ConcordiaCourseId": "001224"
+    },
+    {
+      "Id": "32c91844-b187-4bbd-91f2-e5250066c9c3",
+      "ConcordiaCourseId": "001226"
+    },
+    {
+      "Id": "6bb5bfd5-3abd-4d9d-9023-88a288e3f702",
+      "ConcordiaCourseId": "001227"
+    },
+    {
+      "Id": "65d43c9c-0663-4124-a6f2-7e76316e15a9",
+      "ConcordiaCourseId": "001228"
+    },
+    {
+      "Id": "944e7621-ac9a-43ec-b946-c7827d54e0d2",
+      "ConcordiaCourseId": "001229"
+    },
+    {
+      "Id": "566099c0-0353-49d5-9ddd-331fdd3dc38a",
+      "ConcordiaCourseId": "001230"
+    },
+    {
+      "Id": "d19da28e-c28e-46b7-bfc5-8d3c76a139d7",
+      "ConcordiaCourseId": "001233"
+    },
+    {
+      "Id": "6d367a36-65d3-42dd-97c2-2a34ae8ad68d",
+      "ConcordiaCourseId": "001234"
+    },
+    {
+      "Id": "6345fc0e-2ee1-4590-8cfb-b64284c5b284",
+      "ConcordiaCourseId": "001235"
+    },
+    {
+      "Id": "ee9ff622-46bd-4c72-8431-8a2ba6fca757",
+      "ConcordiaCourseId": "001236"
+    },
+    {
+      "Id": "3fe260f7-b37a-4160-a11e-9530688469c4",
+      "ConcordiaCourseId": "001238"
+    },
+    {
+      "Id": "1272f11b-c958-4e69-a522-d6198a0cbada",
+      "ConcordiaCourseId": "001239"
+    },
+    {
+      "Id": "4ee2612b-f9f9-41ac-af12-240e41941381",
+      "ConcordiaCourseId": "001240"
+    },
+    {
+      "Id": "3ac79359-9311-4c70-910a-8a22b028bedc",
+      "ConcordiaCourseId": "001241"
+    },
+    {
+      "Id": "830dd312-d272-430b-94f5-698c9b772fe9",
+      "ConcordiaCourseId": "001242"
+    },
+    {
+      "Id": "89420424-d287-4f1d-8907-35a6e5c166e6",
+      "ConcordiaCourseId": "001256"
+    },
+    {
+      "Id": "250a1877-e272-4a68-8e3f-4aca7b34f0e0",
+      "ConcordiaCourseId": "001259"
+    },
+    {
+      "Id": "79fad5d0-71a2-4e22-88a7-2d57d537e5c1",
+      "ConcordiaCourseId": "001260"
+    },
+    {
+      "Id": "71cdccce-3ab5-4df8-b881-696e413c6d5f",
+      "ConcordiaCourseId": "001263"
+    },
+    {
+      "Id": "9f6d05b5-96bb-4b68-ac00-e2de26cd43ba",
+      "ConcordiaCourseId": "001265"
+    },
+    {
+      "Id": "6c84409a-fb20-42a0-a1a2-2edc813364f3",
+      "ConcordiaCourseId": "001268"
+    },
+    {
+      "Id": "38e3da4e-dc33-49f0-90da-fc5d074d77e1",
+      "ConcordiaCourseId": "001269"
+    },
+    {
+      "Id": "04b03a32-d63d-40ad-ba90-953805185b4f",
+      "ConcordiaCourseId": "001290"
+    },
+    {
+      "Id": "239703e1-4ea3-4ba4-9cfa-168d9247d962",
+      "ConcordiaCourseId": "001303"
+    },
+    {
+      "Id": "06efa5ec-b9de-48ce-9f79-04878ce828fa",
+      "ConcordiaCourseId": "001308"
+    },
+    {
+      "Id": "48caeaf9-90da-4ec4-bd96-6fc3b0980f19",
+      "ConcordiaCourseId": "001313"
+    },
+    {
+      "Id": "63f9eb2c-95e6-42ad-9420-d40bedb6d30d",
+      "ConcordiaCourseId": "001317"
+    },
+    {
+      "Id": "03e974b1-80f2-461d-9e8b-8484983aa5ed",
+      "ConcordiaCourseId": "001320"
+    },
+    {
+      "Id": "6982559b-41ac-4432-a4df-bff10147c5be",
+      "ConcordiaCourseId": "001321"
+    },
+    {
+      "Id": "341aa1a1-7151-4330-907b-5c0cb255f463",
+      "ConcordiaCourseId": "040072"
+    },
+    {
+      "Id": "302202b7-72a7-4eb2-b238-24c002170d91",
+      "ConcordiaCourseId": "040073"
+    },
+    {
+      "Id": "57707e3a-bedd-4c46-b0d8-d18c07ff4dc0",
+      "ConcordiaCourseId": "040074"
+    },
+    {
+      "Id": "dc55b0c6-9c28-44b0-a78d-9a99ca7e7ef8",
+      "ConcordiaCourseId": "044005"
+    },
+    {
+      "Id": "232f983d-b710-468a-bcfc-c6e6a8e69be7",
+      "ConcordiaCourseId": "047423"
+    },
+    {
+      "Id": "9c2d47af-526a-415d-83bd-8852686714a5",
+      "ConcordiaCourseId": "047618"
+    },
+    {
+      "Id": "4c364265-756d-4d17-a5b0-10d3e174d75c",
+      "ConcordiaCourseId": "047978"
+    },
+    {
+      "Id": "ced6a14a-d84f-4258-9475-0a4b5acb00dd",
+      "ConcordiaCourseId": "001377"
+    },
+    {
+      "Id": "0743d062-313d-42eb-afe1-04364c69fa6f",
+      "ConcordiaCourseId": "001400"
+    },
+    {
+      "Id": "42ac1143-bfbf-4db2-bed0-d85fb82c884e",
+      "ConcordiaCourseId": "046479"
+    },
+    {
+      "Id": "c37b4e39-6ff0-405f-9955-85f37199dc1e",
+      "ConcordiaCourseId": "046480"
+    },
+    {
+      "Id": "83fa7267-4909-4b25-a8d9-7ba753af4c90",
+      "ConcordiaCourseId": "046481"
+    },
+    {
+      "Id": "32d37fe4-0dc1-4eba-aa15-847d64994692",
+      "ConcordiaCourseId": "046482"
+    },
+    {
+      "Id": "c114f9a7-0288-4a22-97aa-630a6cc44b80",
+      "ConcordiaCourseId": "046483"
+    },
+    {
+      "Id": "a12e010a-7bde-4b96-b3e4-972ec102e0ae",
+      "ConcordiaCourseId": "046484"
+    },
+    {
+      "Id": "9ea9c070-8ffa-4354-89b8-a246090a4d3b",
+      "ConcordiaCourseId": "046485"
+    },
+    {
+      "Id": "7ec183d6-677b-4e54-9d73-ab0972d74129",
+      "ConcordiaCourseId": "001566"
+    },
+    {
+      "Id": "99413c84-e2fc-41a7-9cd8-39065af76c79",
+      "ConcordiaCourseId": "040089"
+    },
+    {
+      "Id": "36da5b13-70af-4182-87f2-37e4629e6a8a",
+      "ConcordiaCourseId": "046486"
+    },
+    {
+      "Id": "67f62786-f016-4572-9836-b9c5ffa7b57a",
+      "ConcordiaCourseId": "046487"
+    },
+    {
+      "Id": "e4932e85-1cd5-4fe5-a9fd-64eabb556df1",
+      "ConcordiaCourseId": "046488"
+    },
+    {
+      "Id": "f1408856-b654-4dff-8264-db6827fcf10d",
+      "ConcordiaCourseId": "046489"
+    },
+    {
+      "Id": "d6e3f65b-a079-4886-acaa-a3820cccfcbc",
+      "ConcordiaCourseId": "001766"
+    },
+    {
+      "Id": "7c01b5d0-cd61-44e6-8759-f1c67bf7040e",
+      "ConcordiaCourseId": "001768"
+    },
+    {
+      "Id": "be0dd430-4db9-499a-97c9-f214881b39cd",
+      "ConcordiaCourseId": "001769"
+    },
+    {
+      "Id": "eb68a871-0165-4beb-96c1-7d3fce829bf8",
+      "ConcordiaCourseId": "001771"
+    },
+    {
+      "Id": "dbb17d44-de79-4ea6-88ff-83a58ab5033d",
+      "ConcordiaCourseId": "001772"
+    },
+    {
+      "Id": "3e3cd798-28e0-406a-8a7a-43d900f31b01",
+      "ConcordiaCourseId": "001773"
+    },
+    {
+      "Id": "95b164f9-a24a-4326-ac7a-63da60ba2b02",
+      "ConcordiaCourseId": "001774"
+    },
+    {
+      "Id": "d64c96d2-233a-4ecc-8836-a5b136c7bb94",
+      "ConcordiaCourseId": "001775"
+    },
+    {
+      "Id": "3a8e3791-4e7b-455e-a314-d94d00bf8523",
+      "ConcordiaCourseId": "001797"
+    },
+    {
+      "Id": "85647d37-c296-444d-8d61-aa104f01af4f",
+      "ConcordiaCourseId": "001798"
+    },
+    {
+      "Id": "478e06f3-504f-46dc-8e08-cd3bb859b7b7",
+      "ConcordiaCourseId": "001799"
+    },
+    {
+      "Id": "e62ff111-cecd-442c-86b0-f4cbcfb1e359",
+      "ConcordiaCourseId": "001800"
+    },
+    {
+      "Id": "1f976ed6-b162-4e62-938a-abfadd218c58",
+      "ConcordiaCourseId": "001801"
+    },
+    {
+      "Id": "68bfb982-36f1-435b-8aa1-dbcc641ad4d3",
+      "ConcordiaCourseId": "001802"
+    },
+    {
+      "Id": "f3f6ec8a-dd0f-4666-9726-2f43ad791a30",
+      "ConcordiaCourseId": "001804"
+    },
+    {
+      "Id": "f1afeb05-39e3-41a5-8fb4-fbc2eac3c141",
+      "ConcordiaCourseId": "001805"
+    },
+    {
+      "Id": "4987d6a2-c64e-4db9-a5dc-7537c0197442",
+      "ConcordiaCourseId": "001828"
+    },
+    {
+      "Id": "db63d32d-387f-4fdf-8aa1-e89f9a61e8a5",
+      "ConcordiaCourseId": "001829"
+    },
+    {
+      "Id": "c7ee41c0-5596-40b0-a655-652d5ca42c2b",
+      "ConcordiaCourseId": "001830"
+    },
+    {
+      "Id": "5cd478d3-ed41-4e3a-87e1-ec4a99449f17",
+      "ConcordiaCourseId": "001831"
+    },
+    {
+      "Id": "9ec7ca0f-e641-4421-b1ea-b105217ff184",
+      "ConcordiaCourseId": "001833"
+    },
+    {
+      "Id": "5df8d722-3778-49ef-a016-2fe06a7d4986",
+      "ConcordiaCourseId": "001834"
+    },
+    {
+      "Id": "748a07ae-9bb7-4a6b-a815-b6a0fb79ea57",
+      "ConcordiaCourseId": "001871"
+    },
+    {
+      "Id": "9d871668-88d5-4bc6-8810-33620439534f",
+      "ConcordiaCourseId": "001872"
+    },
+    {
+      "Id": "cf993051-49b3-46c1-8a18-0681d0ca2c5b",
+      "ConcordiaCourseId": "001874"
+    },
+    {
+      "Id": "6f940ff3-263a-49b7-a9c2-ea6570cc1698",
+      "ConcordiaCourseId": "001875"
+    },
+    {
+      "Id": "21614bab-9bea-4798-af6d-9725793aaba1",
+      "ConcordiaCourseId": "001876"
+    },
+    {
+      "Id": "906adf79-7f9b-4f6d-b0bd-a28dbbf93fb6",
+      "ConcordiaCourseId": "001878"
+    },
+    {
+      "Id": "cd027c02-a4dc-469a-918d-3c96d4d4da00",
+      "ConcordiaCourseId": "001885"
+    },
+    {
+      "Id": "e659bd55-1957-43df-8a6b-62dfd4e7278b",
+      "ConcordiaCourseId": "001887"
+    },
+    {
+      "Id": "03162241-74dc-4770-8720-58c833fad487",
+      "ConcordiaCourseId": "001896"
+    },
+    {
+      "Id": "57c42414-a792-4985-80cc-3fb1146a2f7c",
+      "ConcordiaCourseId": "001902"
+    },
+    {
+      "Id": "c4021682-c24c-4ce0-808f-fb51c65510d1",
+      "ConcordiaCourseId": "001903"
+    },
+    {
+      "Id": "de59e0ba-ee3c-4a17-b732-4d9da904d8fa",
+      "ConcordiaCourseId": "001905"
+    },
+    {
+      "Id": "ded07049-5fb1-4cb6-bda6-aab62e761a19",
+      "ConcordiaCourseId": "001906"
+    },
+    {
+      "Id": "f662f29e-e89a-4364-8c3d-fa94f7224196",
+      "ConcordiaCourseId": "001907"
+    },
+    {
+      "Id": "bd346a92-d9e8-4fa3-ac29-aca419cec7d1",
+      "ConcordiaCourseId": "040098"
+    },
+    {
+      "Id": "4532188a-c4c3-4f1b-9222-6acbca4703cf",
+      "ConcordiaCourseId": "040099"
+    },
+    {
+      "Id": "039cf837-3886-4592-a6ff-4988513f659d",
+      "ConcordiaCourseId": "040127"
+    },
+    {
+      "Id": "1e6d05a5-b50e-46a9-ba37-1c70abefdd2e",
+      "ConcordiaCourseId": "040128"
+    },
+    {
+      "Id": "9db1855f-0c50-4071-99de-5cd75b5b32cf",
+      "ConcordiaCourseId": "040129"
+    },
+    {
+      "Id": "f7956557-b38f-4815-ae29-60d20f7abc2e",
+      "ConcordiaCourseId": "046490"
+    },
+    {
+      "Id": "926912d9-5eac-4e96-b8f6-0b6db961b751",
+      "ConcordiaCourseId": "046491"
+    },
+    {
+      "Id": "de115ab5-5936-48ff-94be-48120ebf1b2a",
+      "ConcordiaCourseId": "046492"
+    },
+    {
+      "Id": "8c90a1d5-0c9d-4518-8831-2793d52c1bcd",
+      "ConcordiaCourseId": "046493"
+    },
+    {
+      "Id": "4c05bc19-57f2-4d5e-ba82-102eafe83ae5",
+      "ConcordiaCourseId": "046494"
+    },
+    {
+      "Id": "ced26a32-36cb-4168-816f-f65962053588",
+      "ConcordiaCourseId": "046495"
+    },
+    {
+      "Id": "e84e8e63-32c5-4aa6-ab59-9a368c41c4e3",
+      "ConcordiaCourseId": "046496"
+    },
+    {
+      "Id": "ddbc7f23-7a19-4a84-af4e-9004ae466e6d",
+      "ConcordiaCourseId": "049819"
+    },
+    {
+      "Id": "fc35420c-43db-4996-8d37-063e81b48989",
+      "ConcordiaCourseId": "001925"
+    },
+    {
+      "Id": "5842c7a2-2122-4f51-81bf-6446dadfe2c9",
+      "ConcordiaCourseId": "001937"
+    },
+    {
+      "Id": "331c0286-ede7-454f-bf58-89b23ee81bee",
+      "ConcordiaCourseId": "001938"
+    },
+    {
+      "Id": "0de78ace-fd4b-45f8-a9c8-861f742577bb",
+      "ConcordiaCourseId": "001939"
+    },
+    {
+      "Id": "dd9bf2a9-526e-44a8-82c5-e5bb8b20ab7f",
+      "ConcordiaCourseId": "001941"
+    },
+    {
+      "Id": "006677af-792f-40c6-8edd-1dd52df86b9f",
+      "ConcordiaCourseId": "001942"
+    },
+    {
+      "Id": "22934054-1f9e-44cb-899e-b66a0d06d67b",
+      "ConcordiaCourseId": "001944"
+    },
+    {
+      "Id": "298371f1-72b2-475a-9999-43b9e2b43ba4",
+      "ConcordiaCourseId": "001945"
+    },
+    {
+      "Id": "5565069a-e689-4841-9c46-f484283ff88d",
+      "ConcordiaCourseId": "001946"
+    },
+    {
+      "Id": "b7e5e0a5-4649-43fc-a6b3-ed5f8c32bd65",
+      "ConcordiaCourseId": "001950"
+    },
+    {
+      "Id": "afba0873-7d3a-4fbf-a5e6-67ac89e94983",
+      "ConcordiaCourseId": "001972"
+    },
+    {
+      "Id": "737ea5ab-4d96-4651-91da-b677de752ab7",
+      "ConcordiaCourseId": "001993"
+    },
+    {
+      "Id": "28a083f3-5cac-40dd-85d8-b2dc9436c77b",
+      "ConcordiaCourseId": "002006"
+    },
+    {
+      "Id": "2936ed5b-4423-44ad-8670-d32843ae58af",
+      "ConcordiaCourseId": "002013"
+    },
+    {
+      "Id": "1fc354b9-7106-4d9c-9907-f8730a7dfbe0",
+      "ConcordiaCourseId": "002015"
+    },
+    {
+      "Id": "528108b0-6790-4832-b250-c5d39049df2c",
+      "ConcordiaCourseId": "002016"
+    },
+    {
+      "Id": "1ed2a304-f1d1-492e-9876-19bf6c1cbdf0",
+      "ConcordiaCourseId": "002017"
+    },
+    {
+      "Id": "25baf426-5d4d-4e81-b0c8-71bdc6b35c20",
+      "ConcordiaCourseId": "002018"
+    },
+    {
+      "Id": "8b640af1-69e0-4651-8022-41aad63a9328",
+      "ConcordiaCourseId": "002019"
+    },
+    {
+      "Id": "6626a5b7-b61e-4b77-8039-2aa13f10055b",
+      "ConcordiaCourseId": "002020"
+    },
+    {
+      "Id": "294e25e2-4f32-4247-982f-324c643f5973",
+      "ConcordiaCourseId": "002021"
+    },
+    {
+      "Id": "e5a8e2b3-afee-4797-9a08-fd09b94fea50",
+      "ConcordiaCourseId": "002022"
+    },
+    {
+      "Id": "2d289724-ded1-45fc-820a-0086260f6c6e",
+      "ConcordiaCourseId": "002023"
+    },
+    {
+      "Id": "f2532070-7a94-4716-bdcb-cd057ddc24e2",
+      "ConcordiaCourseId": "002024"
+    },
+    {
+      "Id": "2a2c7519-d72c-4fb6-b640-072bbe3043bb",
+      "ConcordiaCourseId": "002025"
+    },
+    {
+      "Id": "e90935a1-8c36-4684-81be-f2feced45a6e",
+      "ConcordiaCourseId": "002026"
+    },
+    {
+      "Id": "b8eea564-f8bb-4521-95d3-fdcd7b021851",
+      "ConcordiaCourseId": "002027"
+    },
+    {
+      "Id": "d61a2b85-98b7-4179-a038-c8ba9d889535",
+      "ConcordiaCourseId": "002028"
+    },
+    {
+      "Id": "0ca43637-81c6-4dd0-9bdb-6b4b710ec717",
+      "ConcordiaCourseId": "002029"
+    },
+    {
+      "Id": "024b2ab3-3df7-4361-9a45-f781cab597c0",
+      "ConcordiaCourseId": "002030"
+    },
+    {
+      "Id": "16da747a-3cdd-4283-8fa1-62d005ef98e6",
+      "ConcordiaCourseId": "002031"
+    },
+    {
+      "Id": "e993e998-3843-4f76-80b4-0cb3a23a760e",
+      "ConcordiaCourseId": "002032"
+    },
+    {
+      "Id": "28d13244-6939-4233-82c1-ad3355e0db02",
+      "ConcordiaCourseId": "002033"
+    },
+    {
+      "Id": "06c58f4e-9200-4d57-bae7-6c26916f0daf",
+      "ConcordiaCourseId": "002034"
+    },
+    {
+      "Id": "d775afaa-5859-4611-84b3-fdd8feee2f15",
+      "ConcordiaCourseId": "002035"
+    },
+    {
+      "Id": "efdf898d-fd18-4eaa-8afd-25cb3df25b44",
+      "ConcordiaCourseId": "002036"
+    },
+    {
+      "Id": "a73c6bca-557d-4fb6-b9e3-c38ad7115e4d",
+      "ConcordiaCourseId": "002038"
+    },
+    {
+      "Id": "d1c6605e-076f-4642-8688-71436b2ca67a",
+      "ConcordiaCourseId": "002039"
+    },
+    {
+      "Id": "52bac793-d692-44af-b4d1-90f04480fe91",
+      "ConcordiaCourseId": "002040"
+    },
+    {
+      "Id": "5b831404-4743-4d5b-b30d-c768155e8118",
+      "ConcordiaCourseId": "002041"
+    },
+    {
+      "Id": "0ff0effb-1469-4dda-9ea3-ee0055d3f84f",
+      "ConcordiaCourseId": "002042"
+    },
+    {
+      "Id": "18d50ee6-aa5a-41ae-9293-b6c2b40e6027",
+      "ConcordiaCourseId": "002043"
+    },
+    {
+      "Id": "2167a681-4740-4a0a-9295-dad0d168fd02",
+      "ConcordiaCourseId": "002044"
+    },
+    {
+      "Id": "cce739e7-9f33-4aed-b5d5-0ddef60a91fd",
+      "ConcordiaCourseId": "002046"
+    },
+    {
+      "Id": "215dc75d-cdf0-4d56-9613-5375d821d7de",
+      "ConcordiaCourseId": "002047"
+    },
+    {
+      "Id": "5ba4b708-0a12-4b01-b68a-df3dcb0ca026",
+      "ConcordiaCourseId": "002050"
+    },
+    {
+      "Id": "1fdf02ac-7003-4149-8143-dcea39d7045a",
+      "ConcordiaCourseId": "002051"
+    },
+    {
+      "Id": "d6f77625-46e7-4ff7-b2f6-98ca440c9e3f",
+      "ConcordiaCourseId": "002052"
+    },
+    {
+      "Id": "65107e71-38b1-4fe7-9869-04f6ba189058",
+      "ConcordiaCourseId": "002056"
+    },
+    {
+      "Id": "77a8b051-a694-4a10-865a-9dcc4eaea44a",
+      "ConcordiaCourseId": "002057"
+    },
+    {
+      "Id": "76a2c76b-7cab-4817-a4bb-80582a6e5d30",
+      "ConcordiaCourseId": "002058"
+    },
+    {
+      "Id": "41ff92b7-a9c9-4d90-8ebb-4bbc677d25d5",
+      "ConcordiaCourseId": "002059"
+    },
+    {
+      "Id": "89694a9f-2909-4cbd-b299-34bb99e25a0a",
+      "ConcordiaCourseId": "002060"
+    },
+    {
+      "Id": "3968d653-f619-440a-bdc7-a3c31262b45b",
+      "ConcordiaCourseId": "002064"
+    },
+    {
+      "Id": "a33c4641-6b2a-4a49-876f-852ff94ba6d6",
+      "ConcordiaCourseId": "002066"
+    },
+    {
+      "Id": "ef35cb9c-e23a-4ae0-baea-ee90486aafe7",
+      "ConcordiaCourseId": "002068"
+    },
+    {
+      "Id": "64a57a04-6dd5-4bb8-bd89-f01e56638871",
+      "ConcordiaCourseId": "002096"
+    },
+    {
+      "Id": "8d66b9c0-fef5-4cca-ab0b-fc0fbc067f04",
+      "ConcordiaCourseId": "002097"
+    },
+    {
+      "Id": "af297f85-cae2-4d8e-9b49-273396044e95",
+      "ConcordiaCourseId": "002100"
+    },
+    {
+      "Id": "727404d8-2cbd-45bc-9ab5-f1e122df4b73",
+      "ConcordiaCourseId": "002102"
+    },
+    {
+      "Id": "05d55dcd-83a1-4300-99fd-8c5f80278052",
+      "ConcordiaCourseId": "002116"
+    },
+    {
+      "Id": "eb66d7e0-db2e-4c0c-b309-60305b8ea434",
+      "ConcordiaCourseId": "002176"
+    },
+    {
+      "Id": "eeb1f33e-91b6-4ed4-adab-2b542bfcad9b",
+      "ConcordiaCourseId": "002177"
+    },
+    {
+      "Id": "7a46708c-639c-4b4f-b458-53e252e398c4",
+      "ConcordiaCourseId": "002187"
+    },
+    {
+      "Id": "6c38865d-7401-42ef-8553-4e3001135987",
+      "ConcordiaCourseId": "002195"
+    },
+    {
+      "Id": "62271d5f-636e-48dd-a167-65d4593cc70d",
+      "ConcordiaCourseId": "002201"
+    },
+    {
+      "Id": "524b8046-5a7b-4402-9dd2-c3c0c23d97a4",
+      "ConcordiaCourseId": "002203"
+    },
+    {
+      "Id": "49bd3b90-cdd0-4587-ad23-c5df00b8c371",
+      "ConcordiaCourseId": "002219"
+    },
+    {
+      "Id": "3dec7f43-76ad-4e06-8024-b88e7eb59ec7",
+      "ConcordiaCourseId": "002222"
+    },
+    {
+      "Id": "7b91f02e-23be-4c35-8c64-4cae821c3e66",
+      "ConcordiaCourseId": "002241"
+    },
+    {
+      "Id": "2eee61ce-ba78-4079-b052-456bf5a206c4",
+      "ConcordiaCourseId": "002266"
+    },
+    {
+      "Id": "e1cde36b-c1cb-43e0-851f-8b5abff2654a",
+      "ConcordiaCourseId": "002269"
+    },
+    {
+      "Id": "d36f1877-0ca1-44ac-8c9e-d5fc04d09b9c",
+      "ConcordiaCourseId": "002273"
+    },
+    {
+      "Id": "16b44fcb-a247-44ce-a282-5e7781cc513d",
+      "ConcordiaCourseId": "002278"
+    },
+    {
+      "Id": "b2cb1aed-865f-4883-932d-a3d5b54a272c",
+      "ConcordiaCourseId": "002279"
+    },
+    {
+      "Id": "870ca887-30af-4a04-8091-6a289dbfdd73",
+      "ConcordiaCourseId": "002281"
+    },
+    {
+      "Id": "bd035a31-68f2-4753-b162-31a5a1e4c77b",
+      "ConcordiaCourseId": "002285"
+    },
+    {
+      "Id": "825dbfc2-6e30-4ba4-85d2-78d4eea8036f",
+      "ConcordiaCourseId": "002286"
+    },
+    {
+      "Id": "51f08853-197a-4e47-a845-aed30bedb8be",
+      "ConcordiaCourseId": "002287"
+    },
+    {
+      "Id": "1788fc10-4c4a-4252-aeab-dd623c5c4f93",
+      "ConcordiaCourseId": "002288"
+    },
+    {
+      "Id": "ac43c6f5-9686-46ef-8f26-511b8773851d",
+      "ConcordiaCourseId": "002290"
+    },
+    {
+      "Id": "04f051c0-c69e-4f46-8a3e-7559cf15c31d",
+      "ConcordiaCourseId": "002291"
+    },
+    {
+      "Id": "1fd94aab-bab9-4de6-8485-98eafdd5370b",
+      "ConcordiaCourseId": "002298"
+    },
+    {
+      "Id": "f6fccf65-4b44-47a6-b114-6ad82ab3e53b",
+      "ConcordiaCourseId": "002357"
+    },
+    {
+      "Id": "b84fdc63-7ece-4514-b4a3-fea6f66300ec",
+      "ConcordiaCourseId": "002359"
+    },
+    {
+      "Id": "8b0344a9-2e65-4634-a975-e80503b088a3",
+      "ConcordiaCourseId": "040143"
+    },
+    {
+      "Id": "91934078-088f-48d6-acd3-673253521d88",
+      "ConcordiaCourseId": "040144"
+    },
+    {
+      "Id": "90ff3e39-9535-4260-912d-ca2b9cc69300",
+      "ConcordiaCourseId": "040145"
+    },
+    {
+      "Id": "89840970-8495-47a0-8ec3-3225476ccd93",
+      "ConcordiaCourseId": "045179"
+    },
+    {
+      "Id": "a2e51fa9-e7d2-46a9-9b64-27b1aa1acf60",
+      "ConcordiaCourseId": "046497"
+    },
+    {
+      "Id": "77a7a35b-ecbf-489c-89fb-583e14f7d556",
+      "ConcordiaCourseId": "046498"
+    },
+    {
+      "Id": "c901d3a4-a54b-4fbe-b1f7-ed66ae6cb52c",
+      "ConcordiaCourseId": "046499"
+    },
+    {
+      "Id": "caaeb20c-4af9-46c8-bb9e-137ca13e38cc",
+      "ConcordiaCourseId": "046500"
+    },
+    {
+      "Id": "1e51e044-3fb3-4341-ad70-f7dc5e18d8bb",
+      "ConcordiaCourseId": "046501"
+    },
+    {
+      "Id": "dbf57bfd-e378-4da5-9acb-45a20ce401a8",
+      "ConcordiaCourseId": "046502"
+    },
+    {
+      "Id": "148eb848-5b91-4094-9dd9-94b3061a41c0",
+      "ConcordiaCourseId": "046503"
+    },
+    {
+      "Id": "dc2380a4-5870-4f70-9c47-ea8de9784c44",
+      "ConcordiaCourseId": "046505"
+    },
+    {
+      "Id": "b097fce1-9bd6-49e2-9c22-ea00f634b925",
+      "ConcordiaCourseId": "046506"
+    },
+    {
+      "Id": "943ff2de-7500-42b9-8cbe-92431b73cc3f",
+      "ConcordiaCourseId": "046507"
+    },
+    {
+      "Id": "4c875019-5b44-4a47-8cca-00a6bcef09cf",
+      "ConcordiaCourseId": "046508"
+    },
+    {
+      "Id": "b4af2044-3aeb-4278-b7db-ac64ab455bdc",
+      "ConcordiaCourseId": "046509"
+    },
+    {
+      "Id": "40a44534-01de-44f1-b659-5f7b87b568d1",
+      "ConcordiaCourseId": "046510"
+    },
+    {
+      "Id": "3a60d31f-190f-4fdd-866e-923570faf131",
+      "ConcordiaCourseId": "046511"
+    },
+    {
+      "Id": "1ea5db3a-4179-4125-a64a-816077bfe904",
+      "ConcordiaCourseId": "046512"
+    },
+    {
+      "Id": "e4e50793-2012-43ae-8035-3f0a313aee22",
+      "ConcordiaCourseId": "046513"
+    },
+    {
+      "Id": "ee9e401a-d9c6-4ffa-b3ca-8ac4d111a963",
+      "ConcordiaCourseId": "046514"
+    },
+    {
+      "Id": "ab5cb867-9764-45e9-bd80-af4363fcfc83",
+      "ConcordiaCourseId": "047490"
+    },
+    {
+      "Id": "05cbf734-cf5f-40ea-bd64-ab919baabe66",
+      "ConcordiaCourseId": "047491"
+    },
+    {
+      "Id": "a4373b2e-05df-430d-9fc2-d9d1f13522a3",
+      "ConcordiaCourseId": "048308"
+    },
+    {
+      "Id": "c7367e8c-42db-4196-8b85-44b5086f9dfd",
+      "ConcordiaCourseId": "049114"
+    },
+    {
+      "Id": "bf4bbe72-cbb0-4920-995e-90948581c5b3",
+      "ConcordiaCourseId": "050660"
+    },
+    {
+      "Id": "fffed62c-9f39-4ed5-a51c-9c3b66c8af5b",
+      "ConcordiaCourseId": "050661"
+    },
+    {
+      "Id": "e7d1c876-923e-475b-b5e7-fbda44e2dbdd",
+      "ConcordiaCourseId": "050662"
+    },
+    {
+      "Id": "ab6bc358-e16a-4fce-b331-81c9c4d996dd",
+      "ConcordiaCourseId": "002425"
+    },
+    {
+      "Id": "e97a15a6-8b77-4823-9669-6e4148e893d8",
+      "ConcordiaCourseId": "002426"
+    },
+    {
+      "Id": "6bffbadd-1f46-4b0e-b106-d08cd2dcdc06",
+      "ConcordiaCourseId": "002427"
+    },
+    {
+      "Id": "0d3e8192-68d1-44f6-84bc-0891f5cde31d",
+      "ConcordiaCourseId": "046515"
+    },
+    {
+      "Id": "9a9121af-c8a2-42db-80bb-6af953800bab",
+      "ConcordiaCourseId": "046516"
+    },
+    {
+      "Id": "528de0a9-0bc0-4ecd-b738-2170cc003960",
+      "ConcordiaCourseId": "002431"
+    },
+    {
+      "Id": "0786bf64-b418-4df5-af8e-b4f9622b8c35",
+      "ConcordiaCourseId": "002432"
+    },
+    {
+      "Id": "e2e8f16e-7a32-4f43-aede-939dbc46ae95",
+      "ConcordiaCourseId": "002435"
+    },
+    {
+      "Id": "377e0ff9-022b-44be-bac7-72013f69a10c",
+      "ConcordiaCourseId": "002436"
+    },
+    {
+      "Id": "71ef949f-c610-4eea-b4ad-345debfc16aa",
+      "ConcordiaCourseId": "002437"
+    },
+    {
+      "Id": "58c6c45c-d95d-4202-9266-65f3fc5f0744",
+      "ConcordiaCourseId": "002438"
+    },
+    {
+      "Id": "2a1f3b76-414a-4cdf-ad30-8f0bc7e48fab",
+      "ConcordiaCourseId": "046517"
+    },
+    {
+      "Id": "7a80f5fd-715c-4da7-9b86-25a97477b3b1",
+      "ConcordiaCourseId": "048168"
+    },
+    {
+      "Id": "04f0af07-6719-4a9a-9522-2e7c8f3bc67c",
+      "ConcordiaCourseId": "002439"
+    },
+    {
+      "Id": "0630fc9e-26e0-4c80-b4a2-447f100d3d7a",
+      "ConcordiaCourseId": "045192"
+    },
+    {
+      "Id": "9f8315ba-ce79-43a6-98c0-bc5fea0e5d6b",
+      "ConcordiaCourseId": "045194"
+    },
+    {
+      "Id": "a3644626-cd4f-420c-97d7-3340111fc2a5",
+      "ConcordiaCourseId": "045195"
+    },
+    {
+      "Id": "71dec142-9e39-4821-bbcb-e2a7015602bd",
+      "ConcordiaCourseId": "045196"
+    },
+    {
+      "Id": "efb9136a-df3c-4761-92a5-58790f5ea4d1",
+      "ConcordiaCourseId": "046518"
+    },
+    {
+      "Id": "9b9ff2c9-4bc3-4d08-b373-7ea713968209",
+      "ConcordiaCourseId": "046519"
+    },
+    {
+      "Id": "768912b4-0207-45b8-a90e-2fad618b3a8f",
+      "ConcordiaCourseId": "002536"
+    },
+    {
+      "Id": "17f8378b-b565-4f6d-8cd7-4b4e2dd4cfe6",
+      "ConcordiaCourseId": "002543"
+    },
+    {
+      "Id": "0326ac9a-0658-445d-ae33-a5fa86d82b35",
+      "ConcordiaCourseId": "002545"
+    },
+    {
+      "Id": "57b7b22e-63f0-4acc-8976-e8e4f461f66c",
+      "ConcordiaCourseId": "002546"
+    },
+    {
+      "Id": "c84b36fa-2b59-49d6-a925-e3290843a92e",
+      "ConcordiaCourseId": "002547"
+    },
+    {
+      "Id": "59d28bb6-2b9d-461a-b697-fa86c8f428f1",
+      "ConcordiaCourseId": "002553"
+    },
+    {
+      "Id": "ca9f5753-f126-46a1-99f0-2ce75a8058bf",
+      "ConcordiaCourseId": "002554"
+    },
+    {
+      "Id": "ff0df453-3b7d-433d-8e6f-c222481c6589",
+      "ConcordiaCourseId": "002555"
+    },
+    {
+      "Id": "18c18c9b-874d-42b7-bf75-c9e3ca04cb98",
+      "ConcordiaCourseId": "002557"
+    },
+    {
+      "Id": "3f93fef4-a733-4258-8f1f-91ef31837438",
+      "ConcordiaCourseId": "002559"
+    },
+    {
+      "Id": "8d131ec5-0e24-4452-a02d-eee812ca70cb",
+      "ConcordiaCourseId": "002560"
+    },
+    {
+      "Id": "1facc64a-09e3-4842-8f20-0b4bed7b3f31",
+      "ConcordiaCourseId": "002561"
+    },
+    {
+      "Id": "ef29dbaa-e8b3-4711-bc9e-aaa64b14abe5",
+      "ConcordiaCourseId": "002572"
+    },
+    {
+      "Id": "96128ec8-1509-474f-a462-f1db059384ff",
+      "ConcordiaCourseId": "002580"
+    },
+    {
+      "Id": "dea79a76-a23a-43a6-b6e3-930d9bfbb890",
+      "ConcordiaCourseId": "002583"
+    },
+    {
+      "Id": "e0e1f114-975d-447e-9f92-46eefaee74fa",
+      "ConcordiaCourseId": "002584"
+    },
+    {
+      "Id": "6f89eb19-46e2-4056-a142-b60562ea82eb",
+      "ConcordiaCourseId": "002585"
+    },
+    {
+      "Id": "6f1c2309-87cc-419e-af9c-e8758967a7eb",
+      "ConcordiaCourseId": "002586"
+    },
+    {
+      "Id": "c6588da4-891a-40a2-887e-388d48dd4447",
+      "ConcordiaCourseId": "002587"
+    },
+    {
+      "Id": "d2cc23d5-487b-4414-aa3c-5373aa7d7ed9",
+      "ConcordiaCourseId": "002588"
+    },
+    {
+      "Id": "4842702d-b3f2-4e4d-8896-2e17ade2d72c",
+      "ConcordiaCourseId": "002589"
+    },
+    {
+      "Id": "a47815c3-39cf-4c96-ae97-245d9a8ff24d",
+      "ConcordiaCourseId": "002590"
+    },
+    {
+      "Id": "c55a440d-49bd-475a-8331-02e693bc3b64",
+      "ConcordiaCourseId": "002591"
+    },
+    {
+      "Id": "e2f2a833-7a9b-4e34-a116-5b7cb3764eeb",
+      "ConcordiaCourseId": "002592"
+    },
+    {
+      "Id": "6d890d9b-865f-4abb-b251-0fa99c289565",
+      "ConcordiaCourseId": "002593"
+    },
+    {
+      "Id": "7c9cb968-137c-4046-83ff-eba1532fbda9",
+      "ConcordiaCourseId": "002594"
+    },
+    {
+      "Id": "cd613cf9-47b0-47e8-88a0-329b460aa9b2",
+      "ConcordiaCourseId": "049869"
+    },
+    {
+      "Id": "90372997-fc75-4d0c-ac93-db6da3316e35",
+      "ConcordiaCourseId": "049870"
+    },
+    {
+      "Id": "34005a73-adc6-4d02-9fa7-6938f8ca2fa9",
+      "ConcordiaCourseId": "049872"
+    },
+    {
+      "Id": "aa82554f-6252-49c5-916b-28fc55d38b40",
+      "ConcordiaCourseId": "049873"
+    },
+    {
+      "Id": "25864ba4-3f8a-4bd5-8879-6bd90f648b25",
+      "ConcordiaCourseId": "050170"
+    },
+    {
+      "Id": "252b57ba-1b92-4e2e-b8da-fb9841c190e1",
+      "ConcordiaCourseId": "050451"
+    },
+    {
+      "Id": "a7122b51-da94-4217-a1ab-4c2f5da6367e",
+      "ConcordiaCourseId": "002624"
+    },
+    {
+      "Id": "977b9e76-9622-4874-8972-df2855a43386",
+      "ConcordiaCourseId": "002625"
+    },
+    {
+      "Id": "b29439c8-ca26-499a-a2d7-1846c9c4b652",
+      "ConcordiaCourseId": "002628"
+    },
+    {
+      "Id": "163d06b6-c97d-4d3f-a24c-2666d636198c",
+      "ConcordiaCourseId": "002630"
+    },
+    {
+      "Id": "56bcf5e8-1bcf-4089-b75a-4de7df4fcece",
+      "ConcordiaCourseId": "002631"
+    },
+    {
+      "Id": "6a6543e9-6d0a-4151-a099-70abba519ab1",
+      "ConcordiaCourseId": "002632"
+    },
+    {
+      "Id": "8b46b964-f137-457b-96b0-7eb4cb640d27",
+      "ConcordiaCourseId": "002641"
+    },
+    {
+      "Id": "2556f872-632a-4c84-b5d5-72e7a9b0190e",
+      "ConcordiaCourseId": "002642"
+    },
+    {
+      "Id": "4a2f4186-1a34-48cd-8986-5c441f6de1a7",
+      "ConcordiaCourseId": "002643"
+    },
+    {
+      "Id": "9856f29e-a93a-495d-8d5f-f3679ae1b8c6",
+      "ConcordiaCourseId": "002659"
+    },
+    {
+      "Id": "da9850b2-c82f-49e2-ac91-82a252da3784",
+      "ConcordiaCourseId": "002661"
+    },
+    {
+      "Id": "2cfbd2d2-8dca-402c-80c2-ed0208f01cfd",
+      "ConcordiaCourseId": "002683"
+    },
+    {
+      "Id": "c604fb5c-7b8b-493b-a281-107fe4814a02",
+      "ConcordiaCourseId": "002686"
+    },
+    {
+      "Id": "6ffddb0a-b50a-4e60-a6b5-2e93e966cfae",
+      "ConcordiaCourseId": "002690"
+    },
+    {
+      "Id": "3e39ff51-d2f2-45f2-b904-fe21bc65a5aa",
+      "ConcordiaCourseId": "002704"
+    },
+    {
+      "Id": "1a0d0a04-6691-4ffc-9c87-9cfcaf718191",
+      "ConcordiaCourseId": "002706"
+    },
+    {
+      "Id": "fab7f26c-1cf0-4cca-8445-cb88b8291c8a",
+      "ConcordiaCourseId": "002716"
+    },
+    {
+      "Id": "4d8c66fc-89aa-448a-8289-4e65d7af1dee",
+      "ConcordiaCourseId": "002717"
+    },
+    {
+      "Id": "7361033c-a1d8-4105-bc66-70bef3f84da1",
+      "ConcordiaCourseId": "002719"
+    },
+    {
+      "Id": "c933e566-6e26-41dc-8021-ac8f057211cc",
+      "ConcordiaCourseId": "002720"
+    },
+    {
+      "Id": "c3da1d14-33dd-4685-9579-248db0108b33",
+      "ConcordiaCourseId": "002726"
+    },
+    {
+      "Id": "68c97091-77c0-4ca3-93ad-716bfdec25d4",
+      "ConcordiaCourseId": "002728"
+    },
+    {
+      "Id": "b3ac6582-0309-4b27-8bc7-d5065d984e71",
+      "ConcordiaCourseId": "002729"
+    },
+    {
+      "Id": "35a4275e-5e5b-452c-8a93-fdc5850f3f96",
+      "ConcordiaCourseId": "002730"
+    },
+    {
+      "Id": "81d5d5c9-a6cd-4431-aa52-75580cdfe1e4",
+      "ConcordiaCourseId": "002732"
+    },
+    {
+      "Id": "751906de-629d-4d62-a996-19167b61cb4b",
+      "ConcordiaCourseId": "002733"
+    },
+    {
+      "Id": "90e3109d-c17e-4f97-b252-13c44ad92400",
+      "ConcordiaCourseId": "002735"
+    },
+    {
+      "Id": "741d5665-88e5-40c2-8ad4-d61067c0a238",
+      "ConcordiaCourseId": "002762"
+    },
+    {
+      "Id": "77e7fdfc-7c50-44da-b4fe-64740492a0d8",
+      "ConcordiaCourseId": "002763"
+    },
+    {
+      "Id": "98af3e3f-b73f-4adc-a3fa-e797fad117fa",
+      "ConcordiaCourseId": "002778"
+    },
+    {
+      "Id": "a269e34f-3469-47d6-ae2b-d4946d43882b",
+      "ConcordiaCourseId": "002785"
+    },
+    {
+      "Id": "6cfd611f-a781-4d82-8d54-2240a4311793",
+      "ConcordiaCourseId": "002788"
+    },
+    {
+      "Id": "2cee9764-ad54-4060-9624-16c62679ff09",
+      "ConcordiaCourseId": "002789"
+    },
+    {
+      "Id": "bff070d1-61cd-4084-9f42-e309eec73a23",
+      "ConcordiaCourseId": "002790"
+    },
+    {
+      "Id": "84794110-a0ba-4d8d-b000-b6141071aa2d",
+      "ConcordiaCourseId": "002794"
+    },
+    {
+      "Id": "a85eac4d-b086-4766-968c-eb727751d89b",
+      "ConcordiaCourseId": "002795"
+    },
+    {
+      "Id": "e0c80ea1-73a1-4fc7-8d88-fae48a260019",
+      "ConcordiaCourseId": "002796"
+    },
+    {
+      "Id": "f08a8de5-4f84-4b2b-bbe9-bd42e808d7c8",
+      "ConcordiaCourseId": "002798"
+    },
+    {
+      "Id": "5cac4acb-2833-474c-a4ce-ea6c522858c7",
+      "ConcordiaCourseId": "002800"
+    },
+    {
+      "Id": "d156bfd1-dfe0-4a89-8e46-3115f3d32444",
+      "ConcordiaCourseId": "002804"
+    },
+    {
+      "Id": "360f08d5-c532-457a-8448-d33696271f37",
+      "ConcordiaCourseId": "002805"
+    },
+    {
+      "Id": "a2291e5c-893a-40ed-9953-9254fbb97646",
+      "ConcordiaCourseId": "002806"
+    },
+    {
+      "Id": "246fce13-189f-418e-b600-7eabf46ee0ff",
+      "ConcordiaCourseId": "002807"
+    },
+    {
+      "Id": "4d645fc9-e588-49ac-9a8e-fbf2b02a89de",
+      "ConcordiaCourseId": "002810"
+    },
+    {
+      "Id": "c9d51aeb-adeb-475b-9d7a-4b81a6493b09",
+      "ConcordiaCourseId": "002811"
+    },
+    {
+      "Id": "86412fa8-cf43-4480-b989-0d95e38f72f7",
+      "ConcordiaCourseId": "002812"
+    },
+    {
+      "Id": "a1275923-23f5-4135-8fe5-f31551c3f5d0",
+      "ConcordiaCourseId": "002813"
+    },
+    {
+      "Id": "b47d854f-931a-4d4d-b899-1b665ae29a1b",
+      "ConcordiaCourseId": "002814"
+    },
+    {
+      "Id": "2883fd07-cfc6-44df-b09e-e7a8db17d708",
+      "ConcordiaCourseId": "002815"
+    },
+    {
+      "Id": "e92b246e-a73a-4231-bbd2-cf1d2a985a2c",
+      "ConcordiaCourseId": "002817"
+    },
+    {
+      "Id": "6ec74b8d-50f0-4d26-8824-475e54dea46c",
+      "ConcordiaCourseId": "002834"
+    },
+    {
+      "Id": "f3215d92-d3b5-48f1-992b-e135bc949d19",
+      "ConcordiaCourseId": "002844"
+    },
+    {
+      "Id": "551cb2d6-de2e-4390-b6b6-c189d6441525",
+      "ConcordiaCourseId": "002845"
+    },
+    {
+      "Id": "512fa0bd-4f9a-4f1b-98f0-ec937d178cdf",
+      "ConcordiaCourseId": "002847"
+    },
+    {
+      "Id": "0a20e31b-c30f-4eef-92d2-b355534b3fb4",
+      "ConcordiaCourseId": "002850"
+    },
+    {
+      "Id": "dd736433-b77d-4139-8e05-a02e5e108930",
+      "ConcordiaCourseId": "002852"
+    },
+    {
+      "Id": "76dc24e8-ffaf-407a-97d1-7f83118cdc5b",
+      "ConcordiaCourseId": "002856"
+    },
+    {
+      "Id": "573470e6-69f8-4c32-ba30-75bee35e668e",
+      "ConcordiaCourseId": "002858"
+    },
+    {
+      "Id": "ef7e17a4-e35d-4b7c-b297-af292bf360a6",
+      "ConcordiaCourseId": "002859"
+    },
+    {
+      "Id": "881206ab-5edd-4597-ad4a-b7ae387b8661",
+      "ConcordiaCourseId": "002873"
+    },
+    {
+      "Id": "0b55aa82-3e46-46b8-b9d2-5ac1e2450603",
+      "ConcordiaCourseId": "002879"
+    },
+    {
+      "Id": "12a1b2bc-2bcb-40a7-89e8-edcdd8d75d3b",
+      "ConcordiaCourseId": "002882"
+    },
+    {
+      "Id": "558a7757-4262-4111-b5e5-d36d046933b3",
+      "ConcordiaCourseId": "002887"
+    },
+    {
+      "Id": "d56a2691-c7c3-4c04-b99f-cb6e7bea0a8a",
+      "ConcordiaCourseId": "002902"
+    },
+    {
+      "Id": "027811f4-956f-4092-ac08-94315cc0e283",
+      "ConcordiaCourseId": "002924"
+    },
+    {
+      "Id": "d7fceb92-7ab2-4a71-a873-c4ca219419eb",
+      "ConcordiaCourseId": "002927"
+    },
+    {
+      "Id": "31b0f3ef-3f15-4163-bf2a-5bc4b75c90e2",
+      "ConcordiaCourseId": "002930"
+    },
+    {
+      "Id": "b5ec1f36-8715-461d-9925-00be0269b3e7",
+      "ConcordiaCourseId": "002933"
+    },
+    {
+      "Id": "dbc13851-1043-4d11-96d2-b79d62fb6bce",
+      "ConcordiaCourseId": "002936"
+    },
+    {
+      "Id": "b424c281-3fc3-4346-acdb-22b3bc08f5c9",
+      "ConcordiaCourseId": "002942"
+    },
+    {
+      "Id": "8ea59d46-85a1-40a2-b6d6-813648901410",
+      "ConcordiaCourseId": "002945"
+    },
+    {
+      "Id": "e25b8470-7a6c-4191-a3ad-b218a5275b0a",
+      "ConcordiaCourseId": "002947"
+    },
+    {
+      "Id": "b7e5b17f-f06c-4d09-a34b-aa4a72dab321",
+      "ConcordiaCourseId": "002951"
+    },
+    {
+      "Id": "72777aed-4080-46ea-b268-ac59cac46766",
+      "ConcordiaCourseId": "002953"
+    },
+    {
+      "Id": "abd33b18-eb4d-4830-ba5a-f75c090ec7c8",
+      "ConcordiaCourseId": "002958"
+    },
+    {
+      "Id": "7b4732d4-a2a2-4f4d-abda-25b197a5bfe8",
+      "ConcordiaCourseId": "002959"
+    },
+    {
+      "Id": "98938c23-cb6a-4926-ad5f-885f6de80bea",
+      "ConcordiaCourseId": "002981"
+    },
+    {
+      "Id": "3c805c19-59eb-4937-a21a-9c00d26b810c",
+      "ConcordiaCourseId": "002989"
+    },
+    {
+      "Id": "3f288be3-8d36-4763-8f49-2a4abfba6e58",
+      "ConcordiaCourseId": "002992"
+    },
+    {
+      "Id": "5ff3960c-e71e-4a39-ad40-3c61c0989605",
+      "ConcordiaCourseId": "002994"
+    },
+    {
+      "Id": "3024fc89-acbc-4a28-a417-93d021ba467b",
+      "ConcordiaCourseId": "002997"
+    },
+    {
+      "Id": "0a8bed76-25f3-4649-88e4-66a6f5b15c24",
+      "ConcordiaCourseId": "002998"
+    },
+    {
+      "Id": "0f538f33-cb7c-4596-8648-1ca06a63ee4b",
+      "ConcordiaCourseId": "003000"
+    },
+    {
+      "Id": "0dd8a7d8-8e40-40fa-9385-438f1286db96",
+      "ConcordiaCourseId": "003001"
+    },
+    {
+      "Id": "37d64926-fcff-48a1-899b-40b3513b583f",
+      "ConcordiaCourseId": "003003"
+    },
+    {
+      "Id": "5e861872-cb6e-40cd-a6ff-e03942b5a8ec",
+      "ConcordiaCourseId": "003004"
+    },
+    {
+      "Id": "0a0e27bb-3758-4867-a27a-2ca4ecff9946",
+      "ConcordiaCourseId": "003014"
+    },
+    {
+      "Id": "c758410c-093a-4ec9-8fa7-8e9cff8d40a5",
+      "ConcordiaCourseId": "040162"
+    },
+    {
+      "Id": "dac47c28-a985-40c3-bb84-afcfb076b560",
+      "ConcordiaCourseId": "040163"
+    },
+    {
+      "Id": "70cd01b4-9453-43d9-b9e4-b8ecadad49b7",
+      "ConcordiaCourseId": "040164"
+    },
+    {
+      "Id": "bcca4f51-ac24-4d71-95f6-6d57e1ff645f",
+      "ConcordiaCourseId": "040180"
+    },
+    {
+      "Id": "a4749dab-7735-4432-b58d-3c3d309af95c",
+      "ConcordiaCourseId": "040187"
+    },
+    {
+      "Id": "dc127e82-5b62-47ca-a973-796ff4726b71",
+      "ConcordiaCourseId": "040198"
+    },
+    {
+      "Id": "7aab840f-646f-4a0f-848d-de3f587a6d5e",
+      "ConcordiaCourseId": "040210"
+    },
+    {
+      "Id": "4f115215-28ae-4a2a-999c-a02c863f00f5",
+      "ConcordiaCourseId": "040211"
+    },
+    {
+      "Id": "e960b7f4-702a-430a-9eaa-ef87c9c18fc6",
+      "ConcordiaCourseId": "040212"
+    },
+    {
+      "Id": "9168c595-fc5e-46cf-ae68-db87cc79ef3b",
+      "ConcordiaCourseId": "040214"
+    },
+    {
+      "Id": "152efb14-d4a1-4b37-9acb-2e6d50020848",
+      "ConcordiaCourseId": "046520"
+    },
+    {
+      "Id": "ae51d73d-1adc-491b-b50e-dbcdd1634fb6",
+      "ConcordiaCourseId": "046521"
+    },
+    {
+      "Id": "b010c8ed-7179-4a3c-844d-dd95c40ad88d",
+      "ConcordiaCourseId": "046522"
+    },
+    {
+      "Id": "7d613b3b-9eb5-40ee-8351-bc418da983d8",
+      "ConcordiaCourseId": "046523"
+    },
+    {
+      "Id": "a9dace70-fdff-4a83-8552-2e789e809ec2",
+      "ConcordiaCourseId": "046524"
+    },
+    {
+      "Id": "e7baff2d-f966-445a-b03f-cf3a636b3f7c",
+      "ConcordiaCourseId": "046525"
+    },
+    {
+      "Id": "792a5a6e-c0b2-4ec9-9168-34ed3687ab4a",
+      "ConcordiaCourseId": "046526"
+    },
+    {
+      "Id": "3ccd1317-3750-4c74-87b4-211f7fc72b9e",
+      "ConcordiaCourseId": "046527"
+    },
+    {
+      "Id": "1530e652-3a07-46e4-9330-622fe73b1e46",
+      "ConcordiaCourseId": "046528"
+    },
+    {
+      "Id": "47ce2160-513e-44fa-921d-c268b1d9a993",
+      "ConcordiaCourseId": "047220"
+    },
+    {
+      "Id": "c66476b0-fe30-4e02-98d0-1c931e1f1992",
+      "ConcordiaCourseId": "047460"
+    },
+    {
+      "Id": "92a6f5e2-9808-43cd-98be-5ec31fa94c6b",
+      "ConcordiaCourseId": "047818"
+    },
+    {
+      "Id": "aff67a2c-d47a-47c5-a4b6-315c2a08d495",
+      "ConcordiaCourseId": "048775"
+    },
+    {
+      "Id": "343613e2-f817-417d-bbf7-5e0cf5c2747c",
+      "ConcordiaCourseId": "049426"
+    },
+    {
+      "Id": "26b0f82c-96ad-4024-b69b-33a1fc60816e",
+      "ConcordiaCourseId": "049605"
+    },
+    {
+      "Id": "cadc9f5a-54b3-40a6-a225-947037461a7f",
+      "ConcordiaCourseId": "050384"
+    },
+    {
+      "Id": "ec7b79f9-47f9-4a08-b37b-8355bf15379f",
+      "ConcordiaCourseId": "050385"
+    },
+    {
+      "Id": "b15782a8-0864-4fa9-9ccf-3ba3a68da94b",
+      "ConcordiaCourseId": "050386"
+    },
+    {
+      "Id": "17af37a3-85d1-45bd-87fb-f08660a906f0",
+      "ConcordiaCourseId": "050541"
+    },
+    {
+      "Id": "5706cc7a-3e76-4292-b693-dd1873255ba3",
+      "ConcordiaCourseId": "046529"
+    },
+    {
+      "Id": "ca3b82d5-2e14-4622-8266-88e0b2b197f2",
+      "ConcordiaCourseId": "046530"
+    },
+    {
+      "Id": "3de9e784-e80c-4ae1-81f0-a3a05bdcaf8d",
+      "ConcordiaCourseId": "046531"
+    },
+    {
+      "Id": "9b694de8-997a-42c3-8de4-d3dd75014704",
+      "ConcordiaCourseId": "046532"
+    },
+    {
+      "Id": "e96a78f0-2051-48f2-a36a-495f8ce02055",
+      "ConcordiaCourseId": "046533"
+    },
+    {
+      "Id": "421e2fde-3111-4914-9b21-4ae877ef2a53",
+      "ConcordiaCourseId": "046534"
+    },
+    {
+      "Id": "85ba4dcc-1392-4c9d-8e61-a486ae5ffc10",
+      "ConcordiaCourseId": "046535"
+    },
+    {
+      "Id": "28c6abe7-843d-4002-8622-681a557442aa",
+      "ConcordiaCourseId": "003318"
+    },
+    {
+      "Id": "4e88c7b1-3355-4322-83d8-b7db3dca96e1",
+      "ConcordiaCourseId": "003319"
+    },
+    {
+      "Id": "6cd9f972-9980-4b28-bfc1-df8c15b19ae7",
+      "ConcordiaCourseId": "003322"
+    },
+    {
+      "Id": "15dbd634-9ca4-472b-8e5c-babaa04808c6",
+      "ConcordiaCourseId": "003323"
+    },
+    {
+      "Id": "dd2b84af-47c6-4e09-8bb9-8bd07c144e50",
+      "ConcordiaCourseId": "003324"
+    },
+    {
+      "Id": "823ce9d8-825d-415d-95aa-512828075357",
+      "ConcordiaCourseId": "003325"
+    },
+    {
+      "Id": "d13d83f2-f443-4fa3-a2a2-f819a23d3eff",
+      "ConcordiaCourseId": "003330"
+    },
+    {
+      "Id": "ab918956-ef1c-46ac-88c7-5a975572cea2",
+      "ConcordiaCourseId": "003331"
+    },
+    {
+      "Id": "99b5bbd6-c299-4726-bda3-59a3ceb62e1a",
+      "ConcordiaCourseId": "003332"
+    },
+    {
+      "Id": "7960f5f2-f91e-4b3c-822f-5a78a13975ab",
+      "ConcordiaCourseId": "003333"
+    },
+    {
+      "Id": "fe5d0452-6041-4e4e-8bbe-c9154af969ce",
+      "ConcordiaCourseId": "003334"
+    },
+    {
+      "Id": "34814b54-aebd-4681-bf08-2c57d2faf820",
+      "ConcordiaCourseId": "003335"
+    },
+    {
+      "Id": "0d0c35a2-a538-4ac6-a9e3-80aa363c611a",
+      "ConcordiaCourseId": "003336"
+    },
+    {
+      "Id": "633f16d2-2d3a-4ef2-aeb2-84fa993c5c87",
+      "ConcordiaCourseId": "003337"
+    },
+    {
+      "Id": "572015fb-1df6-4abb-ab7c-a2fcbbb75824",
+      "ConcordiaCourseId": "003338"
+    },
+    {
+      "Id": "790af482-a7f5-484b-8e37-46ee488526c3",
+      "ConcordiaCourseId": "003339"
+    },
+    {
+      "Id": "dfdfd542-81ab-4a3b-b059-b18c03e1e18c",
+      "ConcordiaCourseId": "003340"
+    },
+    {
+      "Id": "72e288d2-fd8f-48b8-b862-aa542972857f",
+      "ConcordiaCourseId": "003341"
+    },
+    {
+      "Id": "1918a7d2-e556-43d4-8375-9339e5e89024",
+      "ConcordiaCourseId": "003342"
+    },
+    {
+      "Id": "55f1be64-1f85-487f-b0d4-0e1a5c0f3e76",
+      "ConcordiaCourseId": "003343"
+    },
+    {
+      "Id": "ca3eb243-9894-4ec1-82fc-fc9fe5e30943",
+      "ConcordiaCourseId": "003344"
+    },
+    {
+      "Id": "84c166a2-e741-4484-8f58-b94ac0f8378f",
+      "ConcordiaCourseId": "003345"
+    },
+    {
+      "Id": "feef1f2a-a2bf-49bf-aed3-b288485c9a1e",
+      "ConcordiaCourseId": "003346"
+    },
+    {
+      "Id": "0f2eda73-208d-4c31-a5a9-d43ecfabacfc",
+      "ConcordiaCourseId": "003351"
+    },
+    {
+      "Id": "08f385f2-9740-41e0-9d44-46fb215e5140",
+      "ConcordiaCourseId": "003353"
+    },
+    {
+      "Id": "ff89e293-f884-46ce-a334-7d6f4b99fe75",
+      "ConcordiaCourseId": "003358"
+    },
+    {
+      "Id": "26fadd40-a409-4e8c-a60f-97e746eaa8d2",
+      "ConcordiaCourseId": "003361"
+    },
+    {
+      "Id": "160aab37-54ba-4387-bc20-65248ecbbbed",
+      "ConcordiaCourseId": "003363"
+    },
+    {
+      "Id": "81362da4-df1f-4a03-b4f7-0ed3c8e3ec56",
+      "ConcordiaCourseId": "003365"
+    },
+    {
+      "Id": "622361b2-753d-47d2-96ab-ac7d720823ac",
+      "ConcordiaCourseId": "003367"
+    },
+    {
+      "Id": "2eacc5bf-405f-44f4-b710-45fc2ba77de7",
+      "ConcordiaCourseId": "003370"
+    },
+    {
+      "Id": "a9fc4bc0-62fd-48e9-b7e1-cc995041775d",
+      "ConcordiaCourseId": "003372"
+    },
+    {
+      "Id": "aa393493-d9aa-4a7a-ba1d-25a418c20f60",
+      "ConcordiaCourseId": "003374"
+    },
+    {
+      "Id": "3ba3d02c-defb-44e0-a6ca-d5037081ccca",
+      "ConcordiaCourseId": "003376"
+    },
+    {
+      "Id": "fa131561-ba27-4f33-9408-d3a5e46f6142",
+      "ConcordiaCourseId": "003377"
+    },
+    {
+      "Id": "707e612a-f3e1-4e7e-81cf-f5e5cf3b3139",
+      "ConcordiaCourseId": "003379"
+    },
+    {
+      "Id": "801078e7-eb56-4d9b-b9d5-62204671e654",
+      "ConcordiaCourseId": "003385"
+    },
+    {
+      "Id": "b70d953b-787f-4470-a3d4-14817eb0eea0",
+      "ConcordiaCourseId": "003389"
+    },
+    {
+      "Id": "e589d3ad-7ef5-48dc-8514-6f8341b1e414",
+      "ConcordiaCourseId": "003391"
+    },
+    {
+      "Id": "efb39869-908c-4150-8289-b9547e77f5f0",
+      "ConcordiaCourseId": "003395"
+    },
+    {
+      "Id": "85410716-c99a-492d-8675-8d92401481fe",
+      "ConcordiaCourseId": "003398"
+    },
+    {
+      "Id": "1679b265-144c-4a4d-81da-f1be86add6ae",
+      "ConcordiaCourseId": "003399"
+    },
+    {
+      "Id": "8a59ca60-b869-4823-8385-82a6db9b7268",
+      "ConcordiaCourseId": "003405"
+    },
+    {
+      "Id": "bfbd69d1-6cbe-45f0-aaaf-1c6c99df47dd",
+      "ConcordiaCourseId": "003406"
+    },
+    {
+      "Id": "465a937d-8ea6-4819-98ed-c4e1448201aa",
+      "ConcordiaCourseId": "003407"
+    },
+    {
+      "Id": "78cdb8b6-119d-486f-b5d2-ee26c69c2b02",
+      "ConcordiaCourseId": "003411"
+    },
+    {
+      "Id": "641d2864-93ef-46ac-8bff-715de549d130",
+      "ConcordiaCourseId": "003415"
+    },
+    {
+      "Id": "c6b89f34-ab6d-4922-b8b7-cf3787c3a202",
+      "ConcordiaCourseId": "003417"
+    },
+    {
+      "Id": "e52896de-8bab-4b93-a761-7444ab8c6a87",
+      "ConcordiaCourseId": "003419"
+    },
+    {
+      "Id": "a4604a9c-ae91-40cf-9065-c6e11606d78a",
+      "ConcordiaCourseId": "003421"
+    },
+    {
+      "Id": "2b050f14-e5b5-4093-b217-32378670d5fb",
+      "ConcordiaCourseId": "003423"
+    },
+    {
+      "Id": "281ce078-8a90-4e9a-bb99-3c5327542053",
+      "ConcordiaCourseId": "040218"
+    },
+    {
+      "Id": "40e4573b-a0e7-4c17-baf4-22e733810732",
+      "ConcordiaCourseId": "040219"
+    },
+    {
+      "Id": "71d0fcea-5828-4e20-ad0a-a3c7ca2e6268",
+      "ConcordiaCourseId": "040221"
+    },
+    {
+      "Id": "7babbf96-1247-494f-97fc-993df888685d",
+      "ConcordiaCourseId": "040222"
+    },
+    {
+      "Id": "a8c6b75e-6af2-4093-b04b-99125c2c27c7",
+      "ConcordiaCourseId": "040223"
+    },
+    {
+      "Id": "9f2122a8-4037-4c9d-b456-c95b67d4804d",
+      "ConcordiaCourseId": "040224"
+    },
+    {
+      "Id": "f212261b-ead5-47b9-bc68-adc40c9e6061",
+      "ConcordiaCourseId": "040225"
+    },
+    {
+      "Id": "59880a37-1b2c-4265-9145-4d9f55456414",
+      "ConcordiaCourseId": "040226"
+    },
+    {
+      "Id": "542181af-57f6-42c3-84c0-46c4cf5b5d88",
+      "ConcordiaCourseId": "046536"
+    },
+    {
+      "Id": "8673680c-553f-4c43-a463-e28740f1b7a9",
+      "ConcordiaCourseId": "046537"
+    },
+    {
+      "Id": "b45b76ea-afc2-4dbc-be3d-b732517005a3",
+      "ConcordiaCourseId": "046538"
+    },
+    {
+      "Id": "877826e0-d63a-4368-bfaa-c28fcb7fe79c",
+      "ConcordiaCourseId": "046539"
+    },
+    {
+      "Id": "f73f066b-92bf-41d3-b6ff-2644c9b6cd87",
+      "ConcordiaCourseId": "046540"
+    },
+    {
+      "Id": "f5d4af47-e3a1-442f-9c3b-95cb211787d7",
+      "ConcordiaCourseId": "047817"
+    },
+    {
+      "Id": "03bd5346-4697-4569-861e-639f125eb878",
+      "ConcordiaCourseId": "047832"
+    },
+    {
+      "Id": "b9efaf89-2f12-4c45-add8-8c69b1792c50",
+      "ConcordiaCourseId": "047833"
+    },
+    {
+      "Id": "9802366f-c92f-4536-b72e-59b98c6b0f51",
+      "ConcordiaCourseId": "047961"
+    },
+    {
+      "Id": "1dfd7bc5-664a-4c95-a569-c6574cc5ea41",
+      "ConcordiaCourseId": "049695"
+    },
+    {
+      "Id": "59b55cee-95bc-49d1-b729-8ec2a2d1be4e",
+      "ConcordiaCourseId": "049696"
+    },
+    {
+      "Id": "0e87bb18-e97a-4d52-89bb-e368df31ca50",
+      "ConcordiaCourseId": "049697"
+    },
+    {
+      "Id": "7f6a8481-dfe7-4d2a-9c2e-070cd4902d87",
+      "ConcordiaCourseId": "049758"
+    },
+    {
+      "Id": "a6b816a8-9800-4c09-bf3f-05d58691cec8",
+      "ConcordiaCourseId": "050152"
+    },
+    {
+      "Id": "676d1fda-1a85-43d2-bd12-24195d0a60a4",
+      "ConcordiaCourseId": "050172"
+    },
+    {
+      "Id": "f0625a28-c875-493f-8410-b8b105ca61e1",
+      "ConcordiaCourseId": "050280"
+    },
+    {
+      "Id": "6b96a16b-ce2b-438a-8a7b-41e5514bf18c",
+      "ConcordiaCourseId": "003519"
+    },
+    {
+      "Id": "e85971db-6e4f-4275-8003-a74fe5da4ba4",
+      "ConcordiaCourseId": "003520"
+    },
+    {
+      "Id": "9f03e223-1625-4db1-96ea-b6097cd5b5f8",
+      "ConcordiaCourseId": "003521"
+    },
+    {
+      "Id": "9d182e66-4f2a-479c-9cbf-470d5441a3ed",
+      "ConcordiaCourseId": "003522"
+    },
+    {
+      "Id": "7bfc7f0e-c192-4147-8ab4-46013d9bffd9",
+      "ConcordiaCourseId": "048076"
+    },
+    {
+      "Id": "300f83fb-e61e-43dd-85bf-1916f0f927fe",
+      "ConcordiaCourseId": "048077"
+    },
+    {
+      "Id": "8a1bb9d8-8cd7-4623-83de-d8647f8b207c",
+      "ConcordiaCourseId": "048078"
+    },
+    {
+      "Id": "5d2294d4-19e7-428c-ad76-1a125fbfc0b5",
+      "ConcordiaCourseId": "048954"
+    },
+    {
+      "Id": "0dc95171-eb69-4195-86b8-2a76141e1952",
+      "ConcordiaCourseId": "050042"
+    },
+    {
+      "Id": "6205de05-290b-463b-9987-2ce5ffdd0da7",
+      "ConcordiaCourseId": "050134"
+    },
+    {
+      "Id": "7834551a-2c8f-4347-a459-1de9dda91cd2",
+      "ConcordiaCourseId": "003523"
+    },
+    {
+      "Id": "32cacd49-5cf0-4f8c-92ff-7a63a37ebcd7",
+      "ConcordiaCourseId": "003524"
+    },
+    {
+      "Id": "98cbf6ae-36d5-482a-b890-f11462e3eb8b",
+      "ConcordiaCourseId": "003525"
+    },
+    {
+      "Id": "056dbba0-7a3e-4d1e-b756-e3e9706c063e",
+      "ConcordiaCourseId": "003526"
+    },
+    {
+      "Id": "ace4b704-fff9-43bd-be3f-b08f52b109c8",
+      "ConcordiaCourseId": "003527"
+    },
+    {
+      "Id": "d498a8dc-fd76-4988-a9bb-b1a1954a5250",
+      "ConcordiaCourseId": "003528"
+    },
+    {
+      "Id": "924a043e-0278-47f9-a821-fec3ad8cb63c",
+      "ConcordiaCourseId": "003529"
+    },
+    {
+      "Id": "eea71834-c9ec-4f05-a714-22e40f280a35",
+      "ConcordiaCourseId": "003530"
+    },
+    {
+      "Id": "dbd76aea-da09-4d8f-8482-ed0a3739268a",
+      "ConcordiaCourseId": "003531"
+    },
+    {
+      "Id": "378496e3-9f0d-40f6-a636-e7b4ef0f0e16",
+      "ConcordiaCourseId": "003532"
+    },
+    {
+      "Id": "5a6da551-9456-43ba-8f69-0708762cafce",
+      "ConcordiaCourseId": "047954"
+    },
+    {
+      "Id": "b6b65290-2d7a-473c-8c87-5aeb4f401420",
+      "ConcordiaCourseId": "048074"
+    },
+    {
+      "Id": "2a50765e-0862-4e28-ba87-5b7dcaa7b816",
+      "ConcordiaCourseId": "048075"
+    },
+    {
+      "Id": "2ff7b689-7609-489c-8996-466a35f4b133",
+      "ConcordiaCourseId": "048080"
+    },
+    {
+      "Id": "204cfa50-b329-461d-a666-e8d25e724caa",
+      "ConcordiaCourseId": "049441"
+    },
+    {
+      "Id": "ee2c610d-df9b-45e8-af98-0bd1d87fb077",
+      "ConcordiaCourseId": "003627"
+    },
+    {
+      "Id": "d7102d76-3afd-4481-b5bd-d3358654c240",
+      "ConcordiaCourseId": "003628"
+    },
+    {
+      "Id": "7ef40318-6438-416e-bcac-f73cd4b80651",
+      "ConcordiaCourseId": "003629"
+    },
+    {
+      "Id": "29f376ac-dcba-4cf3-b626-6f2bc6e3cf52",
+      "ConcordiaCourseId": "003632"
+    },
+    {
+      "Id": "0ba9b978-eb6c-4aba-bd0b-ba49ffa676a9",
+      "ConcordiaCourseId": "003634"
+    },
+    {
+      "Id": "ff935cf6-ecd2-4bfc-aa52-f09aa79407cd",
+      "ConcordiaCourseId": "003637"
+    },
+    {
+      "Id": "c65f131d-fbe1-4d3d-91eb-693a3ab89163",
+      "ConcordiaCourseId": "003638"
+    },
+    {
+      "Id": "4c194f16-02fd-4b45-9816-76d6aef62c4a",
+      "ConcordiaCourseId": "003639"
+    },
+    {
+      "Id": "ca63f23c-00a3-4996-93e9-8aaf9e65db61",
+      "ConcordiaCourseId": "003641"
+    },
+    {
+      "Id": "44b0057f-b097-4f23-924b-87d4af6f7c87",
+      "ConcordiaCourseId": "003643"
+    },
+    {
+      "Id": "133a6658-869f-441f-9b28-47051dee9317",
+      "ConcordiaCourseId": "003649"
+    },
+    {
+      "Id": "f57cc9da-3fbb-49ec-ad83-22fd9181a164",
+      "ConcordiaCourseId": "003650"
+    },
+    {
+      "Id": "57ab1c95-142f-47d8-8e81-deb56d898fa3",
+      "ConcordiaCourseId": "003651"
+    },
+    {
+      "Id": "4a126f56-27ce-4e43-9da7-ce9d2cf26a75",
+      "ConcordiaCourseId": "003653"
+    },
+    {
+      "Id": "520c3164-b38c-46b5-9824-eb8f3f5388da",
+      "ConcordiaCourseId": "003654"
+    },
+    {
+      "Id": "d5156054-5acd-4a71-9153-7fc9efa68238",
+      "ConcordiaCourseId": "003655"
+    },
+    {
+      "Id": "d700c81e-ab9e-473f-8faa-b2f0d3472669",
+      "ConcordiaCourseId": "003657"
+    },
+    {
+      "Id": "062d07a8-bdfc-4f6a-83e8-5548b28a9046",
+      "ConcordiaCourseId": "003658"
+    },
+    {
+      "Id": "501af5db-9c88-4d78-b379-0968c276aa93",
+      "ConcordiaCourseId": "003659"
+    },
+    {
+      "Id": "3c772648-5b64-4dae-a0ea-d5e60afb4690",
+      "ConcordiaCourseId": "003660"
+    },
+    {
+      "Id": "f09f14e2-96a4-4858-a9be-1cc85ed4ca44",
+      "ConcordiaCourseId": "003661"
+    },
+    {
+      "Id": "9760b409-04ad-4526-a9b8-546dedb25cda",
+      "ConcordiaCourseId": "003666"
+    },
+    {
+      "Id": "35d6aff0-72c8-43e3-b07c-d9acbdaf58d4",
+      "ConcordiaCourseId": "003667"
+    },
+    {
+      "Id": "a1b579dc-3d9d-46bc-b54c-355a0c523482",
+      "ConcordiaCourseId": "003668"
+    },
+    {
+      "Id": "254c762d-dd3d-4385-ad53-90bd605119c6",
+      "ConcordiaCourseId": "003669"
+    },
+    {
+      "Id": "dc1f377b-7dcd-4e61-b33f-6885d701064b",
+      "ConcordiaCourseId": "003670"
+    },
+    {
+      "Id": "8afb9139-7bc2-41c7-a47e-f5040c9fada4",
+      "ConcordiaCourseId": "046541"
+    },
+    {
+      "Id": "26f6242e-4d46-43b8-af7d-c5eeccd85b81",
+      "ConcordiaCourseId": "046542"
+    },
+    {
+      "Id": "436002e8-663b-49d9-9ce3-bde8478edbe0",
+      "ConcordiaCourseId": "046543"
+    },
+    {
+      "Id": "dba9a05b-bf51-4549-af2d-415205846b41",
+      "ConcordiaCourseId": "046544"
+    },
+    {
+      "Id": "d2187b0d-78db-4d32-a8e9-8118d021369c",
+      "ConcordiaCourseId": "047468"
+    },
+    {
+      "Id": "c8decd8c-2f61-4e5a-996d-0226a6b8c3ad",
+      "ConcordiaCourseId": "047929"
+    },
+    {
+      "Id": "539e2b39-d913-4f6c-886e-ba1711e7dd26",
+      "ConcordiaCourseId": "047944"
+    },
+    {
+      "Id": "4b3a8639-7a34-4bbb-8118-dbb9b43a0d6d",
+      "ConcordiaCourseId": "048522"
+    },
+    {
+      "Id": "a31e1d80-be69-4e37-b5ca-c00d019f0cdc",
+      "ConcordiaCourseId": "048523"
+    },
+    {
+      "Id": "51a7f765-b310-4461-9ca0-338eb9f1ea71",
+      "ConcordiaCourseId": "048524"
+    },
+    {
+      "Id": "1f90130b-ec90-4a5f-913f-ea3b61c7f8c3",
+      "ConcordiaCourseId": "048898"
+    },
+    {
+      "Id": "f2ba3e6c-69ac-4105-a5bc-3fa1e1a0f44e",
+      "ConcordiaCourseId": "048899"
+    },
+    {
+      "Id": "0177c7e2-95b4-47ca-a49c-c687dacf4ded",
+      "ConcordiaCourseId": "048900"
+    },
+    {
+      "Id": "160b9742-4e65-44e4-b275-9b09104b8159",
+      "ConcordiaCourseId": "048901"
+    },
+    {
+      "Id": "25962be5-8210-4cb7-9095-76653cdf201f",
+      "ConcordiaCourseId": "048928"
+    },
+    {
+      "Id": "31454095-0450-4192-b772-ba4bfef64dd6",
+      "ConcordiaCourseId": "048929"
+    },
+    {
+      "Id": "bffae7d7-10de-446b-96a2-66d7cd793914",
+      "ConcordiaCourseId": "049735"
+    },
+    {
+      "Id": "79495150-297e-442d-a610-2e04a96c9098",
+      "ConcordiaCourseId": "003682"
+    },
+    {
+      "Id": "f50bf6ce-7ace-4e8d-9954-c89aae855f65",
+      "ConcordiaCourseId": "003683"
+    },
+    {
+      "Id": "faaed974-b2ad-4d2f-aef1-b8da3316cf6d",
+      "ConcordiaCourseId": "003685"
+    },
+    {
+      "Id": "8bfa8b19-9f1d-48a0-8ce6-6d392a547228",
+      "ConcordiaCourseId": "003687"
+    },
+    {
+      "Id": "1c47e5a0-830b-43d4-9675-3f713f112f95",
+      "ConcordiaCourseId": "003689"
+    },
+    {
+      "Id": "9309d19c-67f0-4e5e-927d-75a41255cdf6",
+      "ConcordiaCourseId": "003690"
+    },
+    {
+      "Id": "3d0d744a-2431-4d37-96d1-94a194c03908",
+      "ConcordiaCourseId": "003691"
+    },
+    {
+      "Id": "5014991f-538c-4099-9b30-681dac43b708",
+      "ConcordiaCourseId": "003693"
+    },
+    {
+      "Id": "c67161be-462d-4dd2-b1d2-c22585776e1f",
+      "ConcordiaCourseId": "003695"
+    },
+    {
+      "Id": "7da529d6-f971-4a5e-91e7-51ccf087002d",
+      "ConcordiaCourseId": "003696"
+    },
+    {
+      "Id": "a479da44-7b69-477a-829b-6b4db2ec30d9",
+      "ConcordiaCourseId": "003697"
+    },
+    {
+      "Id": "20a247dd-c74f-42d8-b325-ca857a2693c7",
+      "ConcordiaCourseId": "003698"
+    },
+    {
+      "Id": "0c20d2a5-80cc-4d37-b37b-203a144e0473",
+      "ConcordiaCourseId": "003699"
+    },
+    {
+      "Id": "a02054ce-f4f3-4064-b958-fa23c294830f",
+      "ConcordiaCourseId": "003700"
+    },
+    {
+      "Id": "86c30fbb-3cc9-431b-97a9-c49c040b016a",
+      "ConcordiaCourseId": "003701"
+    },
+    {
+      "Id": "47763f9e-ac74-4787-a92c-08f913a7bca5",
+      "ConcordiaCourseId": "003702"
+    },
+    {
+      "Id": "2d668f78-b11c-4fe5-8f36-b2bbe0af0af5",
+      "ConcordiaCourseId": "003703"
+    },
+    {
+      "Id": "778415db-4dcf-4b41-9673-9215147e31d2",
+      "ConcordiaCourseId": "003704"
+    },
+    {
+      "Id": "b2341261-8d51-4990-8931-501dc64b819e",
+      "ConcordiaCourseId": "003705"
+    },
+    {
+      "Id": "098d8072-65f8-4d49-8b75-8ad1f9738284",
+      "ConcordiaCourseId": "003706"
+    },
+    {
+      "Id": "aa62b2a8-4cf6-4427-aa70-6ced75efb7a1",
+      "ConcordiaCourseId": "003715"
+    },
+    {
+      "Id": "65c96063-75b1-4d80-bd36-3b28fb96b972",
+      "ConcordiaCourseId": "003716"
+    },
+    {
+      "Id": "af5de985-97d6-4546-894d-d06e205f163d",
+      "ConcordiaCourseId": "003717"
+    },
+    {
+      "Id": "dccf60c9-b77d-44aa-b7f5-a3770b492a31",
+      "ConcordiaCourseId": "003718"
+    },
+    {
+      "Id": "bc46f423-99d4-46d8-bd59-0c6073c68713",
+      "ConcordiaCourseId": "003719"
+    },
+    {
+      "Id": "2cdae223-e2dd-4d6e-a1e8-7760b7490f77",
+      "ConcordiaCourseId": "003721"
+    },
+    {
+      "Id": "3ba23dfe-c8aa-4b7f-abef-bae9d6e896f3",
+      "ConcordiaCourseId": "003722"
+    },
+    {
+      "Id": "6f6d6d0f-877b-44ab-819d-d12fac1c1f8e",
+      "ConcordiaCourseId": "003723"
+    },
+    {
+      "Id": "dce10e12-0f43-46cc-afb1-ee712f25d44a",
+      "ConcordiaCourseId": "003724"
+    },
+    {
+      "Id": "0bf15efb-a4a7-46db-acf9-c9b5b85a2361",
+      "ConcordiaCourseId": "040231"
+    },
+    {
+      "Id": "c33e3ba7-8786-4c2b-afbc-7e6bdc51af5f",
+      "ConcordiaCourseId": "046545"
+    },
+    {
+      "Id": "c209b191-4cd1-45c9-a36a-0f3a1a2e50fd",
+      "ConcordiaCourseId": "047953"
+    },
+    {
+      "Id": "bc92aaa8-acf5-4a4a-b8ee-4257fa1f983f",
+      "ConcordiaCourseId": "046546"
+    },
+    {
+      "Id": "53f5004c-a280-4954-90d6-cbc6534a54e3",
+      "ConcordiaCourseId": "046547"
+    },
+    {
+      "Id": "d2531478-e82e-452a-a7e6-379e9aa79605",
+      "ConcordiaCourseId": "050583"
+    },
+    {
+      "Id": "f418b951-a2a4-49e7-a552-21825a22896c",
+      "ConcordiaCourseId": "050584"
+    },
+    {
+      "Id": "ce88806e-8d3a-462a-8ae7-2be08dceefc1",
+      "ConcordiaCourseId": "050585"
+    },
+    {
+      "Id": "b2019976-b381-444c-94de-829911bd0ee2",
+      "ConcordiaCourseId": "050586"
+    },
+    {
+      "Id": "81d4cfc9-c2f9-4b60-b4e5-8715aab901a9",
+      "ConcordiaCourseId": "048593"
+    },
+    {
+      "Id": "a685776c-691a-4796-8560-1427ebb6603d",
+      "ConcordiaCourseId": "048595"
+    },
+    {
+      "Id": "e020112a-0714-4c23-8cd9-0a646a41735c",
+      "ConcordiaCourseId": "048596"
+    },
+    {
+      "Id": "729c5689-0261-4371-8f2b-183092921068",
+      "ConcordiaCourseId": "048597"
+    },
+    {
+      "Id": "7d60466b-3aea-4ddb-b1d4-e0b278bfafc8",
+      "ConcordiaCourseId": "048598"
+    },
+    {
+      "Id": "b0aebd72-ae4c-4870-b337-7ea4fc775d60",
+      "ConcordiaCourseId": "049325"
+    },
+    {
+      "Id": "e143be00-0b13-4af4-bf05-c7edc3bb7695",
+      "ConcordiaCourseId": "049326"
+    },
+    {
+      "Id": "1c3094fb-1a0f-434e-8610-88fb6f43ed42",
+      "ConcordiaCourseId": "049651"
+    },
+    {
+      "Id": "ec2cb4b7-7fa7-4ba6-99a0-ef39a63c036f",
+      "ConcordiaCourseId": "049660"
+    },
+    {
+      "Id": "02dbef83-3a94-4b3c-bc26-9fe757cc87fe",
+      "ConcordiaCourseId": "049823"
+    },
+    {
+      "Id": "509a511d-61f6-4588-ad7f-c959742fc1b5",
+      "ConcordiaCourseId": "049944"
+    },
+    {
+      "Id": "ca9f2092-ea3f-4c44-b49c-a51f04d5e86a",
+      "ConcordiaCourseId": "046428"
+    },
+    {
+      "Id": "1187f4c1-fa9e-402d-8459-229131d9f332",
+      "ConcordiaCourseId": "046429"
+    },
+    {
+      "Id": "6504a16a-182a-450c-98ae-cddf74aa079c",
+      "ConcordiaCourseId": "046430"
+    },
+    {
+      "Id": "c5d7eb38-f14b-401f-b86c-2b7a23c88be4",
+      "ConcordiaCourseId": "046431"
+    },
+    {
+      "Id": "71b94a7f-81fc-4767-b6de-ec0aff74364b",
+      "ConcordiaCourseId": "048565"
+    },
+    {
+      "Id": "1ac92193-93ad-4330-937b-6de3ad136b0c",
+      "ConcordiaCourseId": "036182"
+    },
+    {
+      "Id": "0433a506-6aa5-416d-96b2-cbc712c82173",
+      "ConcordiaCourseId": "036184"
+    },
+    {
+      "Id": "84eb18c7-7277-44a0-945c-d6453ee891dc",
+      "ConcordiaCourseId": "036187"
+    },
+    {
+      "Id": "63a8645e-eb4d-45a0-9866-39cf58e4392d",
+      "ConcordiaCourseId": "036190"
+    },
+    {
+      "Id": "2992c33d-1b59-4f99-901f-6297bae392ea",
+      "ConcordiaCourseId": "049738"
+    },
+    {
+      "Id": "571339c4-e309-4c1e-ba85-32b992f02a26",
+      "ConcordiaCourseId": "049739"
+    },
+    {
+      "Id": "35d4e49b-7e89-435d-acb3-7304bc6c4848",
+      "ConcordiaCourseId": "050589"
+    },
+    {
+      "Id": "a6a38e33-aaf0-47bd-b12b-c74c414af4c8",
+      "ConcordiaCourseId": "050590"
+    },
+    {
+      "Id": "682e9cfa-2fdf-43f0-8ba9-bb1f970d6487",
+      "ConcordiaCourseId": "050591"
+    },
+    {
+      "Id": "79019913-ebe4-49f9-a5df-01fa290139bc",
+      "ConcordiaCourseId": "050275"
+    },
+    {
+      "Id": "700f7dee-7da0-4c53-a2a9-31c3f94955c2",
+      "ConcordiaCourseId": "050284"
+    },
+    {
+      "Id": "2b4404bd-f53d-4afe-80f7-41cab8876da4",
+      "ConcordiaCourseId": "050285"
+    },
+    {
+      "Id": "e58ae5b9-8b95-4846-92a5-84fb15bad8b7",
+      "ConcordiaCourseId": "050286"
+    },
+    {
+      "Id": "2f0d5575-3af8-4e11-8b59-d99250c7c138",
+      "ConcordiaCourseId": "050287"
+    },
+    {
+      "Id": "bfa9428a-55cc-42da-9181-0658f9f489a9",
+      "ConcordiaCourseId": "050288"
+    },
+    {
+      "Id": "8447ac71-2a34-45e5-a295-0ceec2804c3d",
+      "ConcordiaCourseId": "036236"
+    },
+    {
+      "Id": "66e2b0b5-2a9a-4f13-8906-b40757c4c509",
+      "ConcordiaCourseId": "036239"
+    },
+    {
+      "Id": "a2346381-c1cb-43d5-85e6-9109f8269679",
+      "ConcordiaCourseId": "036242"
+    },
+    {
+      "Id": "6e24386f-9683-4b32-9031-ba7bc583908e",
+      "ConcordiaCourseId": "036245"
+    },
+    {
+      "Id": "ec942b17-1145-457e-b906-31293165fac5",
+      "ConcordiaCourseId": "049671"
+    },
+    {
+      "Id": "0135b84e-1fe5-4f63-bb82-dade4bd10829",
+      "ConcordiaCourseId": "049672"
+    },
+    {
+      "Id": "cec69510-6a03-48f2-b8b2-6bfd181442bb",
+      "ConcordiaCourseId": "050333"
+    },
+    {
+      "Id": "4ddbaab8-2d4c-47a8-b395-f0203cd22044",
+      "ConcordiaCourseId": "049508"
+    },
+    {
+      "Id": "75d8a4cc-b5b9-4ccb-8a37-bd316565a387",
+      "ConcordiaCourseId": "049632"
+    },
+    {
+      "Id": "41bedb95-129b-4590-b816-3e0a6e408858",
+      "ConcordiaCourseId": "049837"
+    },
+    {
+      "Id": "194f3489-4505-4f7f-be51-fe4aaa9634b1",
+      "ConcordiaCourseId": "049914"
+    },
+    {
+      "Id": "1d2b341f-3e10-450e-807d-ce772791ea0b",
+      "ConcordiaCourseId": "046432"
+    },
+    {
+      "Id": "54ccc953-37a4-4411-af88-2266d5cc584a",
+      "ConcordiaCourseId": "046433"
+    },
+    {
+      "Id": "6a4f042a-1ef4-4037-b9e9-7ce053eb2059",
+      "ConcordiaCourseId": "047162"
+    },
+    {
+      "Id": "e0a5431c-3a6e-4f8b-8631-207598b4793f",
+      "ConcordiaCourseId": "047163"
+    },
+    {
+      "Id": "839d756d-6c12-41c1-bb29-6250475f8031",
+      "ConcordiaCourseId": "036388"
+    },
+    {
+      "Id": "a8254a83-ae16-49fd-ba31-1bd4df1a6caa",
+      "ConcordiaCourseId": "036391"
+    },
+    {
+      "Id": "64467644-42d6-4083-844e-7dc4e8462974",
+      "ConcordiaCourseId": "036392"
+    },
+    {
+      "Id": "95967738-9b63-4f3d-8cd8-346d65a34921",
+      "ConcordiaCourseId": "036393"
+    },
+    {
+      "Id": "38b85a52-94be-44b9-bc6c-799ccaab20b5",
+      "ConcordiaCourseId": "036394"
+    },
+    {
+      "Id": "7d1df974-3823-490b-b23b-36324020fdc4",
+      "ConcordiaCourseId": "036396"
+    },
+    {
+      "Id": "1646fd7d-d5cb-43f7-a489-c93c5e6f8bd6",
+      "ConcordiaCourseId": "036399"
+    },
+    {
+      "Id": "259f19f9-8e33-4d60-97f3-a195e5fbe71d",
+      "ConcordiaCourseId": "036400"
+    },
+    {
+      "Id": "c268350e-b0cf-44d1-b21c-d44e2fcb1491",
+      "ConcordiaCourseId": "036402"
+    },
+    {
+      "Id": "f96d47e2-1e38-4b93-9dd1-0445bcef8683",
+      "ConcordiaCourseId": "050651"
+    },
+    {
+      "Id": "44dd0d33-027c-4e94-8373-cd8ed61d63cc",
+      "ConcordiaCourseId": "050652"
+    },
+    {
+      "Id": "dda913ae-89af-4c00-84be-d2bede763cab",
+      "ConcordiaCourseId": "050656"
+    },
+    {
+      "Id": "03498951-b972-4d0d-8743-aae29bd58255",
+      "ConcordiaCourseId": "049318"
+    },
+    {
+      "Id": "1e6ea8c4-10a6-440e-85f5-379de665a3e3",
+      "ConcordiaCourseId": "049319"
+    },
+    {
+      "Id": "54e769b7-e8c7-49d5-9f36-c134a95b7ec8",
+      "ConcordiaCourseId": "049320"
+    },
+    {
+      "Id": "dc2866db-665d-4f30-9d2d-34128c6393dc",
+      "ConcordiaCourseId": "049321"
+    },
+    {
+      "Id": "5aa94498-1c1c-4966-a954-0e3456a47d9c",
+      "ConcordiaCourseId": "049322"
+    },
+    {
+      "Id": "bae7faa6-1b1e-48a8-b1da-314ab235a9c0",
+      "ConcordiaCourseId": "050039"
+    },
+    {
+      "Id": "230bc309-9e42-494a-afcd-a0c2aad2749c",
+      "ConcordiaCourseId": "045021"
+    },
+    {
+      "Id": "2bdf98f1-1e20-4297-a1de-d30e33527258",
+      "ConcordiaCourseId": "046434"
+    },
+    {
+      "Id": "c79ec01e-24a5-46cb-adeb-d8addfd2b0df",
+      "ConcordiaCourseId": "049285"
+    },
+    {
+      "Id": "1af9222f-0bc2-4160-ac26-273bb05d2c98",
+      "ConcordiaCourseId": "049287"
+    },
+    {
+      "Id": "98d08855-fdb3-4ccb-96f3-7c4fbde3e138",
+      "ConcordiaCourseId": "049288"
+    },
+    {
+      "Id": "00c54d9b-b58b-481b-855b-f61a03d29aad",
+      "ConcordiaCourseId": "049290"
+    },
+    {
+      "Id": "6ba3ccbe-f5a7-4912-8bca-f3c5eedfb440",
+      "ConcordiaCourseId": "049079"
+    },
+    {
+      "Id": "7701a9a1-b205-44e8-a4c5-9e050c3d54d8",
+      "ConcordiaCourseId": "049086"
+    },
+    {
+      "Id": "cac9f3b5-517a-408e-adb3-1ba6b1c58d88",
+      "ConcordiaCourseId": "049087"
+    },
+    {
+      "Id": "359c9bab-f582-4eb5-a47f-9ee67e0de149",
+      "ConcordiaCourseId": "049088"
+    },
+    {
+      "Id": "a8653ef1-23f9-48dc-aef3-161fc717aece",
+      "ConcordiaCourseId": "049089"
+    },
+    {
+      "Id": "6c4097d3-2d60-48a0-a21e-ba90832b4f09",
+      "ConcordiaCourseId": "049090"
+    },
+    {
+      "Id": "572242e1-c839-4eaa-9fbe-8e893f08bc81",
+      "ConcordiaCourseId": "050164"
+    },
+    {
+      "Id": "43e7480c-d24b-4872-ab04-9fa8e57e68dd",
+      "ConcordiaCourseId": "050304"
+    },
+    {
+      "Id": "136bb062-9a6f-4f60-b9f0-2930ac3433ab",
+      "ConcordiaCourseId": "050305"
+    },
+    {
+      "Id": "56f1e43f-d77c-4e32-8911-c195518dcf89",
+      "ConcordiaCourseId": "050306"
+    },
+    {
+      "Id": "ae24f26a-d064-4c2f-9468-2296de8cbb6e",
+      "ConcordiaCourseId": "050336"
+    },
+    {
+      "Id": "c27f0ffe-63bf-4323-8fdf-1c1c0abab922",
+      "ConcordiaCourseId": "050341"
+    },
+    {
+      "Id": "81b63365-b973-4dda-802a-4867385cc532",
+      "ConcordiaCourseId": "050342"
+    },
+    {
+      "Id": "322940e7-8470-4fe3-a22f-fbead6601093",
+      "ConcordiaCourseId": "050343"
+    },
+    {
+      "Id": "1529edb7-8f96-4dcd-b924-b63302eecb54",
+      "ConcordiaCourseId": "050344"
+    },
+    {
+      "Id": "43f00e5c-b0a1-46ff-beb7-efb7b92ca64c",
+      "ConcordiaCourseId": "050776"
+    },
+    {
+      "Id": "ebbdc8b7-fb82-4a72-b25f-89281794e45d",
+      "ConcordiaCourseId": "050777"
+    },
+    {
+      "Id": "a8a8b28f-e841-4d8c-b083-aa15e7b499a9",
+      "ConcordiaCourseId": "050778"
+    },
+    {
+      "Id": "258332c0-8822-4a98-a6e2-31de8677a919",
+      "ConcordiaCourseId": "050779"
+    },
+    {
+      "Id": "3873f5ae-1ef0-44d5-94a3-e83634ef8409",
+      "ConcordiaCourseId": "050780"
+    },
+    {
+      "Id": "78675563-9e25-4346-a1da-ac1acbe3080c",
+      "ConcordiaCourseId": "050781"
+    },
+    {
+      "Id": "a56490f8-70cf-4475-8591-235e8784f72e",
+      "ConcordiaCourseId": "050782"
+    },
+    {
+      "Id": "31248239-4bbf-4cd3-89d6-8d169376a651",
+      "ConcordiaCourseId": "050783"
+    },
+    {
+      "Id": "31f28db0-2b97-4b43-80f1-5e50176b2740",
+      "ConcordiaCourseId": "050784"
+    },
+    {
+      "Id": "3a5673a7-896b-423c-b4b8-2bed12e2b62a",
+      "ConcordiaCourseId": "050785"
+    },
+    {
+      "Id": "276a8c97-097b-46d5-9365-94731d4c26e0",
+      "ConcordiaCourseId": "050786"
+    },
+    {
+      "Id": "c21e6358-0a58-4728-bf3d-6fcab9f221a0",
+      "ConcordiaCourseId": "050787"
+    },
+    {
+      "Id": "26a49cf4-bda2-49e7-a304-9411bdb9c53d",
+      "ConcordiaCourseId": "050798"
+    },
+    {
+      "Id": "87958b7a-328e-4e7d-9682-749d8561d1d3",
+      "ConcordiaCourseId": "050831"
+    },
+    {
+      "Id": "e7111251-81d4-4ab9-82ed-476a7e3f294a",
+      "ConcordiaCourseId": "050832"
+    },
+    {
+      "Id": "cdb1094c-d298-4eaa-ac2e-6a19eaceb9ff",
+      "ConcordiaCourseId": "036489"
+    },
+    {
+      "Id": "5b262015-7773-4902-9194-8a44b69e39e5",
+      "ConcordiaCourseId": "036498"
+    },
+    {
+      "Id": "79bbecf1-8716-4c16-b3c0-e41b0f68d9e5",
+      "ConcordiaCourseId": "036519"
+    },
+    {
+      "Id": "e13b1400-75dc-439f-a37a-d6b2b5d857bf",
+      "ConcordiaCourseId": "036521"
+    },
+    {
+      "Id": "4902bbfe-1480-4d18-ba5b-690b3364b9be",
+      "ConcordiaCourseId": "045025"
+    },
+    {
+      "Id": "371505db-b56a-420e-ad0b-b1191e22ba2e",
+      "ConcordiaCourseId": "048494"
+    },
+    {
+      "Id": "816c7d6e-e4fc-4eea-be8f-9efcaea0a500",
+      "ConcordiaCourseId": "049538"
+    },
+    {
+      "Id": "05761071-49d1-49ce-a16f-21a81e841eb1",
+      "ConcordiaCourseId": "049759"
+    },
+    {
+      "Id": "2cc01561-55b8-4c3a-9da2-960e109c30a6",
+      "ConcordiaCourseId": "049760"
+    },
+    {
+      "Id": "62af801a-2c74-4792-be5f-4038e4752bd7",
+      "ConcordiaCourseId": "049761"
+    },
+    {
+      "Id": "b009b1dd-5f3b-4042-911e-6e44126c114e",
+      "ConcordiaCourseId": "049764"
+    },
+    {
+      "Id": "06926cdc-08f9-4fb8-adc5-253c50f282f5",
+      "ConcordiaCourseId": "049765"
+    },
+    {
+      "Id": "6c9d02e4-5698-4dc1-9e83-fc86be5378bd",
+      "ConcordiaCourseId": "049766"
+    },
+    {
+      "Id": "45823e11-fd4d-4899-b61c-21a39524d225",
+      "ConcordiaCourseId": "049767"
+    },
+    {
+      "Id": "57edf651-4156-4562-a1b7-a99c72a1d25d",
+      "ConcordiaCourseId": "049768"
+    },
+    {
+      "Id": "4b4415d8-88a3-42d9-b0a3-ce46bc4da906",
+      "ConcordiaCourseId": "049770"
+    },
+    {
+      "Id": "34d0efef-7d8c-430f-8343-605402edb595",
+      "ConcordiaCourseId": "049771"
+    },
+    {
+      "Id": "08668b48-85af-4124-8a12-6762f7731938",
+      "ConcordiaCourseId": "049774"
+    },
+    {
+      "Id": "991090c4-8a4e-4f1e-b888-1629ecf2ecc4",
+      "ConcordiaCourseId": "049776"
+    },
+    {
+      "Id": "5ae1ce88-034f-478a-82b1-fe73dfc61bc5",
+      "ConcordiaCourseId": "049778"
+    },
+    {
+      "Id": "a99360a5-c45d-453b-9f80-c21c4420bfda",
+      "ConcordiaCourseId": "049779"
+    },
+    {
+      "Id": "2abca07b-4e1f-464e-b7be-e40edea46734",
+      "ConcordiaCourseId": "049780"
+    },
+    {
+      "Id": "55b9f2b0-aa70-40b9-a075-d533ae6baadc",
+      "ConcordiaCourseId": "049781"
+    },
+    {
+      "Id": "b619cd9e-844f-4756-bc71-eb04b44a0656",
+      "ConcordiaCourseId": "049782"
+    },
+    {
+      "Id": "fe14f283-3c8c-4e77-b83c-cb17de31236a",
+      "ConcordiaCourseId": "049783"
+    },
+    {
+      "Id": "b0ccf141-4a52-408e-91da-4d1dceb7078d",
+      "ConcordiaCourseId": "049785"
+    },
+    {
+      "Id": "ba3ebbe9-9271-4067-b178-58cfd02b99bb",
+      "ConcordiaCourseId": "049786"
+    },
+    {
+      "Id": "dfab140a-3ac2-4a97-b7d8-7b554d450046",
+      "ConcordiaCourseId": "049787"
+    },
+    {
+      "Id": "fb09f7c1-0f50-4b6a-89c2-3a8d6809f435",
+      "ConcordiaCourseId": "049791"
+    },
+    {
+      "Id": "cd30a3dc-d766-47e5-8522-beb7bfe03f89",
+      "ConcordiaCourseId": "049792"
+    },
+    {
+      "Id": "ce597d9c-814a-48d1-8a24-4ed147906d9d",
+      "ConcordiaCourseId": "049793"
+    },
+    {
+      "Id": "7ae05a92-8f19-4339-9879-def71aa2bc84",
+      "ConcordiaCourseId": "049804"
+    },
+    {
+      "Id": "965a54e5-a7c7-459c-a4ce-b11415f0f8bd",
+      "ConcordiaCourseId": "049808"
+    },
+    {
+      "Id": "15e827c5-04b2-4982-858d-c4e6068b2a1f",
+      "ConcordiaCourseId": "049812"
+    },
+    {
+      "Id": "317f5aa9-c41d-442c-bce3-e3b263074a00",
+      "ConcordiaCourseId": "049813"
+    },
+    {
+      "Id": "d7f0f55c-11cd-41a8-a004-f9a973fde233",
+      "ConcordiaCourseId": "049814"
+    },
+    {
+      "Id": "871e29d2-ce98-44de-92eb-3332b6875f94",
+      "ConcordiaCourseId": "049860"
+    },
+    {
+      "Id": "94fcacff-5579-4df2-8ffa-74041eb44336",
+      "ConcordiaCourseId": "049861"
+    },
+    {
+      "Id": "377b17a6-e219-49b0-9d0e-dfdc17f2ca86",
+      "ConcordiaCourseId": "049863"
+    },
+    {
+      "Id": "4e7fe8ce-0bcc-448a-82af-b2fb901b05eb",
+      "ConcordiaCourseId": "049946"
+    },
+    {
+      "Id": "f7b43a23-6ca4-4413-93f1-48f2dd38a2db",
+      "ConcordiaCourseId": "049947"
+    },
+    {
+      "Id": "b3e6a661-e9dd-4e6e-8a67-d7d8a20a8460",
+      "ConcordiaCourseId": "049948"
+    },
+    {
+      "Id": "f3a92c29-3571-4141-a93e-04ec4795facc",
+      "ConcordiaCourseId": "049949"
+    },
+    {
+      "Id": "d374cfdc-d549-4d5a-8157-19d2b2d9fedd",
+      "ConcordiaCourseId": "050135"
+    },
+    {
+      "Id": "df19c0b8-4505-40d6-b579-b4196b443392",
+      "ConcordiaCourseId": "050137"
+    },
+    {
+      "Id": "44689aa9-eefd-4582-b8cd-a559c8d8bdc1",
+      "ConcordiaCourseId": "050199"
+    },
+    {
+      "Id": "238b2723-588d-4002-a0c7-09e17782aa70",
+      "ConcordiaCourseId": "050214"
+    },
+    {
+      "Id": "a34c2c35-9fac-4b38-81d2-26c6b186d1ba",
+      "ConcordiaCourseId": "050484"
+    },
+    {
+      "Id": "a1d1c631-3fb6-46f4-86c4-659a994d1423",
+      "ConcordiaCourseId": "050489"
+    },
+    {
+      "Id": "eef4dd7f-4a70-4321-b669-9d3b0cd21ab6",
+      "ConcordiaCourseId": "050494"
+    },
+    {
+      "Id": "333f1cdb-4f30-41b6-a272-f3a5cee52ad2",
+      "ConcordiaCourseId": "050495"
+    },
+    {
+      "Id": "2729c6cc-2369-451d-b503-648d1f204d19",
+      "ConcordiaCourseId": "050496"
+    },
+    {
+      "Id": "a5f889c0-9586-4ace-9d31-c9ff4f2ce2a2",
+      "ConcordiaCourseId": "050497"
+    },
+    {
+      "Id": "618f67e9-74bd-4641-a3fd-caac99d06a79",
+      "ConcordiaCourseId": "050498"
+    },
+    {
+      "Id": "02458002-e1b5-4205-8086-2b18e0e0bd86",
+      "ConcordiaCourseId": "050587"
+    },
+    {
+      "Id": "cda08cdd-f2ef-4ab8-a57a-11547160812f",
+      "ConcordiaCourseId": "050799"
+    },
+    {
+      "Id": "f2e56104-d148-483a-aee7-19ba10060ee2",
+      "ConcordiaCourseId": "050839"
+    },
+    {
+      "Id": "72e9873a-d9dd-4a57-8d6d-6c321624a77e",
+      "ConcordiaCourseId": "050840"
+    },
+    {
+      "Id": "1a46f053-6f0c-498e-a3d5-470b937ffbec",
+      "ConcordiaCourseId": "050841"
+    },
+    {
+      "Id": "bb5e34d8-e495-42c3-a272-adf3f7b17195",
+      "ConcordiaCourseId": "003738"
+    },
+    {
+      "Id": "a4840ff4-02ae-4747-89dc-5772ae914a78",
+      "ConcordiaCourseId": "003739"
+    },
+    {
+      "Id": "ec17ede9-5423-4c35-af62-ca32eea36ede",
+      "ConcordiaCourseId": "003748"
+    },
+    {
+      "Id": "8ff4b447-8d1d-4a49-98d7-72d8bb73ba25",
+      "ConcordiaCourseId": "003749"
+    },
+    {
+      "Id": "194e51f2-8816-4212-b0fe-85751d292462",
+      "ConcordiaCourseId": "003750"
+    },
+    {
+      "Id": "692f20f8-a61d-4b91-ad7e-87452674ac44",
+      "ConcordiaCourseId": "003751"
+    },
+    {
+      "Id": "3745cc70-1416-4b89-9d80-aa56a0b2628d",
+      "ConcordiaCourseId": "046548"
+    },
+    {
+      "Id": "dfdd1887-d3ee-409a-b82c-1544e0ef5a9b",
+      "ConcordiaCourseId": "046549"
+    },
+    {
+      "Id": "b235ba39-55cd-4636-bdef-1c0582b950a7",
+      "ConcordiaCourseId": "046550"
+    },
+    {
+      "Id": "bc71194c-f454-4f0a-9312-e8d3dc484a6f",
+      "ConcordiaCourseId": "049680"
+    },
+    {
+      "Id": "3d8fc9fb-30f8-4701-a7d7-5965787ccf3e",
+      "ConcordiaCourseId": "049681"
+    },
+    {
+      "Id": "b2ddcbfc-5ab0-4994-b8a4-c861d09238fe",
+      "ConcordiaCourseId": "049682"
+    },
+    {
+      "Id": "7cdff88b-d143-42a3-bb36-8dffffdf4e14",
+      "ConcordiaCourseId": "049684"
+    },
+    {
+      "Id": "a8567b11-6f57-40e0-998f-8e2519069eb0",
+      "ConcordiaCourseId": "036534"
+    },
+    {
+      "Id": "b756304c-6388-429b-b6e0-7ab9177da4ae",
+      "ConcordiaCourseId": "036536"
+    },
+    {
+      "Id": "1be7a096-9122-43f1-a10b-2d6255f4d1bc",
+      "ConcordiaCourseId": "036538"
+    },
+    {
+      "Id": "43d54e80-5bfb-4024-a4a3-afcab27ebed1",
+      "ConcordiaCourseId": "036540"
+    },
+    {
+      "Id": "ccf4d95c-d06a-41b8-a24c-47cb9710c046",
+      "ConcordiaCourseId": "036542"
+    },
+    {
+      "Id": "1932ed63-d6fa-4446-a11f-2ca96764b9a5",
+      "ConcordiaCourseId": "036605"
+    },
+    {
+      "Id": "16ba4ba9-d0ed-4131-b1e7-c31112e4673e",
+      "ConcordiaCourseId": "036608"
+    },
+    {
+      "Id": "58cef3a2-1873-41f8-9b33-309404d29f6f",
+      "ConcordiaCourseId": "036612"
+    },
+    {
+      "Id": "31910b67-69f0-4a36-80c3-3ef6abad892a",
+      "ConcordiaCourseId": "036613"
+    },
+    {
+      "Id": "876767ab-76ee-4e91-851d-f009dd9f0a51",
+      "ConcordiaCourseId": "036614"
+    },
+    {
+      "Id": "91b92067-25a9-4fae-8f96-105c300d36fe",
+      "ConcordiaCourseId": "050657"
+    },
+    {
+      "Id": "e4c24aa4-7048-4e15-bddc-3c1cf785a07e",
+      "ConcordiaCourseId": "050658"
+    },
+    {
+      "Id": "e4019217-169a-414d-b85c-07c6e93560f1",
+      "ConcordiaCourseId": "050659"
+    },
+    {
+      "Id": "42f95727-6b51-43e4-b9c4-5c58e479d1b8",
+      "ConcordiaCourseId": "036619"
+    },
+    {
+      "Id": "45667cd2-79d5-4fea-b4d8-2591aa44bc6d",
+      "ConcordiaCourseId": "036622"
+    },
+    {
+      "Id": "9a3b4931-6309-498c-9e77-fd1cf5c6ee2d",
+      "ConcordiaCourseId": "036628"
+    },
+    {
+      "Id": "a54c59c1-fb2c-4ae9-b08e-5773219e1600",
+      "ConcordiaCourseId": "036629"
+    },
+    {
+      "Id": "efc6edc6-a9a0-4c5b-855c-65d92782fc20",
+      "ConcordiaCourseId": "048177"
+    },
+    {
+      "Id": "9a6e2419-4613-452c-9a30-3840deea898b",
+      "ConcordiaCourseId": "048179"
+    },
+    {
+      "Id": "d2f58045-223d-4a45-b570-0dc00039d648",
+      "ConcordiaCourseId": "048469"
+    },
+    {
+      "Id": "21decd62-b533-4a1f-a7dd-e36167eefe32",
+      "ConcordiaCourseId": "048563"
+    },
+    {
+      "Id": "cad1a0da-fefb-4c08-b366-9fd82cd9f2fc",
+      "ConcordiaCourseId": "049317"
+    },
+    {
+      "Id": "ea694b9b-ba6d-4354-b418-8108653d11ec",
+      "ConcordiaCourseId": "049502"
+    },
+    {
+      "Id": "92a67434-f5b5-4613-8712-3dc32a1e16a9",
+      "ConcordiaCourseId": "050334"
+    },
+    {
+      "Id": "1b05327f-2ebb-4975-9284-4f53ffe26174",
+      "ConcordiaCourseId": "050335"
+    },
+    {
+      "Id": "881dd040-42a9-4f17-9220-e23c480cadda",
+      "ConcordiaCourseId": "050453"
+    },
+    {
+      "Id": "cffeda3c-bc2a-44c8-b39e-2ed6e1d09645",
+      "ConcordiaCourseId": "050650"
+    },
+    {
+      "Id": "9bc7561b-3ab1-4159-8b23-5dc26153f7ba",
+      "ConcordiaCourseId": "003793"
+    },
+    {
+      "Id": "92e9877c-5add-4d27-9cf4-2b27e3de7738",
+      "ConcordiaCourseId": "003794"
+    },
+    {
+      "Id": "c19e032d-523a-4c29-b60d-8e612a17c1f8",
+      "ConcordiaCourseId": "003795"
+    },
+    {
+      "Id": "c29edbb4-8dbc-4c33-80c6-ee848dd4575f",
+      "ConcordiaCourseId": "003796"
+    },
+    {
+      "Id": "08a4d608-c07d-4a65-99f6-17e7e63afc43",
+      "ConcordiaCourseId": "003801"
+    },
+    {
+      "Id": "aa0d41c5-fe07-44ba-93c9-1eb412385f6c",
+      "ConcordiaCourseId": "003804"
+    },
+    {
+      "Id": "cf036b90-bb7a-4f5d-a734-c13d8c3f2be6",
+      "ConcordiaCourseId": "003805"
+    },
+    {
+      "Id": "bdf22765-c236-4295-9fe1-7eace3a7968f",
+      "ConcordiaCourseId": "003806"
+    },
+    {
+      "Id": "40fe90e5-ba1c-4b9e-885f-d7a7cd470c3b",
+      "ConcordiaCourseId": "003810"
+    },
+    {
+      "Id": "77331176-fa89-4a1a-a91e-7d0348f53af0",
+      "ConcordiaCourseId": "003819"
+    },
+    {
+      "Id": "9b3be4b6-51bd-4c90-a940-ca1bd428142c",
+      "ConcordiaCourseId": "003820"
+    },
+    {
+      "Id": "d4b244d0-5a62-43a0-afba-0dc2e28ae8da",
+      "ConcordiaCourseId": "003823"
+    },
+    {
+      "Id": "f65d90ed-4715-4d08-93b4-43200435228a",
+      "ConcordiaCourseId": "003824"
+    },
+    {
+      "Id": "0998ee39-aa80-4e35-9423-254b90ae6122",
+      "ConcordiaCourseId": "003827"
+    },
+    {
+      "Id": "fb95490f-539b-4786-8af8-1aea275ca2b7",
+      "ConcordiaCourseId": "003835"
+    },
+    {
+      "Id": "8ac91aa0-4a86-44e0-b392-23c94382b7bd",
+      "ConcordiaCourseId": "003851"
+    },
+    {
+      "Id": "ec80f299-9a4d-43ee-b244-ebac1c55b6e4",
+      "ConcordiaCourseId": "003853"
+    },
+    {
+      "Id": "6c1af649-c318-4406-880a-25e13b0a08ff",
+      "ConcordiaCourseId": "003868"
+    },
+    {
+      "Id": "d6f083df-01fa-4fbc-8375-150f8c179ffc",
+      "ConcordiaCourseId": "003870"
+    },
+    {
+      "Id": "a92630a7-63f6-41a2-a0a5-fe024d9ef9f6",
+      "ConcordiaCourseId": "003879"
+    },
+    {
+      "Id": "85e06ba2-2f20-48e9-b2d1-888244cc9382",
+      "ConcordiaCourseId": "003888"
+    },
+    {
+      "Id": "692ca5a9-f361-43ce-8d99-b50e8c723c5f",
+      "ConcordiaCourseId": "003890"
+    },
+    {
+      "Id": "0893ac27-7021-42eb-8239-5c842ffd75b8",
+      "ConcordiaCourseId": "003897"
+    },
+    {
+      "Id": "25b1a045-e172-4e0b-aa41-bb39632cf2a9",
+      "ConcordiaCourseId": "003905"
+    },
+    {
+      "Id": "6a64a1f0-4149-4c74-9745-c55d15d638d0",
+      "ConcordiaCourseId": "003910"
+    },
+    {
+      "Id": "244f17d3-c4b9-437d-b3ba-3ce9d3f54fa8",
+      "ConcordiaCourseId": "003912"
+    },
+    {
+      "Id": "00ed6fe7-1a54-4faf-8a80-b47159f3d8bf",
+      "ConcordiaCourseId": "003915"
+    },
+    {
+      "Id": "ead65d16-69bb-44bf-b86a-63c29cee30fa",
+      "ConcordiaCourseId": "003917"
+    },
+    {
+      "Id": "10662320-7171-42c5-8331-5f5eb380966d",
+      "ConcordiaCourseId": "003918"
+    },
+    {
+      "Id": "d6ad9ee7-a4c5-4fe9-932a-6fc632a9e769",
+      "ConcordiaCourseId": "003921"
+    },
+    {
+      "Id": "1271b401-8a1a-4dd7-b6ef-5cd7b1db57f7",
+      "ConcordiaCourseId": "003922"
+    },
+    {
+      "Id": "12e271ac-4ded-441d-a4ca-945f625de23d",
+      "ConcordiaCourseId": "003926"
+    },
+    {
+      "Id": "50ecb927-2e77-455c-ba44-1d598cee9cd6",
+      "ConcordiaCourseId": "003927"
+    },
+    {
+      "Id": "fe5a5907-296c-40f2-acf7-4c2e9a280dd4",
+      "ConcordiaCourseId": "003928"
+    },
+    {
+      "Id": "6a7a20f3-7788-499c-ab76-632fb2538bae",
+      "ConcordiaCourseId": "003938"
+    },
+    {
+      "Id": "f9bf48a8-3636-4587-9cbf-af17b6f724ba",
+      "ConcordiaCourseId": "003943"
+    },
+    {
+      "Id": "07178322-f8b7-4ff7-902c-aa8652519d1d",
+      "ConcordiaCourseId": "003951"
+    },
+    {
+      "Id": "bf259032-4968-4a36-9eea-20862771f24f",
+      "ConcordiaCourseId": "003954"
+    },
+    {
+      "Id": "317a7727-3308-426b-9403-7748aecded27",
+      "ConcordiaCourseId": "003955"
+    },
+    {
+      "Id": "5010a52b-07d8-4f39-b3fa-f12d448d116c",
+      "ConcordiaCourseId": "003958"
+    },
+    {
+      "Id": "c6770cd1-a1dd-4768-8580-c370cce67eac",
+      "ConcordiaCourseId": "003964"
+    },
+    {
+      "Id": "109fbde9-d0ca-4910-a503-decebd0d38d7",
+      "ConcordiaCourseId": "003965"
+    },
+    {
+      "Id": "e634182b-9b85-4387-8065-afbb0e0431b7",
+      "ConcordiaCourseId": "003966"
+    },
+    {
+      "Id": "2321f7aa-437d-4d72-ba82-2f1cd50281ca",
+      "ConcordiaCourseId": "003967"
+    },
+    {
+      "Id": "d67927f7-da1c-4e24-9f8d-8c619b65ff93",
+      "ConcordiaCourseId": "003968"
+    },
+    {
+      "Id": "2fe2e523-ca06-4c6d-8e55-d7de27903fc0",
+      "ConcordiaCourseId": "003969"
+    },
+    {
+      "Id": "9223348e-873b-4535-a780-33949dd3ebb9",
+      "ConcordiaCourseId": "003970"
+    },
+    {
+      "Id": "d2a79879-d473-41ce-b192-79920dc02fac",
+      "ConcordiaCourseId": "003971"
+    },
+    {
+      "Id": "b6cb426b-4a07-4521-ad5f-411639ca5583",
+      "ConcordiaCourseId": "003974"
+    },
+    {
+      "Id": "82b7dc91-96be-431f-9db1-cb530a899675",
+      "ConcordiaCourseId": "003982"
+    },
+    {
+      "Id": "b8bdca6b-bfea-4cf9-9af4-e2ebbbfc29ac",
+      "ConcordiaCourseId": "003983"
+    },
+    {
+      "Id": "dbe84fab-2e54-43ad-98aa-118abc0f444d",
+      "ConcordiaCourseId": "004025"
+    },
+    {
+      "Id": "0503bb45-1326-4313-a17e-1186a86878d6",
+      "ConcordiaCourseId": "004031"
+    },
+    {
+      "Id": "bc74aef4-f22c-4173-95cc-b58955109581",
+      "ConcordiaCourseId": "004033"
+    },
+    {
+      "Id": "ac728372-32c3-470e-a91f-bf5e25d6776b",
+      "ConcordiaCourseId": "004049"
+    },
+    {
+      "Id": "2f15d886-7320-4b15-8e87-85077e3a3aa8",
+      "ConcordiaCourseId": "004052"
+    },
+    {
+      "Id": "e3d138e7-3421-46fc-a983-e8531b016f93",
+      "ConcordiaCourseId": "004054"
+    },
+    {
+      "Id": "b38828c5-2c88-4170-aa01-88be350003a6",
+      "ConcordiaCourseId": "004055"
+    },
+    {
+      "Id": "f0e04f4f-1e6d-4038-bb2b-05cd80c72720",
+      "ConcordiaCourseId": "004057"
+    },
+    {
+      "Id": "a2e51f37-550a-45d4-95e4-ca295d3d06d2",
+      "ConcordiaCourseId": "004059"
+    },
+    {
+      "Id": "a2380cc4-2b01-475c-8cbd-feb8983b1ddf",
+      "ConcordiaCourseId": "004061"
+    },
+    {
+      "Id": "7532daf4-1bd8-4cd3-9d56-725db4944faf",
+      "ConcordiaCourseId": "004066"
+    },
+    {
+      "Id": "daf98bc7-0a36-4b79-bbe3-9108f101bb0b",
+      "ConcordiaCourseId": "004068"
+    },
+    {
+      "Id": "a86e6e20-c3c7-4e08-a5e6-600a2b98df14",
+      "ConcordiaCourseId": "004070"
+    },
+    {
+      "Id": "ec7fb784-56f2-412f-82ca-c5d4b43c610b",
+      "ConcordiaCourseId": "004071"
+    },
+    {
+      "Id": "aafb87fb-cff6-4727-8b4d-d452fa4a51d5",
+      "ConcordiaCourseId": "004072"
+    },
+    {
+      "Id": "d22335b9-6db9-4246-9893-b58d9bb5a504",
+      "ConcordiaCourseId": "004074"
+    },
+    {
+      "Id": "debcc1e2-c017-4b52-b99d-d7b11c3180c3",
+      "ConcordiaCourseId": "004077"
+    },
+    {
+      "Id": "11a1104d-66bd-42b8-9597-8f98869f6acb",
+      "ConcordiaCourseId": "004078"
+    },
+    {
+      "Id": "9582c985-8777-43d8-b94e-2edb4b7f9f99",
+      "ConcordiaCourseId": "004085"
+    },
+    {
+      "Id": "9e57b117-a732-446e-a97e-94bcea735ab6",
+      "ConcordiaCourseId": "004088"
+    },
+    {
+      "Id": "0c8b64dc-274c-4cf0-aa48-7d65daee5694",
+      "ConcordiaCourseId": "004090"
+    },
+    {
+      "Id": "cf344dde-3adb-49b6-a2b9-132c62040350",
+      "ConcordiaCourseId": "004091"
+    },
+    {
+      "Id": "2cac5b27-45cf-449a-a822-e42ab926be42",
+      "ConcordiaCourseId": "004092"
+    },
+    {
+      "Id": "6fc0adb9-e790-4a07-9730-1d1b0ec939d0",
+      "ConcordiaCourseId": "004100"
+    },
+    {
+      "Id": "7a07c6fd-09e3-43e7-beb5-72fc16ea3824",
+      "ConcordiaCourseId": "004101"
+    },
+    {
+      "Id": "d7104e8e-398d-4709-9b97-c4af324fc361",
+      "ConcordiaCourseId": "004109"
+    },
+    {
+      "Id": "3d131a88-9b34-4426-b3cc-24624da8feda",
+      "ConcordiaCourseId": "004110"
+    },
+    {
+      "Id": "49797986-8d24-4599-8a11-a771ce1bc63c",
+      "ConcordiaCourseId": "004111"
+    },
+    {
+      "Id": "4b7876fb-02b6-4a87-a983-b48e32760431",
+      "ConcordiaCourseId": "004119"
+    },
+    {
+      "Id": "91423075-54d5-42f3-b5f9-2b832915b5ac",
+      "ConcordiaCourseId": "004120"
+    },
+    {
+      "Id": "81bf24d4-8324-447f-b855-4bda79bd6105",
+      "ConcordiaCourseId": "004125"
+    },
+    {
+      "Id": "b7fa069c-66e3-4704-9271-6b8539c008ed",
+      "ConcordiaCourseId": "004127"
+    },
+    {
+      "Id": "bf4ee808-3a88-4417-a02e-4c1eef18fd30",
+      "ConcordiaCourseId": "004137"
+    },
+    {
+      "Id": "e013fd2f-6f4d-46ed-bbc6-605e8464ab29",
+      "ConcordiaCourseId": "004139"
+    },
+    {
+      "Id": "cce4b5e3-905d-4ea9-a016-2b98f7d01db8",
+      "ConcordiaCourseId": "037615"
+    },
+    {
+      "Id": "a1381830-d0bb-49d8-a8a7-31ab2a6ec102",
+      "ConcordiaCourseId": "040252"
+    },
+    {
+      "Id": "396a510a-e15a-4cfc-9cf9-604300ee5a9e",
+      "ConcordiaCourseId": "040254"
+    },
+    {
+      "Id": "6215aef6-a60f-4266-820b-2c521358002d",
+      "ConcordiaCourseId": "040280"
+    },
+    {
+      "Id": "d5fcbce2-8346-4ea0-901f-f9b642241534",
+      "ConcordiaCourseId": "040281"
+    },
+    {
+      "Id": "280514be-6d00-4681-a0e8-943f101a87de",
+      "ConcordiaCourseId": "044017"
+    },
+    {
+      "Id": "275bbff3-848f-4fa8-83e6-69e9500e6520",
+      "ConcordiaCourseId": "046551"
+    },
+    {
+      "Id": "d8b0d775-fdfa-4c75-b2f1-d538054ab4d7",
+      "ConcordiaCourseId": "046552"
+    },
+    {
+      "Id": "696a611f-6467-4c84-8872-94e7c7add8d2",
+      "ConcordiaCourseId": "046553"
+    },
+    {
+      "Id": "0d9da8ab-0fad-42b5-9f05-3d47d1a52beb",
+      "ConcordiaCourseId": "046554"
+    },
+    {
+      "Id": "f3659724-a299-4cb8-9cbe-85b294af0cf0",
+      "ConcordiaCourseId": "046555"
+    },
+    {
+      "Id": "0520f2da-c6d6-4cec-ac91-e7cca4ae6d78",
+      "ConcordiaCourseId": "047418"
+    },
+    {
+      "Id": "f4a4d645-8fd0-4b26-80d7-ffb99fa76b3d",
+      "ConcordiaCourseId": "047737"
+    },
+    {
+      "Id": "2569acfa-2fcc-4c23-8be6-9ec2ae8dcc81",
+      "ConcordiaCourseId": "048412"
+    },
+    {
+      "Id": "8fe2dfa3-bd5d-4749-8a92-0ac5e6bd84f4",
+      "ConcordiaCourseId": "048422"
+    },
+    {
+      "Id": "b6e47f4a-560c-472f-8bc5-03f77389c4f5",
+      "ConcordiaCourseId": "048551"
+    },
+    {
+      "Id": "43bdf64a-060b-4dd3-a4cf-069b1e8b2504",
+      "ConcordiaCourseId": "048552"
+    },
+    {
+      "Id": "b8aa59e6-d53c-491f-b3d2-bc23193e79fa",
+      "ConcordiaCourseId": "050077"
+    },
+    {
+      "Id": "930a5e25-b223-4513-9b79-9a188aa18e9b",
+      "ConcordiaCourseId": "050670"
+    },
+    {
+      "Id": "639dac24-2ddf-4ee5-827b-0d548616f0b8",
+      "ConcordiaCourseId": "050741"
+    },
+    {
+      "Id": "56f49116-db2a-464d-a41b-0b346e6b1c42",
+      "ConcordiaCourseId": "050878"
+    },
+    {
+      "Id": "fea4de00-d47a-46e8-91f1-eb1abf50a3ae",
+      "ConcordiaCourseId": "048970"
+    },
+    {
+      "Id": "22af5d4f-9dd4-4677-84f4-2cf3252f32be",
+      "ConcordiaCourseId": "048971"
+    },
+    {
+      "Id": "ef9e7563-2141-4335-8f51-767642fc67aa",
+      "ConcordiaCourseId": "048972"
+    },
+    {
+      "Id": "7e4df1db-5d84-48e2-b0a3-ea05f96b212a",
+      "ConcordiaCourseId": "048973"
+    },
+    {
+      "Id": "d7cbb9df-e13e-46d0-b32c-2c3f1098316a",
+      "ConcordiaCourseId": "048974"
+    },
+    {
+      "Id": "d53740ab-fe80-4bb3-8e95-67db486c6ded",
+      "ConcordiaCourseId": "048975"
+    },
+    {
+      "Id": "898108f8-6562-45d1-945f-6631cffa80be",
+      "ConcordiaCourseId": "048977"
+    },
+    {
+      "Id": "2425f4aa-72bc-49ac-a508-83f4baabe214",
+      "ConcordiaCourseId": "049223"
+    },
+    {
+      "Id": "ea4f3a4e-a4da-4818-a147-ed3b40e6b59d",
+      "ConcordiaCourseId": "049224"
+    },
+    {
+      "Id": "638e4600-09fb-44cb-8daa-9eb9db8bda0d",
+      "ConcordiaCourseId": "049225"
+    },
+    {
+      "Id": "f7833aa8-7f70-4545-a73b-99f55fea5ba1",
+      "ConcordiaCourseId": "049709"
+    },
+    {
+      "Id": "f4da8547-8753-4e85-b5b1-8069ff7eb6b1",
+      "ConcordiaCourseId": "049849"
+    },
+    {
+      "Id": "bff48c43-4e36-480a-aaa8-6ba74cf64f3f",
+      "ConcordiaCourseId": "050003"
+    },
+    {
+      "Id": "e39fe1c4-ac0e-4408-9409-8370f783dd5f",
+      "ConcordiaCourseId": "050004"
+    },
+    {
+      "Id": "c3cc15f9-df20-4396-9949-1637869d8ceb",
+      "ConcordiaCourseId": "050058"
+    },
+    {
+      "Id": "e90808e0-6c28-4f7b-87dc-3da7c6642acb",
+      "ConcordiaCourseId": "050265"
+    },
+    {
+      "Id": "b6125198-8357-4272-aa5e-f2914eea9e73",
+      "ConcordiaCourseId": "004291"
+    },
+    {
+      "Id": "72cfd360-ee87-435a-a1f1-58c903ef09cf",
+      "ConcordiaCourseId": "004293"
+    },
+    {
+      "Id": "633f04ee-6645-4960-9f58-4605ae499c59",
+      "ConcordiaCourseId": "004295"
+    },
+    {
+      "Id": "5f6f1e64-b31c-4b8a-8692-0f0e9b6fbc95",
+      "ConcordiaCourseId": "004296"
+    },
+    {
+      "Id": "fb7bf835-c5dc-4ba4-8852-f04e52b29131",
+      "ConcordiaCourseId": "004299"
+    },
+    {
+      "Id": "cefadaa8-004a-454b-99ac-b8672d1f30ad",
+      "ConcordiaCourseId": "004301"
+    },
+    {
+      "Id": "cdcce327-d8da-4d3d-a6cd-eb4665556df2",
+      "ConcordiaCourseId": "004302"
+    },
+    {
+      "Id": "a65465ad-147c-4198-9c13-6db2b754da90",
+      "ConcordiaCourseId": "004303"
+    },
+    {
+      "Id": "08dfe297-b6b9-4ecb-a6f6-0bd25dd8c312",
+      "ConcordiaCourseId": "004317"
+    },
+    {
+      "Id": "b9437ffe-4fc6-4010-9471-7c70bc9ad7b5",
+      "ConcordiaCourseId": "004318"
+    },
+    {
+      "Id": "55be12b1-402c-4f32-a8a8-d24f495ebdbd",
+      "ConcordiaCourseId": "004346"
+    },
+    {
+      "Id": "3217e3f6-12e9-4eb9-bdeb-268207de7400",
+      "ConcordiaCourseId": "004347"
+    },
+    {
+      "Id": "42498a3d-1ff9-4380-b521-304ff82694a0",
+      "ConcordiaCourseId": "004348"
+    },
+    {
+      "Id": "9a71e826-5af8-415d-8a28-ca2a1bf9c681",
+      "ConcordiaCourseId": "004350"
+    },
+    {
+      "Id": "1a2642eb-0442-4831-b603-0c51d3c088ca",
+      "ConcordiaCourseId": "004351"
+    },
+    {
+      "Id": "d6c47e3d-a592-4d56-872f-e49d0f6572b4",
+      "ConcordiaCourseId": "004352"
+    },
+    {
+      "Id": "a458b702-5958-4a82-a69e-cdd30e1e6c1e",
+      "ConcordiaCourseId": "004353"
+    },
+    {
+      "Id": "74bf6acc-a491-4dfc-9349-b20b65aa168a",
+      "ConcordiaCourseId": "037621"
+    },
+    {
+      "Id": "13f65bfe-6996-4fcd-94d9-f280a358b2b9",
+      "ConcordiaCourseId": "037624"
+    },
+    {
+      "Id": "9f17e328-e70f-48f2-9764-f66ff9c69829",
+      "ConcordiaCourseId": "040291"
+    },
+    {
+      "Id": "ec0bdd97-dac6-46e6-af29-83d89f3b809e",
+      "ConcordiaCourseId": "040292"
+    },
+    {
+      "Id": "bb2656de-905e-4465-9284-560e3e0e4768",
+      "ConcordiaCourseId": "040300"
+    },
+    {
+      "Id": "2dccfd4c-df43-49d4-a94a-0f0563f65e8b",
+      "ConcordiaCourseId": "040301"
+    },
+    {
+      "Id": "0cde51d2-e947-40b9-ade0-d55da6054315",
+      "ConcordiaCourseId": "045238"
+    },
+    {
+      "Id": "c6dde9ef-9e70-495f-b696-91b2a7d127aa",
+      "ConcordiaCourseId": "046556"
+    },
+    {
+      "Id": "1cad4f7d-8c01-4c00-8989-6d598a0a9a10",
+      "ConcordiaCourseId": "046557"
+    },
+    {
+      "Id": "e73a8a5c-1de9-4057-a345-43d91460d869",
+      "ConcordiaCourseId": "046558"
+    },
+    {
+      "Id": "8d92a298-e362-42ba-88a2-48f4db5258c0",
+      "ConcordiaCourseId": "046559"
+    },
+    {
+      "Id": "15914f49-6aac-4e2c-8c77-a61024a587c7",
+      "ConcordiaCourseId": "046560"
+    },
+    {
+      "Id": "5436b34d-8880-4d89-9300-f95dca76bf87",
+      "ConcordiaCourseId": "047422"
+    },
+    {
+      "Id": "5a9bc252-6ccd-4eb2-935f-683e5e2f7a1f",
+      "ConcordiaCourseId": "050820"
+    },
+    {
+      "Id": "ef0b2c7d-d1fd-43aa-b65b-8a212fcd1df3",
+      "ConcordiaCourseId": "050821"
+    },
+    {
+      "Id": "9fafb6e8-89a3-41e9-abfa-b8e6e88540a8",
+      "ConcordiaCourseId": "050822"
+    },
+    {
+      "Id": "4b25dc1a-786b-4954-9dc7-033eaae5a837",
+      "ConcordiaCourseId": "050823"
+    },
+    {
+      "Id": "f12e6e0a-034b-45cc-bbb1-f23247137e42",
+      "ConcordiaCourseId": "004370"
+    },
+    {
+      "Id": "1b517267-7fa3-474d-98a4-ef24a8c43ddd",
+      "ConcordiaCourseId": "004371"
+    },
+    {
+      "Id": "30073ebc-6f6c-46bb-8482-eb05d17aa4b3",
+      "ConcordiaCourseId": "046561"
+    },
+    {
+      "Id": "868a6f64-b07f-4735-b47b-ae0001a71e08",
+      "ConcordiaCourseId": "046562"
+    },
+    {
+      "Id": "1d5871a9-4d25-4daa-8779-cdba457b77b0",
+      "ConcordiaCourseId": "046563"
+    },
+    {
+      "Id": "c911723a-10cf-40b2-90f0-2997a43a01a6",
+      "ConcordiaCourseId": "004421"
+    },
+    {
+      "Id": "463ed117-0e52-48ed-b152-2495f8e47a17",
+      "ConcordiaCourseId": "004422"
+    },
+    {
+      "Id": "2fa9b184-7045-483a-948c-38c39abea20d",
+      "ConcordiaCourseId": "004426"
+    },
+    {
+      "Id": "6bd502ea-aaa0-4a03-87cb-22ad4a2eb047",
+      "ConcordiaCourseId": "004427"
+    },
+    {
+      "Id": "e443f638-3722-495e-88ff-5224b1d60d9a",
+      "ConcordiaCourseId": "004429"
+    },
+    {
+      "Id": "d12d1742-deff-484f-a0ad-f547df7c6942",
+      "ConcordiaCourseId": "004430"
+    },
+    {
+      "Id": "30920d59-479e-4ba2-8387-c655e12825a1",
+      "ConcordiaCourseId": "004431"
+    },
+    {
+      "Id": "7f65603d-9538-4355-8c89-782eb71abfe4",
+      "ConcordiaCourseId": "004432"
+    },
+    {
+      "Id": "2e0b8e91-4ecc-48cb-b25b-c32be50ceddb",
+      "ConcordiaCourseId": "004433"
+    },
+    {
+      "Id": "f4fe5a5d-9295-42e5-b253-34151e774bff",
+      "ConcordiaCourseId": "004436"
+    },
+    {
+      "Id": "640c1612-acfa-496e-bd8b-7f283c8bd287",
+      "ConcordiaCourseId": "004438"
+    },
+    {
+      "Id": "8f060dd0-f5ba-4eb3-913d-704baf670312",
+      "ConcordiaCourseId": "004440"
+    },
+    {
+      "Id": "5bf23999-c51c-4877-9648-4b1131838f4f",
+      "ConcordiaCourseId": "004444"
+    },
+    {
+      "Id": "95e00c68-310c-4750-b5b9-d55bac12bc53",
+      "ConcordiaCourseId": "004445"
+    },
+    {
+      "Id": "e599ce04-51e5-44b5-9cd4-91ea29f05705",
+      "ConcordiaCourseId": "004448"
+    },
+    {
+      "Id": "f17e05bd-2e7f-4432-a748-d31a8de32e9f",
+      "ConcordiaCourseId": "004449"
+    },
+    {
+      "Id": "00764629-ff63-45de-9702-203198d5a659",
+      "ConcordiaCourseId": "004450"
+    },
+    {
+      "Id": "3cffd96b-2e09-44ca-9ac3-c0877526e388",
+      "ConcordiaCourseId": "004451"
+    },
+    {
+      "Id": "07d1fb29-efd4-4769-9f3f-b9434445f953",
+      "ConcordiaCourseId": "004452"
+    },
+    {
+      "Id": "bab03238-de77-44c3-abbf-08c41270ab21",
+      "ConcordiaCourseId": "004453"
+    },
+    {
+      "Id": "97a0bde1-7748-40fa-a0a1-1c088ca33b9c",
+      "ConcordiaCourseId": "004454"
+    },
+    {
+      "Id": "89af60d8-6aca-4a48-9fa3-b1a188d04f61",
+      "ConcordiaCourseId": "004456"
+    },
+    {
+      "Id": "d0773d13-9abe-4bb5-891e-a1e92a47131f",
+      "ConcordiaCourseId": "004459"
+    },
+    {
+      "Id": "815ff0b0-7785-4a6b-a289-8c8944ca762f",
+      "ConcordiaCourseId": "004460"
+    },
+    {
+      "Id": "2c959e6e-be8c-4250-a35f-18a7e88acb24",
+      "ConcordiaCourseId": "004466"
+    },
+    {
+      "Id": "5d717086-98e1-4816-a487-94cdc6a51541",
+      "ConcordiaCourseId": "004480"
+    },
+    {
+      "Id": "241ee790-c8b0-43a9-9011-a5f170c51ed4",
+      "ConcordiaCourseId": "004482"
+    },
+    {
+      "Id": "35940ec5-6709-4d03-b167-0d0a65bbe2cd",
+      "ConcordiaCourseId": "004483"
+    },
+    {
+      "Id": "b3b89140-e4aa-481c-8a61-ec4b2ed5c5cf",
+      "ConcordiaCourseId": "004484"
+    },
+    {
+      "Id": "8f5049f9-a624-42c5-a679-1ef81d3b0e7d",
+      "ConcordiaCourseId": "004487"
+    },
+    {
+      "Id": "ff4e115d-7d9f-4e49-8fa2-a2044c3e5d74",
+      "ConcordiaCourseId": "004489"
+    },
+    {
+      "Id": "25792961-8b72-4d4e-9d3e-76feb2158c97",
+      "ConcordiaCourseId": "004494"
+    },
+    {
+      "Id": "1a7e0482-2534-4c69-b4c7-ec72a1f1aead",
+      "ConcordiaCourseId": "004496"
+    },
+    {
+      "Id": "4b79e665-a256-4ee8-b2ba-76b2f0826ffb",
+      "ConcordiaCourseId": "004498"
+    },
+    {
+      "Id": "f7192cc5-6061-4f1e-aefc-3600abbeaaa1",
+      "ConcordiaCourseId": "004502"
+    },
+    {
+      "Id": "f66bc077-bfdf-42a5-9a62-5cdcab79d54a",
+      "ConcordiaCourseId": "004503"
+    },
+    {
+      "Id": "2d447c9b-6fab-472e-b507-c45db19db4f3",
+      "ConcordiaCourseId": "004505"
+    },
+    {
+      "Id": "2126c470-8555-404d-ba86-1e45f13e55fa",
+      "ConcordiaCourseId": "004507"
+    },
+    {
+      "Id": "5e633370-5026-46da-a259-ffafec566255",
+      "ConcordiaCourseId": "004509"
+    },
+    {
+      "Id": "829945db-a31e-4220-b428-836640d1c1c8",
+      "ConcordiaCourseId": "004511"
+    },
+    {
+      "Id": "a7f7bdc5-ebbc-4026-84d6-8fd33e191d31",
+      "ConcordiaCourseId": "004513"
+    },
+    {
+      "Id": "e1b87316-9e1e-4816-84bb-b40e876e3ab3",
+      "ConcordiaCourseId": "004515"
+    },
+    {
+      "Id": "b9b66714-eed4-4e94-8499-9630daf48507",
+      "ConcordiaCourseId": "004517"
+    },
+    {
+      "Id": "01e95624-87fe-456c-bb72-56b74f5592d3",
+      "ConcordiaCourseId": "004519"
+    },
+    {
+      "Id": "ac8bd71e-4e91-4d3d-843c-1514f6aaf9ce",
+      "ConcordiaCourseId": "004521"
+    },
+    {
+      "Id": "ac3b26db-d94f-431b-bdb9-da34e7697626",
+      "ConcordiaCourseId": "004523"
+    },
+    {
+      "Id": "84f1a9bf-a37e-4fbc-8b35-17389c7035c8",
+      "ConcordiaCourseId": "004525"
+    },
+    {
+      "Id": "bdff0c3a-4b2e-48ee-8ef6-00e7c53543e6",
+      "ConcordiaCourseId": "004527"
+    },
+    {
+      "Id": "bcb99edb-86ec-4234-bb5e-09a3959c8936",
+      "ConcordiaCourseId": "004553"
+    },
+    {
+      "Id": "762e5a9e-70ce-4fc7-89ff-5eabc5bf69d0",
+      "ConcordiaCourseId": "004560"
+    },
+    {
+      "Id": "879a5f18-4bfb-4071-93fa-ce9eb2eedd1f",
+      "ConcordiaCourseId": "004571"
+    },
+    {
+      "Id": "bf56cdc0-1ac4-4c39-bd60-866fc4ddd06e",
+      "ConcordiaCourseId": "040305"
+    },
+    {
+      "Id": "b2ffdfdd-575d-491a-a74d-8ea7f00bd6b4",
+      "ConcordiaCourseId": "040306"
+    },
+    {
+      "Id": "73b2195c-cb0a-4a0d-8d7f-eafe8c7dd03e",
+      "ConcordiaCourseId": "040308"
+    },
+    {
+      "Id": "8db2a544-ebc0-4ea6-8c9c-1024d1d8b05e",
+      "ConcordiaCourseId": "040309"
+    },
+    {
+      "Id": "c25d38a3-f488-4098-9f7a-c12b37822b9a",
+      "ConcordiaCourseId": "045242"
+    },
+    {
+      "Id": "6170d0b2-b639-4016-b04c-df564c8f8af5",
+      "ConcordiaCourseId": "045929"
+    },
+    {
+      "Id": "61ff056f-8da1-4e13-b726-8389dd464a56",
+      "ConcordiaCourseId": "046564"
+    },
+    {
+      "Id": "9b972a6c-09fb-43c0-b974-39847839fe59",
+      "ConcordiaCourseId": "046565"
+    },
+    {
+      "Id": "0f917672-3a8d-45dd-8837-505862ffd316",
+      "ConcordiaCourseId": "046566"
+    },
+    {
+      "Id": "39f8e214-2c1b-4534-9fd1-d7fbea3c6521",
+      "ConcordiaCourseId": "046567"
+    },
+    {
+      "Id": "2ff0682a-ba41-4521-8373-34a999f991ba",
+      "ConcordiaCourseId": "047813"
+    },
+    {
+      "Id": "ddd356a1-6270-4d8a-a2bb-ae5cdaf070d1",
+      "ConcordiaCourseId": "047824"
+    },
+    {
+      "Id": "3e472a4c-064a-4d61-aeb3-622af51a390a",
+      "ConcordiaCourseId": "047962"
+    },
+    {
+      "Id": "b04192da-2519-4b3b-bf7d-6bdcd49bf817",
+      "ConcordiaCourseId": "047963"
+    },
+    {
+      "Id": "78162d28-5fd3-482b-8e1c-59f9ca5b587a",
+      "ConcordiaCourseId": "047964"
+    },
+    {
+      "Id": "0837780c-690c-4f74-99c0-9208d3addbaf",
+      "ConcordiaCourseId": "048388"
+    },
+    {
+      "Id": "b40e5a00-2775-4b66-85ce-d49c776f82af",
+      "ConcordiaCourseId": "049092"
+    },
+    {
+      "Id": "e53272b0-c25d-4358-bfd6-a21bc21c55b7",
+      "ConcordiaCourseId": "049130"
+    },
+    {
+      "Id": "ba06957b-7f28-42ed-9b7e-d9101ca136e6",
+      "ConcordiaCourseId": "049539"
+    },
+    {
+      "Id": "4213ccf4-cba3-42df-8f13-311dccf830f1",
+      "ConcordiaCourseId": "050171"
+    },
+    {
+      "Id": "fdaee097-bf2d-493c-b89b-c60876dc8097",
+      "ConcordiaCourseId": "050173"
+    },
+    {
+      "Id": "502b16f5-177b-4f74-9e9c-6f9e21581c43",
+      "ConcordiaCourseId": "050174"
+    },
+    {
+      "Id": "9f07335b-43de-4eb9-bafe-e72a02ad75bc",
+      "ConcordiaCourseId": "050175"
+    },
+    {
+      "Id": "f704fd25-2db5-4567-a967-9320bcd7af87",
+      "ConcordiaCourseId": "004704"
+    },
+    {
+      "Id": "910565ce-b89d-4f8f-8135-a1320fb8ef31",
+      "ConcordiaCourseId": "004705"
+    },
+    {
+      "Id": "d9c9c4b2-e543-4c9b-813f-807972cf4622",
+      "ConcordiaCourseId": "004709"
+    },
+    {
+      "Id": "6c57c467-ae67-4468-944d-1b7ff35749e5",
+      "ConcordiaCourseId": "004711"
+    },
+    {
+      "Id": "95d4f6a1-311a-4d46-a0f8-2b78db8fdf8a",
+      "ConcordiaCourseId": "004713"
+    },
+    {
+      "Id": "89675f61-a9b9-4747-bbbc-343a91a64ff9",
+      "ConcordiaCourseId": "004715"
+    },
+    {
+      "Id": "0fb55814-a55f-43a3-9048-011c33bb5331",
+      "ConcordiaCourseId": "004719"
+    },
+    {
+      "Id": "0e61a2fb-17ee-4895-8268-2df22ca24583",
+      "ConcordiaCourseId": "004720"
+    },
+    {
+      "Id": "4928507d-4246-4fdd-a33d-c12dd56c060d",
+      "ConcordiaCourseId": "004721"
+    },
+    {
+      "Id": "bba59b38-2212-4330-8a82-ce73998f5d2f",
+      "ConcordiaCourseId": "004722"
+    },
+    {
+      "Id": "a49b0f98-b846-4675-a3d0-e2aa76c16d85",
+      "ConcordiaCourseId": "004723"
+    },
+    {
+      "Id": "5f1e4ad5-61a1-4b47-bf2e-e74d0908eb0d",
+      "ConcordiaCourseId": "004724"
+    },
+    {
+      "Id": "a2c4984e-bff9-41f3-8f3f-2c8f90aa7b9d",
+      "ConcordiaCourseId": "004727"
+    },
+    {
+      "Id": "6047c70d-5858-41eb-8d5b-766b6c41fa74",
+      "ConcordiaCourseId": "004728"
+    },
+    {
+      "Id": "d3e0c596-90e7-40a2-9432-9bb3818a16b1",
+      "ConcordiaCourseId": "004739"
+    },
+    {
+      "Id": "a70d9a4f-74be-416f-b848-c8c4d165876c",
+      "ConcordiaCourseId": "004746"
+    },
+    {
+      "Id": "570d885d-36a6-41fd-9d4d-77ae1e5fe786",
+      "ConcordiaCourseId": "004753"
+    },
+    {
+      "Id": "b05b221a-d996-4616-8579-63b22a7b9c21",
+      "ConcordiaCourseId": "004754"
+    },
+    {
+      "Id": "56204625-4a6e-42e8-ba5b-25791744ea33",
+      "ConcordiaCourseId": "004757"
+    },
+    {
+      "Id": "d61112d8-7f4f-4fff-bd47-553e1506a2ac",
+      "ConcordiaCourseId": "004762"
+    },
+    {
+      "Id": "5933cc75-9ea8-4ce2-8a16-09dbdff7e9ff",
+      "ConcordiaCourseId": "004763"
+    },
+    {
+      "Id": "3b521696-3145-47b5-a787-7b25d1c342ef",
+      "ConcordiaCourseId": "004767"
+    },
+    {
+      "Id": "87887d33-95d4-4615-a99e-985d023e291b",
+      "ConcordiaCourseId": "004768"
+    },
+    {
+      "Id": "a6bfa981-7259-42cb-a6aa-649b2bdc677d",
+      "ConcordiaCourseId": "004781"
+    },
+    {
+      "Id": "4b034df9-6b16-495b-b7f1-48f78622ac55",
+      "ConcordiaCourseId": "004782"
+    },
+    {
+      "Id": "052de100-94c2-40fc-b243-75a932a63c06",
+      "ConcordiaCourseId": "004790"
+    },
+    {
+      "Id": "56fddc94-4d93-4549-9c1b-38a8b5e5033e",
+      "ConcordiaCourseId": "004791"
+    },
+    {
+      "Id": "b517fb88-94ce-4616-9ea3-ebb4061e194e",
+      "ConcordiaCourseId": "004816"
+    },
+    {
+      "Id": "cbbc4610-ca1b-4480-a050-d0efbea891ab",
+      "ConcordiaCourseId": "004827"
+    },
+    {
+      "Id": "9cb44ad3-4c0c-40e6-890f-f9f031574065",
+      "ConcordiaCourseId": "004838"
+    },
+    {
+      "Id": "0f7f7126-0c09-42eb-ae1c-a449ebd2b004",
+      "ConcordiaCourseId": "004847"
+    },
+    {
+      "Id": "4f125028-80f3-41d7-871c-f6054097918e",
+      "ConcordiaCourseId": "004865"
+    },
+    {
+      "Id": "2c4bc687-750d-4819-98c2-b4aa3997acb6",
+      "ConcordiaCourseId": "004868"
+    },
+    {
+      "Id": "8ea965a9-6741-47de-9456-67d605574ca1",
+      "ConcordiaCourseId": "004869"
+    },
+    {
+      "Id": "1eb381a8-b77e-4ff6-be94-4d543f8ee692",
+      "ConcordiaCourseId": "004871"
+    },
+    {
+      "Id": "acd50bb7-3a24-446a-bb34-f1e38b01ffa9",
+      "ConcordiaCourseId": "004881"
+    },
+    {
+      "Id": "976cf445-21f6-4b66-a11b-be9720f0e975",
+      "ConcordiaCourseId": "004886"
+    },
+    {
+      "Id": "5785d670-d009-4875-b8e1-602c05be1bec",
+      "ConcordiaCourseId": "046568"
+    },
+    {
+      "Id": "9c2c7ccd-dacf-4117-9d40-6a5711e41b98",
+      "ConcordiaCourseId": "046569"
+    },
+    {
+      "Id": "d930d0e1-3eb4-4fac-afc5-9d89110c14e0",
+      "ConcordiaCourseId": "046570"
+    },
+    {
+      "Id": "b0344201-675c-4a6e-b578-d63337caf53a",
+      "ConcordiaCourseId": "046571"
+    },
+    {
+      "Id": "f0310e71-8041-4f18-ac47-40401e64ac49",
+      "ConcordiaCourseId": "046572"
+    },
+    {
+      "Id": "4ea4dcff-cfab-4c2c-9031-a72e418c3aef",
+      "ConcordiaCourseId": "046573"
+    },
+    {
+      "Id": "b6c39955-77e4-4792-8ebb-a0b6bd52d150",
+      "ConcordiaCourseId": "047231"
+    },
+    {
+      "Id": "e6cb5177-e3c8-4aa5-8924-bd8756601ebc",
+      "ConcordiaCourseId": "047232"
+    },
+    {
+      "Id": "2e213d29-bc2e-4422-bc63-22a356425cd1",
+      "ConcordiaCourseId": "047237"
+    },
+    {
+      "Id": "0d259954-e12d-4235-a7f9-75fd0f57bcbc",
+      "ConcordiaCourseId": "047238"
+    },
+    {
+      "Id": "6ec6d645-8bdb-4736-a060-4f4a5921610d",
+      "ConcordiaCourseId": "047239"
+    },
+    {
+      "Id": "0f26a659-5ad0-4904-a271-f8cb324245c7",
+      "ConcordiaCourseId": "047240"
+    },
+    {
+      "Id": "bbe53fe2-1f97-47c6-be72-0c9b00761172",
+      "ConcordiaCourseId": "048839"
+    },
+    {
+      "Id": "3f3a6046-1541-4960-ad53-d40f187b2c5f",
+      "ConcordiaCourseId": "048840"
+    },
+    {
+      "Id": "87a8c147-a2f3-4110-ad7d-300a57c4063a",
+      "ConcordiaCourseId": "048841"
+    },
+    {
+      "Id": "a362c1af-6e90-43f8-91b8-16ed3584ab35",
+      "ConcordiaCourseId": "048842"
+    },
+    {
+      "Id": "e2d6e061-8e5b-490f-8f58-d7de36423a0e",
+      "ConcordiaCourseId": "048843"
+    },
+    {
+      "Id": "5c0811dc-eda6-4e02-867c-5025032fe49e",
+      "ConcordiaCourseId": "046574"
+    },
+    {
+      "Id": "d672f323-0be9-414e-9b0b-cfcf104e487d",
+      "ConcordiaCourseId": "005054"
+    },
+    {
+      "Id": "064e56ad-930c-4369-9152-56f5101376e1",
+      "ConcordiaCourseId": "005055"
+    },
+    {
+      "Id": "559c2d94-55d9-40a9-bb69-9c3dffe61f57",
+      "ConcordiaCourseId": "005059"
+    },
+    {
+      "Id": "8799456a-4a61-4fc8-83f5-9d80bb1eb358",
+      "ConcordiaCourseId": "005060"
+    },
+    {
+      "Id": "6752ddde-c183-4aea-9816-6b5f04da15f6",
+      "ConcordiaCourseId": "005062"
+    },
+    {
+      "Id": "39367a01-aa9e-4e36-bd37-f01fe4244e88",
+      "ConcordiaCourseId": "005064"
+    },
+    {
+      "Id": "e27b3c1a-aac8-48bb-b1df-ad4912c08e1a",
+      "ConcordiaCourseId": "005065"
+    },
+    {
+      "Id": "1c52872f-89b8-4700-8f0e-785b6b14dc37",
+      "ConcordiaCourseId": "005066"
+    },
+    {
+      "Id": "1df29602-ffb4-4a82-98a4-db2cb10d838f",
+      "ConcordiaCourseId": "005067"
+    },
+    {
+      "Id": "74141479-3707-4f6a-9b11-7df30f95caf7",
+      "ConcordiaCourseId": "005068"
+    },
+    {
+      "Id": "652b787a-ee25-4f12-a526-0c0ece859028",
+      "ConcordiaCourseId": "005069"
+    },
+    {
+      "Id": "4424a19a-a652-42a1-9deb-720f4f6a6516",
+      "ConcordiaCourseId": "005070"
+    },
+    {
+      "Id": "a1b6a9d7-811a-49fd-a912-554b90d006f4",
+      "ConcordiaCourseId": "005071"
+    },
+    {
+      "Id": "048741ca-8744-4dea-b38e-5ee953ca0a9b",
+      "ConcordiaCourseId": "005072"
+    },
+    {
+      "Id": "51952803-321c-4e7f-97de-047c0a620ad6",
+      "ConcordiaCourseId": "005074"
+    },
+    {
+      "Id": "ab08ef62-8610-457f-8ecc-4f672f5eba27",
+      "ConcordiaCourseId": "005075"
+    },
+    {
+      "Id": "8342ee2f-e51d-417a-8f2b-a4485ed1ed13",
+      "ConcordiaCourseId": "005080"
+    },
+    {
+      "Id": "83988f4f-18fc-453a-9a71-9fbbff553a65",
+      "ConcordiaCourseId": "005082"
+    },
+    {
+      "Id": "67756e35-43b2-4f6a-950c-93a8c73945d0",
+      "ConcordiaCourseId": "005083"
+    },
+    {
+      "Id": "766dc9c1-4f42-4125-a421-346434a006e1",
+      "ConcordiaCourseId": "005084"
+    },
+    {
+      "Id": "73d314ab-d435-4e69-bba3-0e1a20738182",
+      "ConcordiaCourseId": "005086"
+    },
+    {
+      "Id": "789b91bc-466e-4ce3-a365-9dbe85bdc7f9",
+      "ConcordiaCourseId": "005095"
+    },
+    {
+      "Id": "bed6e81c-610a-43e8-8eeb-92c15d0c49c7",
+      "ConcordiaCourseId": "005096"
+    },
+    {
+      "Id": "d932e188-5d43-496f-bf31-4ce758cd8676",
+      "ConcordiaCourseId": "005097"
+    },
+    {
+      "Id": "76b90de5-a735-4283-b4b4-ebc396b50d85",
+      "ConcordiaCourseId": "005098"
+    },
+    {
+      "Id": "013a8935-bc0b-4920-82bd-4c3d7a5befd1",
+      "ConcordiaCourseId": "005099"
+    },
+    {
+      "Id": "90e1c350-25f2-4daa-9641-815e5f43b3cf",
+      "ConcordiaCourseId": "005100"
+    },
+    {
+      "Id": "8982f349-f3b8-40f7-9b07-cf17c4b632c8",
+      "ConcordiaCourseId": "005101"
+    },
+    {
+      "Id": "5019a18f-7a3e-4be1-834a-5994dbd9451e",
+      "ConcordiaCourseId": "005102"
+    },
+    {
+      "Id": "fd334d9e-142c-4717-a403-cadd575886bb",
+      "ConcordiaCourseId": "005103"
+    },
+    {
+      "Id": "1fac681b-9daf-46f8-acab-f3085ffe2854",
+      "ConcordiaCourseId": "005104"
+    },
+    {
+      "Id": "7017f9b9-5daf-4102-b78b-c5899ffaae31",
+      "ConcordiaCourseId": "005106"
+    },
+    {
+      "Id": "2d5ba63a-2682-46b4-a739-9995329bf6c9",
+      "ConcordiaCourseId": "005108"
+    },
+    {
+      "Id": "6e1f753b-cfdd-4265-b40e-4e754c667556",
+      "ConcordiaCourseId": "005115"
+    },
+    {
+      "Id": "e1b5cbc5-e76b-448e-bc89-71e5f6f9b79b",
+      "ConcordiaCourseId": "005117"
+    },
+    {
+      "Id": "8a707130-4a2d-458f-bc98-7b4c39f127ca",
+      "ConcordiaCourseId": "040325"
+    },
+    {
+      "Id": "48473bd4-f70c-46d0-a6e4-07403a5165d6",
+      "ConcordiaCourseId": "046575"
+    },
+    {
+      "Id": "9bddd05c-5bc1-465d-b488-fdc68c8e6715",
+      "ConcordiaCourseId": "046576"
+    },
+    {
+      "Id": "02bbb817-144f-4e3d-b8a6-91b1ff011685",
+      "ConcordiaCourseId": "047638"
+    },
+    {
+      "Id": "db5e412d-e364-497e-aa44-86ccd97f622c",
+      "ConcordiaCourseId": "048391"
+    },
+    {
+      "Id": "f0cd8e96-98c8-4dcb-be3e-06fcef06a7dc",
+      "ConcordiaCourseId": "048392"
+    },
+    {
+      "Id": "7a4db4bf-0c56-4f75-b36f-5dafb4cc2d31",
+      "ConcordiaCourseId": "048393"
+    },
+    {
+      "Id": "2c3ddab2-f3b7-4a67-b78b-70ff6258adda",
+      "ConcordiaCourseId": "048394"
+    },
+    {
+      "Id": "ca50a25d-12ac-438d-b052-2a522aa57f30",
+      "ConcordiaCourseId": "048395"
+    },
+    {
+      "Id": "630ba345-768d-41fe-9ded-5fd44c19219e",
+      "ConcordiaCourseId": "048396"
+    },
+    {
+      "Id": "1480299b-8694-44dd-bedc-a87316aeeaa6",
+      "ConcordiaCourseId": "048401"
+    },
+    {
+      "Id": "86e9e4af-4b52-4337-a1d7-88a6826dfef2",
+      "ConcordiaCourseId": "049850"
+    },
+    {
+      "Id": "70a1759a-1b7a-4214-9c89-008a9ca23fc6",
+      "ConcordiaCourseId": "050062"
+    },
+    {
+      "Id": "10371e6a-63f7-4e93-ad58-0802e4d4e0f9",
+      "ConcordiaCourseId": "050082"
+    },
+    {
+      "Id": "ca495315-4c1f-41e1-96cc-7f5a7e32f416",
+      "ConcordiaCourseId": "050087"
+    },
+    {
+      "Id": "63199ee5-fd85-4533-967e-a87049e046dc",
+      "ConcordiaCourseId": "050429"
+    },
+    {
+      "Id": "66f24e9f-db8d-4342-8bad-8360254c2232",
+      "ConcordiaCourseId": "050431"
+    },
+    {
+      "Id": "14772993-feb6-4785-8723-acd32ab57fc4",
+      "ConcordiaCourseId": "050432"
+    },
+    {
+      "Id": "47aa652c-7480-4844-9761-51a465359132",
+      "ConcordiaCourseId": "050433"
+    },
+    {
+      "Id": "e8735ee7-ec49-4115-ab09-1fdaed4f57a9",
+      "ConcordiaCourseId": "050693"
+    },
+    {
+      "Id": "1605f760-e747-4852-a76c-296e9b77bea8",
+      "ConcordiaCourseId": "050694"
+    },
+    {
+      "Id": "fdf61ee9-ed9a-49ba-9d19-3947b7a8555d",
+      "ConcordiaCourseId": "050695"
+    },
+    {
+      "Id": "b7193ecd-5837-4385-a8b1-9885d5e04018",
+      "ConcordiaCourseId": "050725"
+    },
+    {
+      "Id": "95e8d3d9-038c-4710-b7fa-9ea4df40e468",
+      "ConcordiaCourseId": "005254"
+    },
+    {
+      "Id": "39fad72f-d366-46f2-9894-6397bc9fc5d3",
+      "ConcordiaCourseId": "005255"
+    },
+    {
+      "Id": "405decca-2a82-4b44-a7d5-42c752056986",
+      "ConcordiaCourseId": "005256"
+    },
+    {
+      "Id": "fe4a1801-8be9-4182-bc5f-e0d8d708a9b8",
+      "ConcordiaCourseId": "005257"
+    },
+    {
+      "Id": "27020211-a0b8-4002-997e-af444dfec6d7",
+      "ConcordiaCourseId": "005258"
+    },
+    {
+      "Id": "2e044e35-77fd-440e-9ee4-4c8ac2c12a38",
+      "ConcordiaCourseId": "005259"
+    },
+    {
+      "Id": "d6d8df0e-de54-41a8-9915-0578767a1275",
+      "ConcordiaCourseId": "005260"
+    },
+    {
+      "Id": "a9b92fe1-7034-4029-84cd-cb1ff38ff2f4",
+      "ConcordiaCourseId": "005262"
+    },
+    {
+      "Id": "69e76242-474f-41f5-967d-86e932e2e1af",
+      "ConcordiaCourseId": "005263"
+    },
+    {
+      "Id": "fe073a4c-d103-4ccf-b9c0-ac2550b21b0e",
+      "ConcordiaCourseId": "005276"
+    },
+    {
+      "Id": "ae732864-3186-4662-a253-5d23c458dde7",
+      "ConcordiaCourseId": "005281"
+    },
+    {
+      "Id": "e131ac15-c005-4429-9ede-0877f6a97cc2",
+      "ConcordiaCourseId": "005284"
+    },
+    {
+      "Id": "bc3eb52e-4238-4ee7-aaa8-c84f88fd96e9",
+      "ConcordiaCourseId": "005285"
+    },
+    {
+      "Id": "192d5c0f-f875-40a9-98f8-ca96847d89d7",
+      "ConcordiaCourseId": "005286"
+    },
+    {
+      "Id": "7ba971ba-da2b-4cd1-a9fa-fe1d63d15e8e",
+      "ConcordiaCourseId": "005312"
+    },
+    {
+      "Id": "3d07b15c-d634-4d59-b9b8-e781c79d4f22",
+      "ConcordiaCourseId": "046577"
+    },
+    {
+      "Id": "d055396a-9a4e-413f-b07b-9aa43ee865a6",
+      "ConcordiaCourseId": "046578"
+    },
+    {
+      "Id": "a0c7dce9-7526-4a79-96b5-dbe289b08e06",
+      "ConcordiaCourseId": "048423"
+    },
+    {
+      "Id": "818a2f2d-6cba-4f8c-b064-ff7612615801",
+      "ConcordiaCourseId": "050471"
+    },
+    {
+      "Id": "4a847ee5-2cf5-46e5-96cb-547442803e17",
+      "ConcordiaCourseId": "050472"
+    },
+    {
+      "Id": "9ae2e7ad-bbee-4985-892a-ef7c43027481",
+      "ConcordiaCourseId": "050474"
+    },
+    {
+      "Id": "6cc20113-a57b-46b1-ae86-6d05b354de4a",
+      "ConcordiaCourseId": "050475"
+    },
+    {
+      "Id": "60c91907-b8df-49f0-a7ba-9eef26094b5a",
+      "ConcordiaCourseId": "050476"
+    },
+    {
+      "Id": "710ea7fd-a6f1-42c0-bfdd-a982181aa11b",
+      "ConcordiaCourseId": "050477"
+    },
+    {
+      "Id": "93e3d6e6-eac8-4233-ace1-1b36630d5489",
+      "ConcordiaCourseId": "050478"
+    },
+    {
+      "Id": "e5104d5a-bdb5-48dc-8682-c4be189a18b6",
+      "ConcordiaCourseId": "050479"
+    },
+    {
+      "Id": "b2181d3c-7ca8-4f8a-9e33-9377948cfc66",
+      "ConcordiaCourseId": "050480"
+    },
+    {
+      "Id": "d01c4a4d-c044-4b15-9adb-6d7395080ee5",
+      "ConcordiaCourseId": "050481"
+    },
+    {
+      "Id": "a97c7aa5-9c85-47cd-9ce6-6ea0b67b8596",
+      "ConcordiaCourseId": "005326"
+    },
+    {
+      "Id": "3e6f0ec4-d6af-42a3-9c28-dadff09ea975",
+      "ConcordiaCourseId": "005337"
+    },
+    {
+      "Id": "9bc8d545-9662-4011-aebc-c6a04892e04c",
+      "ConcordiaCourseId": "005350"
+    },
+    {
+      "Id": "80a91b95-76e7-4fa4-b9f0-db4797358d22",
+      "ConcordiaCourseId": "005353"
+    },
+    {
+      "Id": "8a0e1902-77f8-4b08-8ca0-c63c6fd6fed5",
+      "ConcordiaCourseId": "005354"
+    },
+    {
+      "Id": "6c4b658f-a15f-42a7-a849-f7b6286c572c",
+      "ConcordiaCourseId": "005363"
+    },
+    {
+      "Id": "4f666950-f5ee-4355-9594-21e01a1e5205",
+      "ConcordiaCourseId": "005364"
+    },
+    {
+      "Id": "8f180d58-29fe-459b-958d-45c8c237f81d",
+      "ConcordiaCourseId": "005391"
+    },
+    {
+      "Id": "cee19a35-e413-4163-be3b-f6d56bf32130",
+      "ConcordiaCourseId": "005394"
+    },
+    {
+      "Id": "07d1fcc0-9b26-4f5b-978b-21d27a3c182b",
+      "ConcordiaCourseId": "005398"
+    },
+    {
+      "Id": "67dcb87b-78b4-4079-ba3d-b5bc5c9a4fad",
+      "ConcordiaCourseId": "005405"
+    },
+    {
+      "Id": "975d21af-d6ee-448d-8553-b9676baafe42",
+      "ConcordiaCourseId": "005406"
+    },
+    {
+      "Id": "82ee8094-dbfc-487c-8c43-b268e08b8a54",
+      "ConcordiaCourseId": "005407"
+    },
+    {
+      "Id": "74af95e9-7e1d-484b-837c-b811280556a2",
+      "ConcordiaCourseId": "005409"
+    },
+    {
+      "Id": "ac2522f7-9fbb-4c1e-8358-b6e55e5e93b9",
+      "ConcordiaCourseId": "005410"
+    },
+    {
+      "Id": "30bcb058-7e29-4980-913c-b8c887189d1e",
+      "ConcordiaCourseId": "005411"
+    },
+    {
+      "Id": "07508d09-b759-4f88-be10-c4150c452d58",
+      "ConcordiaCourseId": "005412"
+    },
+    {
+      "Id": "b22ab473-755f-4222-8be2-928be2d84c1f",
+      "ConcordiaCourseId": "005414"
+    },
+    {
+      "Id": "c15c06a7-6827-4484-bb40-d4ee0a3889aa",
+      "ConcordiaCourseId": "005415"
+    },
+    {
+      "Id": "fb92f57f-4fdd-4a92-8b0b-cc2ee183bbe0",
+      "ConcordiaCourseId": "005416"
+    },
+    {
+      "Id": "f02f5d73-f3dc-4b06-a716-ba960adf4153",
+      "ConcordiaCourseId": "005446"
+    },
+    {
+      "Id": "aec5deb0-c781-49ac-aac8-c683c294acef",
+      "ConcordiaCourseId": "005447"
+    },
+    {
+      "Id": "dc5b1eda-7cf9-42dd-b6f6-449dbe03f37e",
+      "ConcordiaCourseId": "005449"
+    },
+    {
+      "Id": "a5520ec1-c000-4bdb-8ffb-645ea48949d2",
+      "ConcordiaCourseId": "005454"
+    },
+    {
+      "Id": "37c3edfb-ec62-4e59-8517-266d97b3223f",
+      "ConcordiaCourseId": "005461"
+    },
+    {
+      "Id": "ae7b21ad-9089-40e1-87ec-8a45dfae6278",
+      "ConcordiaCourseId": "005464"
+    },
+    {
+      "Id": "bf638597-267a-4366-8629-4d6a9d4166a5",
+      "ConcordiaCourseId": "005469"
+    },
+    {
+      "Id": "297407ad-167b-4d9f-a08b-3b3d97cdc596",
+      "ConcordiaCourseId": "005477"
+    },
+    {
+      "Id": "cb298742-8924-4828-a04f-ceb2ea19d5df",
+      "ConcordiaCourseId": "005482"
+    },
+    {
+      "Id": "d9820cf5-cae6-467f-b396-49ba98fd87cf",
+      "ConcordiaCourseId": "005483"
+    },
+    {
+      "Id": "97828367-abef-4eba-a573-6d9eb7281f67",
+      "ConcordiaCourseId": "005484"
+    },
+    {
+      "Id": "36681b27-dd8b-4059-b1ac-85bec9c99582",
+      "ConcordiaCourseId": "005485"
+    },
+    {
+      "Id": "77605ef3-18e4-4d2d-a042-2796e20fe50b",
+      "ConcordiaCourseId": "005486"
+    },
+    {
+      "Id": "b90273a1-ea4b-4ae8-9368-5e2aa6186859",
+      "ConcordiaCourseId": "005487"
+    },
+    {
+      "Id": "c673eece-71b4-4dd4-bdf9-ff9c60cbcd99",
+      "ConcordiaCourseId": "005488"
+    },
+    {
+      "Id": "3d757295-c27a-4e97-a872-3e631b9666ef",
+      "ConcordiaCourseId": "005491"
+    },
+    {
+      "Id": "1f8821bb-bdef-45db-b8c9-f3014beba58f",
+      "ConcordiaCourseId": "005492"
+    },
+    {
+      "Id": "6b1778ef-b99d-462f-b1d7-35173e09feed",
+      "ConcordiaCourseId": "005493"
+    },
+    {
+      "Id": "411d321d-3773-493e-9724-94fd3633a972",
+      "ConcordiaCourseId": "005500"
+    },
+    {
+      "Id": "08e3bd99-322d-40e3-ad36-49505ae66e7c",
+      "ConcordiaCourseId": "005520"
+    },
+    {
+      "Id": "939f5b9e-6406-4eb5-8e0c-74a16ef38c7c",
+      "ConcordiaCourseId": "005522"
+    },
+    {
+      "Id": "cf155d00-0ebf-41fe-957d-b2749245f6f0",
+      "ConcordiaCourseId": "005526"
+    },
+    {
+      "Id": "df201736-760c-4502-afed-d8e1cc67e529",
+      "ConcordiaCourseId": "005527"
+    },
+    {
+      "Id": "e9ac1a3e-4524-44b8-982c-03b4a2e33e15",
+      "ConcordiaCourseId": "005530"
+    },
+    {
+      "Id": "64c9bd07-3e85-4d7e-8de9-92b52b49b42c",
+      "ConcordiaCourseId": "005534"
+    },
+    {
+      "Id": "9a81e837-a1a0-4ada-80cd-9bef985dd372",
+      "ConcordiaCourseId": "005536"
+    },
+    {
+      "Id": "343a60a8-8dde-4c90-ade7-7a1894b37f56",
+      "ConcordiaCourseId": "005567"
+    },
+    {
+      "Id": "c4a49407-8228-4c0b-ae0f-e220d0d7c9bd",
+      "ConcordiaCourseId": "005570"
+    },
+    {
+      "Id": "27cc1a9c-4272-4916-83b3-c8e338cb7cbb",
+      "ConcordiaCourseId": "005572"
+    },
+    {
+      "Id": "5a49b614-4104-46a5-8c3e-cd34c2e5d35a",
+      "ConcordiaCourseId": "005575"
+    },
+    {
+      "Id": "37876db6-30a5-431b-91c2-f757a5b98d0b",
+      "ConcordiaCourseId": "005577"
+    },
+    {
+      "Id": "d7e24ce5-1785-452d-9bd7-d5a1736227f8",
+      "ConcordiaCourseId": "005579"
+    },
+    {
+      "Id": "4ccab3f9-efe1-4a8c-b593-292b61c1cc1b",
+      "ConcordiaCourseId": "005585"
+    },
+    {
+      "Id": "9c74d1c1-67aa-43b1-ba65-04832da676a0",
+      "ConcordiaCourseId": "005589"
+    },
+    {
+      "Id": "8d3d20c9-d937-4051-b7a2-a22e239482c5",
+      "ConcordiaCourseId": "005592"
+    },
+    {
+      "Id": "d36e9505-0dcc-4d3e-96ae-28d28315fed1",
+      "ConcordiaCourseId": "005593"
+    },
+    {
+      "Id": "bfd71544-4407-44c3-8796-ee6ed3993193",
+      "ConcordiaCourseId": "005598"
+    },
+    {
+      "Id": "eec8b110-4a10-4d99-bd24-66a2f8239bca",
+      "ConcordiaCourseId": "005603"
+    },
+    {
+      "Id": "a4d2dcef-ddbf-44dd-ba1f-f3556d4c1eec",
+      "ConcordiaCourseId": "005605"
+    },
+    {
+      "Id": "09869753-9302-4433-a2ac-8fb416f64cbb",
+      "ConcordiaCourseId": "005607"
+    },
+    {
+      "Id": "e60a4fe5-ae4a-4c80-889c-7fe11fc51e5e",
+      "ConcordiaCourseId": "005615"
+    },
+    {
+      "Id": "30e48aa0-2ee3-4ce0-9b97-c7b620f17c54",
+      "ConcordiaCourseId": "005617"
+    },
+    {
+      "Id": "6cf1c9ce-a2c6-45ac-8771-0df8c15d9010",
+      "ConcordiaCourseId": "005619"
+    },
+    {
+      "Id": "71419f71-9d6b-4232-9af6-dd2fef45465e",
+      "ConcordiaCourseId": "005620"
+    },
+    {
+      "Id": "a049411f-68d6-4158-ab66-28a4556fa603",
+      "ConcordiaCourseId": "005621"
+    },
+    {
+      "Id": "33a90e53-93d8-4da2-ae9c-8619f6ded9a8",
+      "ConcordiaCourseId": "005622"
+    },
+    {
+      "Id": "09147739-e1f8-4592-807d-44007c5feddc",
+      "ConcordiaCourseId": "005625"
+    },
+    {
+      "Id": "462791fb-19db-4e87-b407-884b2a0ed800",
+      "ConcordiaCourseId": "005656"
+    },
+    {
+      "Id": "1a8fcba3-dd33-4b3e-b048-5f7ca8119a77",
+      "ConcordiaCourseId": "005661"
+    },
+    {
+      "Id": "13c9e7c6-55c9-4f16-aec9-fc0e66bd00a8",
+      "ConcordiaCourseId": "005678"
+    },
+    {
+      "Id": "c558d059-98e0-4235-b382-aeda5cc201e4",
+      "ConcordiaCourseId": "005684"
+    },
+    {
+      "Id": "0bbd1a30-3b00-43f6-8825-ebcdab2136d4",
+      "ConcordiaCourseId": "005702"
+    },
+    {
+      "Id": "d074030d-8969-432a-b8f5-cbc3973169e2",
+      "ConcordiaCourseId": "005703"
+    },
+    {
+      "Id": "2a26085a-23bb-40e5-86b1-b9d66d7264f2",
+      "ConcordiaCourseId": "005720"
+    },
+    {
+      "Id": "20bf9433-b710-4548-b60b-89f3ae9bf376",
+      "ConcordiaCourseId": "005724"
+    },
+    {
+      "Id": "8ce23ccc-0aee-453f-9307-06373ba5ac14",
+      "ConcordiaCourseId": "005731"
+    },
+    {
+      "Id": "713fb3cf-4461-4b84-9524-33fd54db6e6f",
+      "ConcordiaCourseId": "040329"
+    },
+    {
+      "Id": "aa20bf2d-5ef9-4373-b951-ef3d9903e34f",
+      "ConcordiaCourseId": "040331"
+    },
+    {
+      "Id": "504bbef1-1c13-4ea6-861b-8c6f9c7f4d30",
+      "ConcordiaCourseId": "040332"
+    },
+    {
+      "Id": "3aa0d638-33be-4fd3-93c4-f1b29af5762b",
+      "ConcordiaCourseId": "040335"
+    },
+    {
+      "Id": "c6a9dbfb-9edb-472f-8cdd-17a801eab5d1",
+      "ConcordiaCourseId": "040344"
+    },
+    {
+      "Id": "6d65aabd-85d7-4b0a-a201-95eeaddccfa1",
+      "ConcordiaCourseId": "040345"
+    },
+    {
+      "Id": "ff29323b-d675-4df2-93db-69212bc37b82",
+      "ConcordiaCourseId": "040353"
+    },
+    {
+      "Id": "d5c7d13d-1db0-4f1d-8f47-d19a9e51ba5b",
+      "ConcordiaCourseId": "040354"
+    },
+    {
+      "Id": "6364a3e9-5453-43a0-b3bd-223ae6f2fdaf",
+      "ConcordiaCourseId": "040355"
+    },
+    {
+      "Id": "ba67d358-aa94-43da-9ce1-782ea7ed31c1",
+      "ConcordiaCourseId": "040356"
+    },
+    {
+      "Id": "c323d0dd-0738-4b2c-b6a6-5b46dc181891",
+      "ConcordiaCourseId": "040357"
+    },
+    {
+      "Id": "514aa355-9261-4afc-947a-934f92aff5ef",
+      "ConcordiaCourseId": "040358"
+    },
+    {
+      "Id": "9ae52568-f7e5-451b-ad69-ee9bcb50716b",
+      "ConcordiaCourseId": "044019"
+    },
+    {
+      "Id": "c647c6fa-584d-4711-8016-6b59fb725af1",
+      "ConcordiaCourseId": "045940"
+    },
+    {
+      "Id": "b118fc3f-d6bd-4874-8065-43382bc8b7a3",
+      "ConcordiaCourseId": "046579"
+    },
+    {
+      "Id": "7153dd09-aaf4-4ad7-97f9-4761722d107d",
+      "ConcordiaCourseId": "046580"
+    },
+    {
+      "Id": "cc35853f-fde9-4a7d-a0a0-874faf527453",
+      "ConcordiaCourseId": "046581"
+    },
+    {
+      "Id": "9cb22a4f-8f27-4067-aee4-29656b19c484",
+      "ConcordiaCourseId": "046582"
+    },
+    {
+      "Id": "6012600f-1885-43d2-888c-c6fe9f04a60b",
+      "ConcordiaCourseId": "046583"
+    },
+    {
+      "Id": "83df1645-e5a8-46dc-80a9-f930f5b21e09",
+      "ConcordiaCourseId": "046584"
+    },
+    {
+      "Id": "a9c25125-f8f5-41e9-9225-f19b9561e68a",
+      "ConcordiaCourseId": "046585"
+    },
+    {
+      "Id": "f83121d4-6dbf-4cd0-a6e2-b59c95819650",
+      "ConcordiaCourseId": "046586"
+    },
+    {
+      "Id": "b7fefdf9-e404-4a9f-b5cf-2a9048431cd2",
+      "ConcordiaCourseId": "047980"
+    },
+    {
+      "Id": "61a0acb7-947a-464e-a1cf-d208cb38f42e",
+      "ConcordiaCourseId": "048285"
+    },
+    {
+      "Id": "057e3a7c-0907-4440-bbf6-34827d5cd8ea",
+      "ConcordiaCourseId": "048956"
+    },
+    {
+      "Id": "9aab57ba-9849-4563-a304-26fe962eae14",
+      "ConcordiaCourseId": "048967"
+    },
+    {
+      "Id": "60a31637-8764-4915-b958-f034b074c45e",
+      "ConcordiaCourseId": "049296"
+    },
+    {
+      "Id": "245a96c3-0e07-479e-b622-002dee046c40",
+      "ConcordiaCourseId": "049309"
+    },
+    {
+      "Id": "1b6a9f84-51b2-41bd-a41b-10b2ca00a630",
+      "ConcordiaCourseId": "049310"
+    },
+    {
+      "Id": "b0823cb5-8950-4479-94be-aceb7e6132ac",
+      "ConcordiaCourseId": "049700"
+    },
+    {
+      "Id": "4df1c8f6-53d2-45ec-be1b-6fdffb1ed0d1",
+      "ConcordiaCourseId": "049701"
+    },
+    {
+      "Id": "d6b35c61-54cd-4920-9f14-f0524a88e2e1",
+      "ConcordiaCourseId": "049712"
+    },
+    {
+      "Id": "fcf2befb-8099-40b9-8e43-4370dd37cc99",
+      "ConcordiaCourseId": "050123"
+    },
+    {
+      "Id": "3c8fc2bc-75a0-4658-8f3c-afc8fa1b5157",
+      "ConcordiaCourseId": "050437"
+    },
+    {
+      "Id": "d93cccd0-62f3-4335-9527-70eabefcdd74",
+      "ConcordiaCourseId": "050448"
+    },
+    {
+      "Id": "af8ea8e4-47d4-4c09-abbe-09776d34d381",
+      "ConcordiaCourseId": "050482"
+    },
+    {
+      "Id": "b1e45d63-26a1-41b5-97de-cc746b98dc96",
+      "ConcordiaCourseId": "005891"
+    },
+    {
+      "Id": "4d0ec4bc-0f80-4194-ab71-cce7ecd7d1c5",
+      "ConcordiaCourseId": "005892"
+    },
+    {
+      "Id": "42829169-6c43-4b73-a5d8-5e919f76e4fc",
+      "ConcordiaCourseId": "005893"
+    },
+    {
+      "Id": "4668151c-3e52-485d-84f2-f6a1dca9dba4",
+      "ConcordiaCourseId": "005895"
+    },
+    {
+      "Id": "d0dbbe26-4a14-4fd9-a26f-a55e134b8cfa",
+      "ConcordiaCourseId": "005898"
+    },
+    {
+      "Id": "17665292-6aa2-41b3-839b-255848333e4c",
+      "ConcordiaCourseId": "005900"
+    },
+    {
+      "Id": "8e2e9e08-77c8-47fc-8303-6840e4851393",
+      "ConcordiaCourseId": "005904"
+    },
+    {
+      "Id": "b8bf2940-bc30-46d6-9e80-4e1234646332",
+      "ConcordiaCourseId": "005928"
+    },
+    {
+      "Id": "a9507588-bd2f-4c2d-b229-b1755903854e",
+      "ConcordiaCourseId": "005930"
+    },
+    {
+      "Id": "ae771f0e-6327-46d1-bab1-82d39d92c795",
+      "ConcordiaCourseId": "005931"
+    },
+    {
+      "Id": "d2df5bcd-fe48-4953-9fff-33af6bfd0f2f",
+      "ConcordiaCourseId": "005932"
+    },
+    {
+      "Id": "d0e7c900-50f9-48d7-99ca-a060a0e0736b",
+      "ConcordiaCourseId": "005933"
+    },
+    {
+      "Id": "449f87b2-4dbb-4153-ab3e-8bd79df17920",
+      "ConcordiaCourseId": "005939"
+    },
+    {
+      "Id": "c6dfd070-2eff-4bde-b7b9-347409b6c70d",
+      "ConcordiaCourseId": "005944"
+    },
+    {
+      "Id": "757a5a75-42cb-4f85-8ba7-21d811cd09b8",
+      "ConcordiaCourseId": "005945"
+    },
+    {
+      "Id": "6955f485-b771-4467-9875-c1194ae8131a",
+      "ConcordiaCourseId": "005950"
+    },
+    {
+      "Id": "0544f40d-6e82-4d61-8f22-f4c1622c2e91",
+      "ConcordiaCourseId": "005951"
+    },
+    {
+      "Id": "45f9d039-718e-4dfb-976f-8c9fa345f2df",
+      "ConcordiaCourseId": "005952"
+    },
+    {
+      "Id": "5ca75b08-7939-46ee-af16-b1a58819b2b7",
+      "ConcordiaCourseId": "005954"
+    },
+    {
+      "Id": "53a2db75-4f37-4b8d-925e-1021acfa29a4",
+      "ConcordiaCourseId": "005955"
+    },
+    {
+      "Id": "e4022444-d136-4460-a626-8634b8ba1c38",
+      "ConcordiaCourseId": "005956"
+    },
+    {
+      "Id": "99027889-890e-4649-b4bb-e52c29567a8d",
+      "ConcordiaCourseId": "005957"
+    },
+    {
+      "Id": "6ee39a39-dd45-405c-96d0-db814a2b5bad",
+      "ConcordiaCourseId": "005959"
+    },
+    {
+      "Id": "5f1ca84d-eddb-43e8-a200-999e4c2eaaf1",
+      "ConcordiaCourseId": "005961"
+    },
+    {
+      "Id": "7a467b0f-3158-4b6c-b04d-a05dadacbda7",
+      "ConcordiaCourseId": "005962"
+    },
+    {
+      "Id": "3c9134c8-048f-4011-bac2-4362025f49ad",
+      "ConcordiaCourseId": "005963"
+    },
+    {
+      "Id": "5abc0ff5-af42-470b-9b17-0c3e154385e5",
+      "ConcordiaCourseId": "005964"
+    },
+    {
+      "Id": "266c3726-e5d6-4d7e-9a74-748d44672166",
+      "ConcordiaCourseId": "005965"
+    },
+    {
+      "Id": "08774893-b706-4f2e-9f9a-beed95745c83",
+      "ConcordiaCourseId": "005966"
+    },
+    {
+      "Id": "6426e960-5880-4857-ad2e-0787f907b01c",
+      "ConcordiaCourseId": "005967"
+    },
+    {
+      "Id": "2bffe4ca-bea6-4de9-be5b-0dca93d16dea",
+      "ConcordiaCourseId": "005968"
+    },
+    {
+      "Id": "a8bf8f1b-6ed8-47cf-b038-4bc469d8b9ab",
+      "ConcordiaCourseId": "005970"
+    },
+    {
+      "Id": "f306dfdd-4f8b-410c-a473-282a052eb7c6",
+      "ConcordiaCourseId": "005975"
+    },
+    {
+      "Id": "1a347d76-a4b8-453a-bc54-1223b2fbc353",
+      "ConcordiaCourseId": "005976"
+    },
+    {
+      "Id": "3f343394-abf7-46fd-a4a5-b68a3b8e8335",
+      "ConcordiaCourseId": "005978"
+    },
+    {
+      "Id": "f9505e58-4e0e-4df6-92d4-57af6822d1be",
+      "ConcordiaCourseId": "005979"
+    },
+    {
+      "Id": "763def50-7667-4f45-b2b2-4d28a13378da",
+      "ConcordiaCourseId": "005997"
+    },
+    {
+      "Id": "bbd9ac2f-f412-4aa9-ba8d-58820a0e0016",
+      "ConcordiaCourseId": "005998"
+    },
+    {
+      "Id": "9f96a5f8-b343-4007-aae4-cc322be48368",
+      "ConcordiaCourseId": "005999"
+    },
+    {
+      "Id": "b6031468-5634-41e7-9c99-ecb4afe2fe21",
+      "ConcordiaCourseId": "006000"
+    },
+    {
+      "Id": "5be85ce8-d412-47f2-a742-c42b7d7251c5",
+      "ConcordiaCourseId": "006001"
+    },
+    {
+      "Id": "494e6152-c7ac-4c7a-8ae1-af568135a689",
+      "ConcordiaCourseId": "006002"
+    },
+    {
+      "Id": "cb00e76a-e4cf-4dfc-b71f-8fcce65ed622",
+      "ConcordiaCourseId": "006003"
+    },
+    {
+      "Id": "b8c937b5-678a-47e9-a8c0-daf10fe6814d",
+      "ConcordiaCourseId": "006005"
+    },
+    {
+      "Id": "62cc530a-0283-4db5-8c20-cb540dc1769e",
+      "ConcordiaCourseId": "006006"
+    },
+    {
+      "Id": "9e6f1412-129e-4ab5-bc3e-dba65d4461b7",
+      "ConcordiaCourseId": "006007"
+    },
+    {
+      "Id": "72a216aa-ca34-4472-8083-396ecab80a82",
+      "ConcordiaCourseId": "006008"
+    },
+    {
+      "Id": "dad40d38-2d3e-4a61-b558-57aecd0e4730",
+      "ConcordiaCourseId": "006009"
+    },
+    {
+      "Id": "60a5e6dc-c6bc-4bc5-890f-adf55ff57983",
+      "ConcordiaCourseId": "006010"
+    },
+    {
+      "Id": "ccb4877a-c55a-4a09-90b2-ed6047fd06d2",
+      "ConcordiaCourseId": "006011"
+    },
+    {
+      "Id": "70813866-88b2-4026-9c61-1b3e73f384e6",
+      "ConcordiaCourseId": "006012"
+    },
+    {
+      "Id": "072d17a1-0c49-4553-b13b-014f7ba2587e",
+      "ConcordiaCourseId": "006013"
+    },
+    {
+      "Id": "13bbed10-e02a-41b7-9004-907dbd00606a",
+      "ConcordiaCourseId": "006014"
+    },
+    {
+      "Id": "054236b7-cf59-4b55-aedc-531cfb335b22",
+      "ConcordiaCourseId": "006018"
+    },
+    {
+      "Id": "0b5536fc-c4c8-4e9a-8b2a-959e12770cfc",
+      "ConcordiaCourseId": "006027"
+    },
+    {
+      "Id": "33eb4661-ae57-46ea-9cdc-0a751c031045",
+      "ConcordiaCourseId": "006029"
+    },
+    {
+      "Id": "c62cb7a6-0966-4184-885d-1b180a3f49ba",
+      "ConcordiaCourseId": "006030"
+    },
+    {
+      "Id": "32975fc9-30a0-4a4e-904e-3dc6fd9842e2",
+      "ConcordiaCourseId": "006031"
+    },
+    {
+      "Id": "fa473b17-ec4d-47b6-805b-9ee27c2af991",
+      "ConcordiaCourseId": "006032"
+    },
+    {
+      "Id": "a0411a44-5373-44a9-b5b1-93b6be7558a7",
+      "ConcordiaCourseId": "006033"
+    },
+    {
+      "Id": "419cc726-9371-41b7-9e25-3fdcc897dace",
+      "ConcordiaCourseId": "006034"
+    },
+    {
+      "Id": "05abb5ea-1b7c-4eed-8683-bd12592f3f04",
+      "ConcordiaCourseId": "006035"
+    },
+    {
+      "Id": "fb6f5695-2a10-4d19-94fd-63e19d5a35d8",
+      "ConcordiaCourseId": "006036"
+    },
+    {
+      "Id": "2bd79b85-e84b-4e02-b191-ff5b32f47e68",
+      "ConcordiaCourseId": "006040"
+    },
+    {
+      "Id": "2455d6ed-bfc3-4152-9baf-38312162e09a",
+      "ConcordiaCourseId": "006041"
+    },
+    {
+      "Id": "97bf8253-c803-4d7d-baa9-7d297bfe3177",
+      "ConcordiaCourseId": "006042"
+    },
+    {
+      "Id": "87f4e155-24d4-4acf-bdf7-4a54e5a68862",
+      "ConcordiaCourseId": "006043"
+    },
+    {
+      "Id": "54c42cbb-6ce4-428c-aaa2-5f89bb275be0",
+      "ConcordiaCourseId": "006044"
+    },
+    {
+      "Id": "9f8d2f5a-231a-4458-8f5c-36399b87ba0d",
+      "ConcordiaCourseId": "006047"
+    },
+    {
+      "Id": "497d81a1-a5ef-447e-b344-cdcb75f5a80a",
+      "ConcordiaCourseId": "006048"
+    },
+    {
+      "Id": "d0280167-3fca-4030-bd24-e6dd91a84ded",
+      "ConcordiaCourseId": "006051"
+    },
+    {
+      "Id": "e4d5cfe2-6b06-473a-b5cc-cc29d6204235",
+      "ConcordiaCourseId": "006054"
+    },
+    {
+      "Id": "110ff00b-6f75-4000-8d73-6538d410cbbc",
+      "ConcordiaCourseId": "006077"
+    },
+    {
+      "Id": "30a41d77-cfe1-48cd-9abf-355b419df027",
+      "ConcordiaCourseId": "006078"
+    },
+    {
+      "Id": "30df4d72-d7c0-436e-8be1-49f5c814c641",
+      "ConcordiaCourseId": "006079"
+    },
+    {
+      "Id": "12c90540-1e8b-446e-8ea0-f01879cacd98",
+      "ConcordiaCourseId": "006080"
+    },
+    {
+      "Id": "ebf3abd1-b9a3-48e9-ad39-d8e08baa831c",
+      "ConcordiaCourseId": "006081"
+    },
+    {
+      "Id": "6dbc8d5b-9f91-4b75-a8b2-df51c95d0c61",
+      "ConcordiaCourseId": "006082"
+    },
+    {
+      "Id": "b9f48b30-e5db-4ecd-98da-65390fc9803a",
+      "ConcordiaCourseId": "006084"
+    },
+    {
+      "Id": "366dfbd3-9d0a-4e08-8d97-bd78330cc06a",
+      "ConcordiaCourseId": "006086"
+    },
+    {
+      "Id": "4889a254-8801-4125-8f00-889c7fe5a3a0",
+      "ConcordiaCourseId": "006087"
+    },
+    {
+      "Id": "885b0d21-5709-4b9f-8bb9-3f6c5ad8c20e",
+      "ConcordiaCourseId": "006089"
+    },
+    {
+      "Id": "71e626b3-f239-403b-b0d7-a69b677a1ba2",
+      "ConcordiaCourseId": "006090"
+    },
+    {
+      "Id": "a9448c8b-07f5-4aa1-9000-5d44f4d8e29f",
+      "ConcordiaCourseId": "006091"
+    },
+    {
+      "Id": "17af59f5-a3bd-48c1-abd8-7bcbd88f64c7",
+      "ConcordiaCourseId": "006092"
+    },
+    {
+      "Id": "e87271f5-1241-417a-a369-bb90ef72d8d9",
+      "ConcordiaCourseId": "006096"
+    },
+    {
+      "Id": "5ad44c52-358e-4d4f-bbaf-0dac2ec25c0e",
+      "ConcordiaCourseId": "006101"
+    },
+    {
+      "Id": "5af6d2f3-4dc6-46ef-bbe3-620360ae64a4",
+      "ConcordiaCourseId": "006102"
+    },
+    {
+      "Id": "cf8ca591-b1ab-4701-9c3a-5fc0be464978",
+      "ConcordiaCourseId": "006104"
+    },
+    {
+      "Id": "107fa3a3-b607-46e4-858d-e8ca894c1c43",
+      "ConcordiaCourseId": "006105"
+    },
+    {
+      "Id": "fa72a626-88ac-4bcd-b8e0-2a600c5e121e",
+      "ConcordiaCourseId": "006106"
+    },
+    {
+      "Id": "e9147f1f-b99b-4900-9373-c9c80a9d0c6e",
+      "ConcordiaCourseId": "006107"
+    },
+    {
+      "Id": "92e006a2-bcbd-4c36-b6bf-d9036259a3aa",
+      "ConcordiaCourseId": "006108"
+    },
+    {
+      "Id": "808fe83d-8660-4dc9-87cf-e551a7ef1b2a",
+      "ConcordiaCourseId": "006109"
+    },
+    {
+      "Id": "8ad39a94-8c04-4328-91b8-2a5aceb7dd2f",
+      "ConcordiaCourseId": "006110"
+    },
+    {
+      "Id": "97515c1f-6b3d-4600-9aa2-76f394339e06",
+      "ConcordiaCourseId": "006111"
+    },
+    {
+      "Id": "0739265f-997a-4045-adeb-4b15caaa2c2e",
+      "ConcordiaCourseId": "006112"
+    },
+    {
+      "Id": "39b4edcc-a08f-4905-b42d-6d7defd2c457",
+      "ConcordiaCourseId": "006117"
+    },
+    {
+      "Id": "61ef95c7-85dc-415d-bd31-c1002d0158c3",
+      "ConcordiaCourseId": "006122"
+    },
+    {
+      "Id": "afe51508-351c-4bb9-9b94-f4fa1e887adc",
+      "ConcordiaCourseId": "006123"
+    },
+    {
+      "Id": "2b9bc983-39c2-44e4-b507-76e5483ff7ff",
+      "ConcordiaCourseId": "006124"
+    },
+    {
+      "Id": "a2913af1-2a44-49fd-98c1-4956729141c5",
+      "ConcordiaCourseId": "006131"
+    },
+    {
+      "Id": "c71de1fe-7d65-498f-a09b-6cbea6502340",
+      "ConcordiaCourseId": "006132"
+    },
+    {
+      "Id": "b4c006b0-35d1-4850-a8bd-f500cd6b50b9",
+      "ConcordiaCourseId": "006138"
+    },
+    {
+      "Id": "3e797f94-4db1-4ac9-9090-7ed6a1e6ebfa",
+      "ConcordiaCourseId": "006145"
+    },
+    {
+      "Id": "8b7f51fa-5825-40fa-8b82-5cb804ce8829",
+      "ConcordiaCourseId": "006147"
+    },
+    {
+      "Id": "90f445ac-898b-4d2b-9b9a-a15464a7e40a",
+      "ConcordiaCourseId": "006148"
+    },
+    {
+      "Id": "bff48307-d2d2-4e72-985b-166ce94352d4",
+      "ConcordiaCourseId": "006153"
+    },
+    {
+      "Id": "ac584ff3-9537-499d-b583-80988e6fc428",
+      "ConcordiaCourseId": "006155"
+    },
+    {
+      "Id": "8952d15c-884d-4fb6-a4e5-9a3a6f25762b",
+      "ConcordiaCourseId": "006156"
+    },
+    {
+      "Id": "fc43bd91-c291-49c0-b394-22ac17172d0f",
+      "ConcordiaCourseId": "006157"
+    },
+    {
+      "Id": "6bfc342a-4325-408f-8b8e-f9ad085991b0",
+      "ConcordiaCourseId": "006158"
+    },
+    {
+      "Id": "a61a839b-f024-4482-8c6f-ee66a844c188",
+      "ConcordiaCourseId": "006161"
+    },
+    {
+      "Id": "d3c4f950-c2e2-4735-a019-c40f1f7f72d4",
+      "ConcordiaCourseId": "006166"
+    },
+    {
+      "Id": "2d7d7808-0ff5-4133-880d-80c496fe7057",
+      "ConcordiaCourseId": "006168"
+    },
+    {
+      "Id": "67184248-e12e-4321-a214-dabe908dc3a2",
+      "ConcordiaCourseId": "006169"
+    },
+    {
+      "Id": "6dd57f0a-2b8c-497f-b9a4-42f90634b0d8",
+      "ConcordiaCourseId": "006173"
+    },
+    {
+      "Id": "ba1ff870-90fe-4cde-968d-113b5278c15f",
+      "ConcordiaCourseId": "006174"
+    },
+    {
+      "Id": "6f22bb92-4750-469e-b83d-dce8b32c8ef0",
+      "ConcordiaCourseId": "006201"
+    },
+    {
+      "Id": "fc4b0ade-88db-4792-bdda-ed6b0afb7865",
+      "ConcordiaCourseId": "006202"
+    },
+    {
+      "Id": "9c91607e-cf47-422d-8107-52413c44c2f5",
+      "ConcordiaCourseId": "006204"
+    },
+    {
+      "Id": "3865cd46-82d9-4fb9-921e-0ca38bdb400d",
+      "ConcordiaCourseId": "006209"
+    },
+    {
+      "Id": "b07cf55c-b0fc-4f32-8a9c-7e9c49d7075b",
+      "ConcordiaCourseId": "006210"
+    },
+    {
+      "Id": "bea2dbbd-8365-44c9-9513-396bf1205682",
+      "ConcordiaCourseId": "006211"
+    },
+    {
+      "Id": "54a5ccd5-85bf-4928-a0f3-719552e06702",
+      "ConcordiaCourseId": "006213"
+    },
+    {
+      "Id": "9dde7159-3d04-4671-83c0-040cd65abce2",
+      "ConcordiaCourseId": "006224"
+    },
+    {
+      "Id": "31795acd-0a9c-4f98-9e96-5668e0714db6",
+      "ConcordiaCourseId": "006225"
+    },
+    {
+      "Id": "4477e92a-d06b-494e-9a65-d1726f92a2aa",
+      "ConcordiaCourseId": "006227"
+    },
+    {
+      "Id": "89752c29-11e6-462d-817e-29cdd7af2293",
+      "ConcordiaCourseId": "006228"
+    },
+    {
+      "Id": "de57a3a8-f205-495b-b367-ec842d89687a",
+      "ConcordiaCourseId": "006229"
+    },
+    {
+      "Id": "a805f441-af00-4a2c-8469-ea34586e85f4",
+      "ConcordiaCourseId": "006230"
+    },
+    {
+      "Id": "ea94aea9-0268-48e6-9935-39cd4b2ddbae",
+      "ConcordiaCourseId": "006231"
+    },
+    {
+      "Id": "ef698ea2-ee72-412d-adf7-ecd6bb2ffe7b",
+      "ConcordiaCourseId": "006232"
+    },
+    {
+      "Id": "d1788798-c651-4159-8cef-ba46be4d00a2",
+      "ConcordiaCourseId": "006237"
+    },
+    {
+      "Id": "d0f01737-9ec7-4ea7-90e0-7e014b3b67ad",
+      "ConcordiaCourseId": "006241"
+    },
+    {
+      "Id": "73f595e0-4b39-4b99-bb92-4a84672caf51",
+      "ConcordiaCourseId": "006246"
+    },
+    {
+      "Id": "6413d4de-7e70-4a90-9a27-652784d897e4",
+      "ConcordiaCourseId": "006251"
+    },
+    {
+      "Id": "aab34611-153f-4dac-b8c3-ecc0d09d3ba0",
+      "ConcordiaCourseId": "006252"
+    },
+    {
+      "Id": "9304fe75-83f1-4a7b-b385-5a925ea85c21",
+      "ConcordiaCourseId": "006256"
+    },
+    {
+      "Id": "e01aae4b-edd6-4c55-a3f8-cceb88873939",
+      "ConcordiaCourseId": "006262"
+    },
+    {
+      "Id": "1ed0ace7-45f6-4e13-88af-c935162095df",
+      "ConcordiaCourseId": "006263"
+    },
+    {
+      "Id": "86758f35-47c1-4359-b556-6ebb6d40b5c1",
+      "ConcordiaCourseId": "006264"
+    },
+    {
+      "Id": "b12ffe79-e28f-43f4-a6c5-5059658d3c5b",
+      "ConcordiaCourseId": "006266"
+    },
+    {
+      "Id": "cfcd9a88-c108-487b-8898-c7b009bf8b07",
+      "ConcordiaCourseId": "006268"
+    },
+    {
+      "Id": "afc861f6-957e-47d5-84b0-3dd5715c24e2",
+      "ConcordiaCourseId": "006273"
+    },
+    {
+      "Id": "eda333f0-c31b-4381-bef5-4f3084af7043",
+      "ConcordiaCourseId": "006274"
+    },
+    {
+      "Id": "58dcf21f-9225-4f38-9f5f-439b6ac1d5f0",
+      "ConcordiaCourseId": "006276"
+    },
+    {
+      "Id": "9b7509c3-a5c1-4983-ba13-7848a768ee3b",
+      "ConcordiaCourseId": "006283"
+    },
+    {
+      "Id": "30e57cab-e63a-4db3-920f-ca424514f372",
+      "ConcordiaCourseId": "006284"
+    },
+    {
+      "Id": "1f122f5b-4daf-405e-92c8-2caa13ae0870",
+      "ConcordiaCourseId": "006286"
+    },
+    {
+      "Id": "5df6e2d4-71f9-45ad-80b2-302ae3ff809c",
+      "ConcordiaCourseId": "006287"
+    },
+    {
+      "Id": "c673cbd4-2947-4aa8-a4fe-90efbfb69bbd",
+      "ConcordiaCourseId": "006288"
+    },
+    {
+      "Id": "37be6d33-e99f-48d0-b82f-a26caae79f8e",
+      "ConcordiaCourseId": "006289"
+    },
+    {
+      "Id": "69dd4b14-3d25-419c-9740-cfcec2a884ab",
+      "ConcordiaCourseId": "006290"
+    },
+    {
+      "Id": "4998796d-06c8-4a03-b49f-d33701e6a578",
+      "ConcordiaCourseId": "006291"
+    },
+    {
+      "Id": "8b9eb2db-8db7-473f-a5b0-ce089ba9e0c5",
+      "ConcordiaCourseId": "006292"
+    },
+    {
+      "Id": "efe21f62-ea2b-4f23-8cff-5d87c272612f",
+      "ConcordiaCourseId": "006293"
+    },
+    {
+      "Id": "cbac8928-ab30-45a8-8b98-6057e29609aa",
+      "ConcordiaCourseId": "006294"
+    },
+    {
+      "Id": "f7051f6c-1f2c-4d5f-b40f-25f6c7a44bcd",
+      "ConcordiaCourseId": "006295"
+    },
+    {
+      "Id": "3b08b38d-3d23-456f-a386-25a5149a90c8",
+      "ConcordiaCourseId": "006296"
+    },
+    {
+      "Id": "73de0e32-f1d9-4b0b-90b5-8fe63b0afc1c",
+      "ConcordiaCourseId": "006297"
+    },
+    {
+      "Id": "1d99eedf-a08d-4b14-87cd-2ded09f86297",
+      "ConcordiaCourseId": "006298"
+    },
+    {
+      "Id": "ac8bcfb5-cb4a-4146-b2e7-6f24808b2d60",
+      "ConcordiaCourseId": "006299"
+    },
+    {
+      "Id": "1faf3a7c-4ddc-4834-9214-a9f27edfbf42",
+      "ConcordiaCourseId": "006300"
+    },
+    {
+      "Id": "1f422407-999b-4bea-9844-812024b98e0b",
+      "ConcordiaCourseId": "006302"
+    },
+    {
+      "Id": "0deaa14b-a1fc-4cb4-a1fe-04fc3de47483",
+      "ConcordiaCourseId": "006325"
+    },
+    {
+      "Id": "dfe147c8-ddef-4289-b835-2e5a774e699e",
+      "ConcordiaCourseId": "006326"
+    },
+    {
+      "Id": "c3519e1d-fe49-4782-a3ea-84cf2572d6a1",
+      "ConcordiaCourseId": "040366"
+    },
+    {
+      "Id": "20c62425-bae0-4eb9-8270-ea08fffd4c17",
+      "ConcordiaCourseId": "040369"
+    },
+    {
+      "Id": "29e5fe01-ea2d-4aa1-8dea-54bc10bdcb1d",
+      "ConcordiaCourseId": "040378"
+    },
+    {
+      "Id": "b49e9957-6063-4fe8-a3aa-ad0b98c94e81",
+      "ConcordiaCourseId": "040391"
+    },
+    {
+      "Id": "dc3e0b2b-d1c3-4a77-b455-93b6f5ca0a3d",
+      "ConcordiaCourseId": "040393"
+    },
+    {
+      "Id": "84000300-cff8-4860-bd3a-f372b241e912",
+      "ConcordiaCourseId": "040394"
+    },
+    {
+      "Id": "fe732399-5ed6-4cca-9857-6ab896a902f8",
+      "ConcordiaCourseId": "040395"
+    },
+    {
+      "Id": "ac251d75-335e-4302-ac91-c8455db0bf9c",
+      "ConcordiaCourseId": "040410"
+    },
+    {
+      "Id": "55ed8da2-866e-465d-8696-2472017afbc9",
+      "ConcordiaCourseId": "040422"
+    },
+    {
+      "Id": "6cc9d34f-453e-45e2-859d-fa6631a4b91b",
+      "ConcordiaCourseId": "040423"
+    },
+    {
+      "Id": "4d273711-0aa7-466c-bf52-a33fe138ac9b",
+      "ConcordiaCourseId": "040424"
+    },
+    {
+      "Id": "67684f56-f60f-4e6b-b6c6-bf7d98d1a742",
+      "ConcordiaCourseId": "040425"
+    },
+    {
+      "Id": "974d9d0d-3a62-4e79-9691-be47c17571e9",
+      "ConcordiaCourseId": "040426"
+    },
+    {
+      "Id": "f5e1e6a3-7fa5-4ae0-b539-aff0207c6ba3",
+      "ConcordiaCourseId": "045082"
+    },
+    {
+      "Id": "0de004ca-b83c-4759-866e-17258c88cb5b",
+      "ConcordiaCourseId": "045268"
+    },
+    {
+      "Id": "1dded4e3-c6b7-4417-9010-49bccd27b949",
+      "ConcordiaCourseId": "045269"
+    },
+    {
+      "Id": "5a43804d-f7cc-4aea-9ebf-95fdb2352cec",
+      "ConcordiaCourseId": "045271"
+    },
+    {
+      "Id": "8ef34ae6-7300-4931-834a-23a970dea687",
+      "ConcordiaCourseId": "046587"
+    },
+    {
+      "Id": "5507c07c-acbc-4de0-ae96-2c6a35108e24",
+      "ConcordiaCourseId": "046588"
+    },
+    {
+      "Id": "afcba76b-7247-4cd9-8025-eb9ceedd7cba",
+      "ConcordiaCourseId": "046589"
+    },
+    {
+      "Id": "ec97931a-27b4-4e59-94d0-86b615b8ba20",
+      "ConcordiaCourseId": "046590"
+    },
+    {
+      "Id": "064f1094-a582-464a-b2ea-b7d730305a05",
+      "ConcordiaCourseId": "046591"
+    },
+    {
+      "Id": "0a980ec3-0c83-4648-b14c-f7396cc6b284",
+      "ConcordiaCourseId": "046592"
+    },
+    {
+      "Id": "086bbdb3-2793-43f8-ad62-efccc35303f7",
+      "ConcordiaCourseId": "046593"
+    },
+    {
+      "Id": "5c7bfeb3-e3fb-473b-accd-89e9fc6c3830",
+      "ConcordiaCourseId": "046594"
+    },
+    {
+      "Id": "a6b7aa83-b0cf-4c63-b15d-b459c6c78ef7",
+      "ConcordiaCourseId": "046595"
+    },
+    {
+      "Id": "b5774d58-ed05-4fbf-9207-5a767d1d60be",
+      "ConcordiaCourseId": "046596"
+    },
+    {
+      "Id": "cb85ea54-e767-4463-b644-8f2f95dc2f63",
+      "ConcordiaCourseId": "046597"
+    },
+    {
+      "Id": "88311bc5-fc67-49bb-ab5b-1d719453a812",
+      "ConcordiaCourseId": "046598"
+    },
+    {
+      "Id": "8b1efb5d-46fa-4782-98e2-5e8115c5ba75",
+      "ConcordiaCourseId": "046599"
+    },
+    {
+      "Id": "a7fb4ccb-23e7-46f3-9dbb-031a2d39184d",
+      "ConcordiaCourseId": "046600"
+    },
+    {
+      "Id": "0cbdd496-f906-4211-a176-914f8f5a7fe4",
+      "ConcordiaCourseId": "046601"
+    },
+    {
+      "Id": "3de8d0d5-3568-49cc-acf3-9871aa774b70",
+      "ConcordiaCourseId": "046602"
+    },
+    {
+      "Id": "04c00446-c2ab-4127-a6b8-3836caf4825d",
+      "ConcordiaCourseId": "046603"
+    },
+    {
+      "Id": "b0ef6bbc-3a96-483a-bdd0-d55f6f19827d",
+      "ConcordiaCourseId": "046604"
+    },
+    {
+      "Id": "81364807-a770-49f3-8e62-04ae896196c8",
+      "ConcordiaCourseId": "048639"
+    },
+    {
+      "Id": "f4fd18a8-c0fd-48d2-9dc2-6f9d94a1bc20",
+      "ConcordiaCourseId": "048640"
+    },
+    {
+      "Id": "a607cb4d-3851-4540-b364-ab40450323d2",
+      "ConcordiaCourseId": "048641"
+    },
+    {
+      "Id": "c4caffb0-23af-4fbd-bcda-065b2868d8ac",
+      "ConcordiaCourseId": "048765"
+    },
+    {
+      "Id": "c2cd1e1a-9b34-45b9-857b-2f0f016a1fc9",
+      "ConcordiaCourseId": "048766"
+    },
+    {
+      "Id": "310edf67-864c-4c5f-9806-3738086b303a",
+      "ConcordiaCourseId": "048767"
+    },
+    {
+      "Id": "07bf18a3-bdf4-47a2-9168-2a8df1039f7c",
+      "ConcordiaCourseId": "048768"
+    },
+    {
+      "Id": "b56f26f0-5211-417f-8a2b-fa5cdc95cd22",
+      "ConcordiaCourseId": "048769"
+    },
+    {
+      "Id": "8f812dfd-7af9-4702-a076-5d5e2b81a082",
+      "ConcordiaCourseId": "048770"
+    },
+    {
+      "Id": "4ae690dd-b619-49e6-a455-4c44aafb7a27",
+      "ConcordiaCourseId": "048771"
+    },
+    {
+      "Id": "3ee90c56-83fa-479e-8412-066bc1ab3ca2",
+      "ConcordiaCourseId": "048772"
+    },
+    {
+      "Id": "23cf4356-96d6-472f-9675-c0b2ad80c3ea",
+      "ConcordiaCourseId": "049014"
+    },
+    {
+      "Id": "3a1265c4-5143-40cf-8839-a893fff5b608",
+      "ConcordiaCourseId": "046605"
+    },
+    {
+      "Id": "5328bbc7-e5dd-4e27-a219-474dbf425af0",
+      "ConcordiaCourseId": "006469"
+    },
+    {
+      "Id": "cd1dc01d-cf61-490b-8e29-de1be7735b87",
+      "ConcordiaCourseId": "006471"
+    },
+    {
+      "Id": "9ecbc045-0478-40cb-9210-fc62d1b254e3",
+      "ConcordiaCourseId": "006473"
+    },
+    {
+      "Id": "4a020003-608a-4782-b7e7-b5aae979aba6",
+      "ConcordiaCourseId": "006475"
+    },
+    {
+      "Id": "3044865e-3b0e-4706-98fd-5fc61a9a9fc7",
+      "ConcordiaCourseId": "006483"
+    },
+    {
+      "Id": "9b0f837b-68cd-418b-bdbc-5b093194463a",
+      "ConcordiaCourseId": "006485"
+    },
+    {
+      "Id": "c0fe480d-cd97-4d8c-b1ca-f54cc0b1e134",
+      "ConcordiaCourseId": "006487"
+    },
+    {
+      "Id": "bb905842-2562-4737-b98f-dec0465f361e",
+      "ConcordiaCourseId": "006489"
+    },
+    {
+      "Id": "e83fde6e-571b-4952-ac01-1ecdeccd61f0",
+      "ConcordiaCourseId": "006497"
+    },
+    {
+      "Id": "c8eca77b-1772-4212-b42b-aef9c3c8ad89",
+      "ConcordiaCourseId": "006500"
+    },
+    {
+      "Id": "086238b5-2a93-4d13-92a5-4a15f453afd3",
+      "ConcordiaCourseId": "006502"
+    },
+    {
+      "Id": "6dc1b901-369a-47d7-861e-4b716b70fc2b",
+      "ConcordiaCourseId": "006504"
+    },
+    {
+      "Id": "16ab196e-a0b8-423f-955d-e9b613e22433",
+      "ConcordiaCourseId": "006512"
+    },
+    {
+      "Id": "40affaa2-1e87-4163-b3cc-62c46f01914f",
+      "ConcordiaCourseId": "006515"
+    },
+    {
+      "Id": "d5aabec6-cbfc-411d-97fc-e511aaac4eb6",
+      "ConcordiaCourseId": "006517"
+    },
+    {
+      "Id": "9a73c9fd-5091-431b-a648-e466a9521139",
+      "ConcordiaCourseId": "006519"
+    },
+    {
+      "Id": "eb2b212c-27a8-4d14-9ffb-b1b3d1e18c69",
+      "ConcordiaCourseId": "006534"
+    },
+    {
+      "Id": "10de83af-f798-4073-83b5-79e293b9bb3a",
+      "ConcordiaCourseId": "006541"
+    },
+    {
+      "Id": "ccc6a96a-111d-4c0d-a667-40fd23bf12df",
+      "ConcordiaCourseId": "006542"
+    },
+    {
+      "Id": "51363d95-b70d-4c6a-bbed-6b6d0294caf2",
+      "ConcordiaCourseId": "006543"
+    },
+    {
+      "Id": "802beafb-3896-4523-b1d3-a83e87cd4a9d",
+      "ConcordiaCourseId": "006544"
+    },
+    {
+      "Id": "e3e15e90-e134-44b9-b941-d217afd336a5",
+      "ConcordiaCourseId": "006545"
+    },
+    {
+      "Id": "aa3759ce-7775-4cdb-a724-a73a0d642f2c",
+      "ConcordiaCourseId": "006546"
+    },
+    {
+      "Id": "3a4e725f-c4d9-4eca-95ad-a66263396a25",
+      "ConcordiaCourseId": "006547"
+    },
+    {
+      "Id": "904f4eb8-4042-4172-8c16-683be8e60b5b",
+      "ConcordiaCourseId": "006548"
+    },
+    {
+      "Id": "25dca011-5c98-45bc-a8bd-159aac4b02ff",
+      "ConcordiaCourseId": "006549"
+    },
+    {
+      "Id": "2b9debcc-c268-4ae9-b3ad-43b9f09b5714",
+      "ConcordiaCourseId": "006550"
+    },
+    {
+      "Id": "b61605bf-f26f-413e-9b37-77b8641beb53",
+      "ConcordiaCourseId": "006551"
+    },
+    {
+      "Id": "9f5b6b55-c19d-43f5-a9cc-667665731b36",
+      "ConcordiaCourseId": "006552"
+    },
+    {
+      "Id": "42fd3372-ab54-4251-9c5d-4ecac3e068d5",
+      "ConcordiaCourseId": "006554"
+    },
+    {
+      "Id": "c08e91aa-9101-42a1-9ba1-3c17eadac8ee",
+      "ConcordiaCourseId": "006555"
+    },
+    {
+      "Id": "4c3d9697-70f8-4e24-b479-3a2d03b38547",
+      "ConcordiaCourseId": "006557"
+    },
+    {
+      "Id": "9fba5d5b-d91b-4faa-a2e8-254c5ea3bf22",
+      "ConcordiaCourseId": "006562"
+    },
+    {
+      "Id": "b2f3b978-9410-4429-ae18-b8e86d7fbd33",
+      "ConcordiaCourseId": "006563"
+    },
+    {
+      "Id": "f0198321-79cc-489d-aaff-57668263a4f8",
+      "ConcordiaCourseId": "006564"
+    },
+    {
+      "Id": "572c1170-48e9-43a9-a0f4-34014e5d722e",
+      "ConcordiaCourseId": "006566"
+    },
+    {
+      "Id": "05450cfd-8d8b-48a0-a027-1e7222bf33e4",
+      "ConcordiaCourseId": "006567"
+    },
+    {
+      "Id": "cd721e49-c211-491a-a7cd-9b369d0af47d",
+      "ConcordiaCourseId": "006570"
+    },
+    {
+      "Id": "fc02d231-e12c-4aa4-966f-bb59deef212d",
+      "ConcordiaCourseId": "006572"
+    },
+    {
+      "Id": "52b4029e-6d53-4014-9980-0e29291ef24a",
+      "ConcordiaCourseId": "006592"
+    },
+    {
+      "Id": "1bfacb2c-4341-4e91-8319-1db8a82a2015",
+      "ConcordiaCourseId": "006593"
+    },
+    {
+      "Id": "f1f541be-95cc-4bee-9368-6102edf918a2",
+      "ConcordiaCourseId": "006595"
+    },
+    {
+      "Id": "30e48f28-bc6d-4f59-8746-0829e0720d4b",
+      "ConcordiaCourseId": "006596"
+    },
+    {
+      "Id": "09a1cf57-6cea-4855-a2a3-965833812a90",
+      "ConcordiaCourseId": "006597"
+    },
+    {
+      "Id": "b7097793-59bf-4824-a8a1-2a56a719bb1f",
+      "ConcordiaCourseId": "046606"
+    },
+    {
+      "Id": "70a3f582-a757-43bf-bd50-5b04423d10f0",
+      "ConcordiaCourseId": "046607"
+    },
+    {
+      "Id": "bec98d97-27e7-4e6a-b92b-f2513fa72eac",
+      "ConcordiaCourseId": "046608"
+    },
+    {
+      "Id": "13ee3e4f-e56c-4fb1-936f-c02b66ace923",
+      "ConcordiaCourseId": "046609"
+    },
+    {
+      "Id": "17ec13ae-603b-491f-a0c6-d3cc92f1a66a",
+      "ConcordiaCourseId": "046610"
+    },
+    {
+      "Id": "19316792-1436-4d10-8e8c-b49abf599adf",
+      "ConcordiaCourseId": "006622"
+    },
+    {
+      "Id": "c88c8fca-aeb8-49f4-91ec-4d1c00c3d64f",
+      "ConcordiaCourseId": "006626"
+    },
+    {
+      "Id": "cf8daa9c-6745-4d68-bd2f-0b46387f2777",
+      "ConcordiaCourseId": "006627"
+    },
+    {
+      "Id": "92837280-d7d7-4887-8291-56ae60dfaa95",
+      "ConcordiaCourseId": "006628"
+    },
+    {
+      "Id": "291fee9c-3917-491b-adef-03a6c54423ea",
+      "ConcordiaCourseId": "006629"
+    },
+    {
+      "Id": "8f3b7b4c-031a-4e22-84b4-3bb082535867",
+      "ConcordiaCourseId": "006631"
+    },
+    {
+      "Id": "e74d3a86-1492-4d27-a097-f5d29cc7297a",
+      "ConcordiaCourseId": "006632"
+    },
+    {
+      "Id": "cbbd3ac0-2141-4954-93af-6e9775959efd",
+      "ConcordiaCourseId": "006636"
+    },
+    {
+      "Id": "537c3e4b-f83e-42f6-afb5-9d1347cc1af5",
+      "ConcordiaCourseId": "006637"
+    },
+    {
+      "Id": "6d1048ef-1f7a-40ca-80e0-29d7863a022d",
+      "ConcordiaCourseId": "006638"
+    },
+    {
+      "Id": "98e584eb-f127-4d90-9efa-16c7e10316dd",
+      "ConcordiaCourseId": "006639"
+    },
+    {
+      "Id": "f1d48249-0616-4c98-ac4f-2682eff3173c",
+      "ConcordiaCourseId": "006640"
+    },
+    {
+      "Id": "23d422e5-eb67-467e-8c8a-e923d7a91980",
+      "ConcordiaCourseId": "006642"
+    },
+    {
+      "Id": "bb8cb7ab-3931-4921-abab-a224c8fb275b",
+      "ConcordiaCourseId": "006643"
+    },
+    {
+      "Id": "f67af78e-6fc7-4b2b-9056-7d5e8d945e5f",
+      "ConcordiaCourseId": "006658"
+    },
+    {
+      "Id": "285d51bf-acc0-4cfc-85a9-4ffe03093dbc",
+      "ConcordiaCourseId": "006660"
+    },
+    {
+      "Id": "b4010bb4-aed1-4828-9f54-88edcfeeba59",
+      "ConcordiaCourseId": "006661"
+    },
+    {
+      "Id": "4d680d23-6085-48ac-b248-b127ba66ef8c",
+      "ConcordiaCourseId": "006663"
+    },
+    {
+      "Id": "bf24208d-5398-49da-9dcf-676ea574cb5c",
+      "ConcordiaCourseId": "006666"
+    },
+    {
+      "Id": "97e559a4-0c80-4100-a7c3-f7a2674e78c5",
+      "ConcordiaCourseId": "006667"
+    },
+    {
+      "Id": "c7edbfa0-434b-4ea9-a3f5-91280f766f1e",
+      "ConcordiaCourseId": "006668"
+    },
+    {
+      "Id": "ce5a0655-9ef5-4fc7-88e1-111e0556847a",
+      "ConcordiaCourseId": "006669"
+    },
+    {
+      "Id": "a428ba1b-3ea2-42f8-9dc9-604adaab6be6",
+      "ConcordiaCourseId": "006671"
+    },
+    {
+      "Id": "c737c6d8-766f-489d-a897-a3041f5fb608",
+      "ConcordiaCourseId": "006673"
+    },
+    {
+      "Id": "53180fef-2a52-46a9-8afb-31d05cd8d27d",
+      "ConcordiaCourseId": "006674"
+    },
+    {
+      "Id": "c12aeb79-5ef5-4141-81b2-7e000054b3f7",
+      "ConcordiaCourseId": "006675"
+    },
+    {
+      "Id": "1e098518-48ca-4b85-b2e9-b2ed8989e12f",
+      "ConcordiaCourseId": "006677"
+    },
+    {
+      "Id": "560c3737-66d2-452e-be49-c5e2ad7d0231",
+      "ConcordiaCourseId": "006678"
+    },
+    {
+      "Id": "a3c482ce-0f9c-40ce-bfee-7b8ca2f79d03",
+      "ConcordiaCourseId": "006681"
+    },
+    {
+      "Id": "782c120f-c9ac-4b24-ae72-ff05de9004ee",
+      "ConcordiaCourseId": "006682"
+    },
+    {
+      "Id": "1bceb34e-ecee-4365-954b-d0d405e02108",
+      "ConcordiaCourseId": "006692"
+    },
+    {
+      "Id": "647a0904-2551-4b73-a3e3-a989acdf28ee",
+      "ConcordiaCourseId": "006694"
+    },
+    {
+      "Id": "9ff1eb5b-feae-4aaa-90b3-94b0c42db018",
+      "ConcordiaCourseId": "006695"
+    },
+    {
+      "Id": "0474a471-baec-4a6d-84d8-85b1c5658126",
+      "ConcordiaCourseId": "006696"
+    },
+    {
+      "Id": "45ade122-3642-47b3-8a39-c04f341b9655",
+      "ConcordiaCourseId": "006697"
+    },
+    {
+      "Id": "3932901c-d686-489c-b9a2-82e1f8a2098d",
+      "ConcordiaCourseId": "044021"
+    },
+    {
+      "Id": "e7887899-c5ce-437c-92c8-47b6f66219d9",
+      "ConcordiaCourseId": "046611"
+    },
+    {
+      "Id": "2f96a966-ab2f-45e8-8120-f700f6c266bd",
+      "ConcordiaCourseId": "046612"
+    },
+    {
+      "Id": "54496ab1-7309-4128-a016-0c08de1d12a5",
+      "ConcordiaCourseId": "046613"
+    },
+    {
+      "Id": "76c4bd63-117d-4677-aef0-1b472217cfa6",
+      "ConcordiaCourseId": "047245"
+    },
+    {
+      "Id": "71181930-9ba2-49d8-af2f-8e8678713aa6",
+      "ConcordiaCourseId": "047469"
+    },
+    {
+      "Id": "a8c9170b-fd8c-4ed6-b92d-b7912732827b",
+      "ConcordiaCourseId": "047470"
+    },
+    {
+      "Id": "82485c40-a812-4ae4-92f5-8b3872493325",
+      "ConcordiaCourseId": "047931"
+    },
+    {
+      "Id": "d44e7107-7b84-4c2b-8ece-fc3eb4de616d",
+      "ConcordiaCourseId": "047932"
+    },
+    {
+      "Id": "652c3da9-7bee-43b4-9530-3a3fcd8b707f",
+      "ConcordiaCourseId": "047933"
+    },
+    {
+      "Id": "a72895b3-787e-4a18-9538-05fb6adf1ff2",
+      "ConcordiaCourseId": "047934"
+    },
+    {
+      "Id": "da1cbdaf-9155-46c6-87b3-b1cc3303a7c2",
+      "ConcordiaCourseId": "047935"
+    },
+    {
+      "Id": "86370d23-6aa4-43bd-bd36-87b89ac5c76f",
+      "ConcordiaCourseId": "047936"
+    },
+    {
+      "Id": "fe949de0-6c69-4886-a2a0-208c370b78a2",
+      "ConcordiaCourseId": "047937"
+    },
+    {
+      "Id": "d1adb043-50c7-43be-8fff-057d3e2fbb56",
+      "ConcordiaCourseId": "047938"
+    },
+    {
+      "Id": "e4c579e2-d1f3-47d3-bbc9-19ab9d754074",
+      "ConcordiaCourseId": "047939"
+    },
+    {
+      "Id": "bc443a68-ef8f-4b78-a4ba-30ed1a0ad6e3",
+      "ConcordiaCourseId": "047940"
+    },
+    {
+      "Id": "67e214fe-615c-4181-afba-6bbc7a15122a",
+      "ConcordiaCourseId": "048902"
+    },
+    {
+      "Id": "cea7c200-68d1-4675-86dd-3a7148f74e5d",
+      "ConcordiaCourseId": "048903"
+    },
+    {
+      "Id": "e86761a7-0aae-4c6f-82b6-665f36dd829c",
+      "ConcordiaCourseId": "048904"
+    },
+    {
+      "Id": "eaae38a4-ac63-4956-b91c-72b4a2c1b4de",
+      "ConcordiaCourseId": "048930"
+    },
+    {
+      "Id": "65ad4e3d-2301-4cff-b071-c9f5dd1e526e",
+      "ConcordiaCourseId": "049160"
+    },
+    {
+      "Id": "e0dda0e9-8ed4-42a4-949c-e4f709800e72",
+      "ConcordiaCourseId": "049346"
+    },
+    {
+      "Id": "a77864a4-be06-4818-892d-ec706b7eb708",
+      "ConcordiaCourseId": "049689"
+    },
+    {
+      "Id": "691a67b0-246e-45d2-b78c-4db618740443",
+      "ConcordiaCourseId": "049691"
+    },
+    {
+      "Id": "743186a2-c2f8-4e68-83e1-e48258aff55e",
+      "ConcordiaCourseId": "049692"
+    },
+    {
+      "Id": "09a50c42-6b1e-4f73-8258-ed57aac90b3c",
+      "ConcordiaCourseId": "049693"
+    },
+    {
+      "Id": "0b9b0142-efc3-44a5-9768-913ea6d42039",
+      "ConcordiaCourseId": "049736"
+    },
+    {
+      "Id": "4e92eb27-c14b-47ab-a5aa-7eecb02efa7f",
+      "ConcordiaCourseId": "006792"
+    },
+    {
+      "Id": "de967d93-ea32-411f-84c0-aff8336dbcd1",
+      "ConcordiaCourseId": "006798"
+    },
+    {
+      "Id": "ab949d08-0946-446b-b6b1-fdc0cac59ffd",
+      "ConcordiaCourseId": "006813"
+    },
+    {
+      "Id": "0cb207ef-5ccd-42a7-bfa3-b8313a6aaf4c",
+      "ConcordiaCourseId": "006818"
+    },
+    {
+      "Id": "cf18d295-999a-4dd6-9345-816f49415edc",
+      "ConcordiaCourseId": "037672"
+    },
+    {
+      "Id": "d8833f74-ee72-44f7-bfb1-45c3b2ad4ad8",
+      "ConcordiaCourseId": "046614"
+    },
+    {
+      "Id": "3c8258c6-457e-405b-aaf7-b5000877816d",
+      "ConcordiaCourseId": "046615"
+    },
+    {
+      "Id": "ae89cc1b-0b8d-4590-8d68-f16c409eccd6",
+      "ConcordiaCourseId": "046616"
+    },
+    {
+      "Id": "1efab7f5-c24d-45ad-bac8-cdcf9fd82d63",
+      "ConcordiaCourseId": "046617"
+    },
+    {
+      "Id": "d5ce3c46-9bfa-4c22-9bdd-d3f47926a367",
+      "ConcordiaCourseId": "046618"
+    },
+    {
+      "Id": "2a9dec23-e621-4bb4-9002-cbf9ee55bcff",
+      "ConcordiaCourseId": "046619"
+    },
+    {
+      "Id": "e7334a48-2644-4ead-9e12-93a2783053d3",
+      "ConcordiaCourseId": "046620"
+    },
+    {
+      "Id": "ce1e833f-5a64-47fe-ac04-137ffc14516d",
+      "ConcordiaCourseId": "006902"
+    },
+    {
+      "Id": "f487430a-4e70-4947-ab66-15ca5ed414d0",
+      "ConcordiaCourseId": "006906"
+    },
+    {
+      "Id": "9958ba91-87c8-4cdc-804d-10fd8dcf2ff3",
+      "ConcordiaCourseId": "006907"
+    },
+    {
+      "Id": "a8778cb1-c17e-4a96-89f0-8eb72b15924d",
+      "ConcordiaCourseId": "006908"
+    },
+    {
+      "Id": "ea8b6dab-7567-4edc-bd5f-fdb0f0cfda23",
+      "ConcordiaCourseId": "006909"
+    },
+    {
+      "Id": "62868883-cefe-4a0e-af9d-c2d9d32e51f3",
+      "ConcordiaCourseId": "006910"
+    },
+    {
+      "Id": "07ecd4db-d484-4ebe-842f-f6283837125e",
+      "ConcordiaCourseId": "006911"
+    },
+    {
+      "Id": "9cb83af5-8c33-4c2b-84df-ed570a593490",
+      "ConcordiaCourseId": "006912"
+    },
+    {
+      "Id": "e54fcfc6-be20-4170-a20d-8acd8de420d7",
+      "ConcordiaCourseId": "006913"
+    },
+    {
+      "Id": "f39a4859-ce05-4a31-868f-fbd4c2d83ac9",
+      "ConcordiaCourseId": "006914"
+    },
+    {
+      "Id": "b7e3323e-b6c1-40f1-959f-011280c89e6c",
+      "ConcordiaCourseId": "006915"
+    },
+    {
+      "Id": "78924447-8bcb-445a-a3a4-b72a1a1804e7",
+      "ConcordiaCourseId": "006916"
+    },
+    {
+      "Id": "a5c15017-f38f-4993-adcb-994516982694",
+      "ConcordiaCourseId": "006922"
+    },
+    {
+      "Id": "d00d0229-0b18-48de-af1d-65650e2015a4",
+      "ConcordiaCourseId": "006923"
+    },
+    {
+      "Id": "702de473-068e-4457-a1b5-bb4e23f3e4c0",
+      "ConcordiaCourseId": "006924"
+    },
+    {
+      "Id": "fd9ec942-6cde-453b-8bc5-5a2245300a07",
+      "ConcordiaCourseId": "046621"
+    },
+    {
+      "Id": "9dc1fc89-87e9-419b-a9db-c401a1dd07a1",
+      "ConcordiaCourseId": "046622"
+    },
+    {
+      "Id": "0cb239a4-c9bd-4c79-a553-3875259a9695",
+      "ConcordiaCourseId": "046623"
+    },
+    {
+      "Id": "321e88c9-842c-4057-b9be-3b503edba044",
+      "ConcordiaCourseId": "047694"
+    },
+    {
+      "Id": "a639f1c1-07e8-4c49-a3db-624a6fe86592",
+      "ConcordiaCourseId": "047695"
+    },
+    {
+      "Id": "97c04536-0600-40a4-a9e5-3f1ddc494570",
+      "ConcordiaCourseId": "047696"
+    },
+    {
+      "Id": "194f9f90-3b26-4ce1-8df8-8ca230301948",
+      "ConcordiaCourseId": "047697"
+    },
+    {
+      "Id": "a584ddef-9e8a-483d-bf65-bf1326cf89e9",
+      "ConcordiaCourseId": "047698"
+    },
+    {
+      "Id": "d46e12be-8b78-4013-a334-3a7281fc9750",
+      "ConcordiaCourseId": "047699"
+    },
+    {
+      "Id": "f585bfee-457c-4782-8c74-2d82da10a13a",
+      "ConcordiaCourseId": "047700"
+    },
+    {
+      "Id": "beefbc30-7e12-43ec-aae6-cc4218876bcf",
+      "ConcordiaCourseId": "047701"
+    },
+    {
+      "Id": "b9258084-4c41-4496-93fa-2676d4c46b82",
+      "ConcordiaCourseId": "047702"
+    },
+    {
+      "Id": "9f8fcd52-eb62-4d6e-bfa1-fd405b74168f",
+      "ConcordiaCourseId": "047703"
+    },
+    {
+      "Id": "e10e3a25-44a7-4b1d-935d-ce064dd1a450",
+      "ConcordiaCourseId": "047704"
+    },
+    {
+      "Id": "00044bfc-d5bd-4fd1-bd1b-9a36ccf251df",
+      "ConcordiaCourseId": "047705"
+    },
+    {
+      "Id": "f513198f-6d97-4ded-b071-67b480a41a4a",
+      "ConcordiaCourseId": "047706"
+    },
+    {
+      "Id": "33469796-bce6-480a-8388-878a0b3afdd8",
+      "ConcordiaCourseId": "047707"
+    },
+    {
+      "Id": "bbec0346-5008-43e7-aebc-739525844070",
+      "ConcordiaCourseId": "050410"
+    },
+    {
+      "Id": "da7986c8-6cc3-4361-a58b-1543882d732a",
+      "ConcordiaCourseId": "046624"
+    },
+    {
+      "Id": "9bd2de20-76fc-438d-b7cb-723b7e6dac31",
+      "ConcordiaCourseId": "046625"
+    },
+    {
+      "Id": "2d1f62ca-790d-40ec-8c68-9817c30974d7",
+      "ConcordiaCourseId": "046626"
+    },
+    {
+      "Id": "51e327ca-2aee-4c93-b7df-f2273cdcdbeb",
+      "ConcordiaCourseId": "006980"
+    },
+    {
+      "Id": "588194b0-739f-4170-afc9-67e5af1501c2",
+      "ConcordiaCourseId": "007028"
+    },
+    {
+      "Id": "a25e53aa-184c-4100-b641-27dbb0cc2a61",
+      "ConcordiaCourseId": "007030"
+    },
+    {
+      "Id": "c78078da-b7e9-4de7-85d3-b7d7b9c2e911",
+      "ConcordiaCourseId": "007039"
+    },
+    {
+      "Id": "42dd1cfd-4598-443e-a322-6fe4e480f08e",
+      "ConcordiaCourseId": "007041"
+    },
+    {
+      "Id": "9f24986a-8374-493e-889d-55baec6fe3f8",
+      "ConcordiaCourseId": "007042"
+    },
+    {
+      "Id": "a5c96aee-9013-4550-b0d7-74e40f17277f",
+      "ConcordiaCourseId": "007043"
+    },
+    {
+      "Id": "75a8f34f-7a86-402f-9460-bf549443660b",
+      "ConcordiaCourseId": "040467"
+    },
+    {
+      "Id": "cdc561ff-a8c2-46de-8e64-a8fc7cc64c1f",
+      "ConcordiaCourseId": "046627"
+    },
+    {
+      "Id": "43ff394d-5c27-4f37-ba8a-e7a8c7f71a32",
+      "ConcordiaCourseId": "046628"
+    },
+    {
+      "Id": "c859bddf-49ed-48f5-8763-b84acf8318f8",
+      "ConcordiaCourseId": "047509"
+    },
+    {
+      "Id": "09516a57-1cb4-4e34-9b33-427a5bc1daac",
+      "ConcordiaCourseId": "047510"
+    },
+    {
+      "Id": "0503d067-d695-4b68-bab9-b5ca153cfeee",
+      "ConcordiaCourseId": "047511"
+    },
+    {
+      "Id": "9f45f82f-c942-4d06-bc48-474bee818ac9",
+      "ConcordiaCourseId": "047513"
+    },
+    {
+      "Id": "aaeaa9ef-fed8-442d-9901-ed43c42abb6f",
+      "ConcordiaCourseId": "047514"
+    },
+    {
+      "Id": "d570b7a6-7afc-4f93-abbb-22691886b555",
+      "ConcordiaCourseId": "047515"
+    },
+    {
+      "Id": "ab52392e-d658-4fb4-be41-3b5855189460",
+      "ConcordiaCourseId": "049333"
+    },
+    {
+      "Id": "59a406a8-c5ee-4a6d-b10a-a14a942a6f0e",
+      "ConcordiaCourseId": "049334"
+    },
+    {
+      "Id": "16eafd31-e5a8-458f-a4d7-4be5dd3738a1",
+      "ConcordiaCourseId": "007054"
+    },
+    {
+      "Id": "ddb96c8d-619e-4aa2-bd31-1d14210803d8",
+      "ConcordiaCourseId": "007055"
+    },
+    {
+      "Id": "a02b5460-58cd-40c1-a355-63a5ec232289",
+      "ConcordiaCourseId": "007056"
+    },
+    {
+      "Id": "f00c1fc4-1881-450b-b392-11950734a11f",
+      "ConcordiaCourseId": "007057"
+    },
+    {
+      "Id": "1cf4fedd-02b6-40be-a753-2a6dda47e663",
+      "ConcordiaCourseId": "007058"
+    },
+    {
+      "Id": "446f2d2a-5605-4fe7-9f13-930f2f6eea13",
+      "ConcordiaCourseId": "007059"
+    },
+    {
+      "Id": "4a5fd1ce-21be-49bb-b48c-6c64c79aaf62",
+      "ConcordiaCourseId": "007061"
+    },
+    {
+      "Id": "a02de538-b0ac-4488-ac39-464b97af0d79",
+      "ConcordiaCourseId": "007062"
+    },
+    {
+      "Id": "4974c024-74cc-4bb3-9767-0d82dc627d18",
+      "ConcordiaCourseId": "007063"
+    },
+    {
+      "Id": "388060f3-b513-493c-af1b-d104c52cb53f",
+      "ConcordiaCourseId": "007064"
+    },
+    {
+      "Id": "1e7183d7-b89a-4150-9a33-79f6d681ca5c",
+      "ConcordiaCourseId": "007065"
+    },
+    {
+      "Id": "b9f2257f-1cb6-4575-9449-44d2f3f95957",
+      "ConcordiaCourseId": "007066"
+    },
+    {
+      "Id": "07a306e5-0dee-4729-8203-511705891208",
+      "ConcordiaCourseId": "046629"
+    },
+    {
+      "Id": "dede5741-44c9-4146-a91d-6bb891d21d5d",
+      "ConcordiaCourseId": "046630"
+    },
+    {
+      "Id": "62bd91d2-9195-414e-90bd-96badc9b98c9",
+      "ConcordiaCourseId": "046631"
+    },
+    {
+      "Id": "28c8a9a3-31c2-4b3f-9706-ad8112d92cf2",
+      "ConcordiaCourseId": "046632"
+    },
+    {
+      "Id": "0ab0e894-c1ff-4613-ae8b-d3bdbcbe8835",
+      "ConcordiaCourseId": "046633"
+    },
+    {
+      "Id": "4593907f-4fc7-4dd1-8f36-b866c85f7448",
+      "ConcordiaCourseId": "007105"
+    },
+    {
+      "Id": "961b60b7-3dee-45a6-aa94-d549730adb75",
+      "ConcordiaCourseId": "007106"
+    },
+    {
+      "Id": "887d8894-c1e8-45b3-8a8b-8ef8b47806aa",
+      "ConcordiaCourseId": "007108"
+    },
+    {
+      "Id": "3756e51f-7cda-4136-9515-4eec1ebe2f1b",
+      "ConcordiaCourseId": "007109"
+    },
+    {
+      "Id": "165fefeb-d287-4997-8a27-c28165d79d99",
+      "ConcordiaCourseId": "007110"
+    },
+    {
+      "Id": "b9d6450d-1d9f-4c45-93c0-57373b8994c4",
+      "ConcordiaCourseId": "007111"
+    },
+    {
+      "Id": "da9fdc92-249f-4e97-b6f6-de9654c643db",
+      "ConcordiaCourseId": "007112"
+    },
+    {
+      "Id": "6615d107-1543-4608-b7eb-9d643ce9de61",
+      "ConcordiaCourseId": "007113"
+    },
+    {
+      "Id": "b80c55c6-931c-4dd3-ae3e-743ed7e0e91e",
+      "ConcordiaCourseId": "007114"
+    },
+    {
+      "Id": "a70ffd8c-9039-419c-b528-99b27c278153",
+      "ConcordiaCourseId": "007115"
+    },
+    {
+      "Id": "10c5cdad-4644-47f0-8811-e5a4cd9b3d51",
+      "ConcordiaCourseId": "007116"
+    },
+    {
+      "Id": "0057c9bf-82a1-4489-9a9f-0cd3e238e5af",
+      "ConcordiaCourseId": "007117"
+    },
+    {
+      "Id": "fb7d8695-7847-423a-af47-ee4062b572e2",
+      "ConcordiaCourseId": "007118"
+    },
+    {
+      "Id": "4e478af8-6259-429e-8c26-c1864067bd2c",
+      "ConcordiaCourseId": "007121"
+    },
+    {
+      "Id": "a6869bf8-61d6-482e-bc90-302ea3cab1d6",
+      "ConcordiaCourseId": "007122"
+    },
+    {
+      "Id": "97947493-9e4d-4a7d-b3f4-2b17016e13c7",
+      "ConcordiaCourseId": "007123"
+    },
+    {
+      "Id": "f033ede9-8b50-485c-9729-ef684d9d8e7a",
+      "ConcordiaCourseId": "007124"
+    },
+    {
+      "Id": "08ec0625-c42f-4d1f-9f97-d28051e20081",
+      "ConcordiaCourseId": "007125"
+    },
+    {
+      "Id": "0d71bf9b-164f-4ba5-a665-fe55e73aed37",
+      "ConcordiaCourseId": "007126"
+    },
+    {
+      "Id": "acb5101d-f224-4445-b808-a6b28fc88013",
+      "ConcordiaCourseId": "007127"
+    },
+    {
+      "Id": "bb735a52-a27e-4152-8ed5-63a1e63a5385",
+      "ConcordiaCourseId": "040478"
+    },
+    {
+      "Id": "8a08e72b-0d20-49fb-adf5-f1fc58bd79b2",
+      "ConcordiaCourseId": "040479"
+    },
+    {
+      "Id": "693946ca-f6e1-4a15-a319-08bc33c712b2",
+      "ConcordiaCourseId": "040480"
+    },
+    {
+      "Id": "64bdfcac-fd08-4e8d-a9d1-de21d8a20ba5",
+      "ConcordiaCourseId": "040481"
+    },
+    {
+      "Id": "dfa03783-2b0c-470c-ad6b-ff2b49756591",
+      "ConcordiaCourseId": "046634"
+    },
+    {
+      "Id": "2f72a329-e911-4fdb-a7ea-0f2921863e57",
+      "ConcordiaCourseId": "047374"
+    },
+    {
+      "Id": "9ca1ec42-5487-4344-a32c-c64a68b9f0ea",
+      "ConcordiaCourseId": "047375"
+    },
+    {
+      "Id": "a034d2cf-a699-4cc7-ae1a-c528855c8aa9",
+      "ConcordiaCourseId": "047376"
+    },
+    {
+      "Id": "50bf938e-73a7-41a6-9d12-30c615c1edcb",
+      "ConcordiaCourseId": "047377"
+    },
+    {
+      "Id": "1d1dd6ec-8e72-4efb-a1df-db217f66700e",
+      "ConcordiaCourseId": "048931"
+    },
+    {
+      "Id": "ac184027-9de0-47cd-abaf-8d07ed2b79dd",
+      "ConcordiaCourseId": "048932"
+    },
+    {
+      "Id": "6bee4f74-cf41-4db4-be84-26d33ec3e680",
+      "ConcordiaCourseId": "049726"
+    },
+    {
+      "Id": "5cefdd33-1bf7-44a6-819f-f182dd70bb78",
+      "ConcordiaCourseId": "049727"
+    },
+    {
+      "Id": "1af65403-11f6-4efb-ba31-2a823049509c",
+      "ConcordiaCourseId": "049728"
+    },
+    {
+      "Id": "94c5d66c-294f-4095-89c7-d047cd0c7715",
+      "ConcordiaCourseId": "049732"
+    },
+    {
+      "Id": "a35392d7-0758-48d3-bca5-4e8816b10113",
+      "ConcordiaCourseId": "007155"
+    },
+    {
+      "Id": "8ebeb05d-a164-4973-8742-f76ff8311c4c",
+      "ConcordiaCourseId": "007158"
+    },
+    {
+      "Id": "f1db623e-d594-4fcc-8554-9f40f2d5edc7",
+      "ConcordiaCourseId": "007160"
+    },
+    {
+      "Id": "b24b30dc-7b44-45cc-9c9c-234a387458be",
+      "ConcordiaCourseId": "007168"
+    },
+    {
+      "Id": "ac38afcf-c0a5-49b5-b822-baaffbce3c71",
+      "ConcordiaCourseId": "007170"
+    },
+    {
+      "Id": "e02e078f-4dad-42cc-a82e-fd823e465f73",
+      "ConcordiaCourseId": "007174"
+    },
+    {
+      "Id": "68ba71ac-3be2-445d-b36b-d8e8ba2fac17",
+      "ConcordiaCourseId": "007175"
+    },
+    {
+      "Id": "221ce3d6-68de-41ce-9ae4-c20f1bc382ed",
+      "ConcordiaCourseId": "007184"
+    },
+    {
+      "Id": "338499e5-e5fb-4f16-a69a-c535f505b2b9",
+      "ConcordiaCourseId": "007185"
+    },
+    {
+      "Id": "76d54cdf-45d1-4670-b192-2b91b04c4fc2",
+      "ConcordiaCourseId": "007188"
+    },
+    {
+      "Id": "4cfa1969-a9f1-4d71-a179-68d29d195a6f",
+      "ConcordiaCourseId": "007190"
+    },
+    {
+      "Id": "227a4a25-240d-4a32-adc8-d714aeec5f30",
+      "ConcordiaCourseId": "007202"
+    },
+    {
+      "Id": "a8f2eecd-4208-466f-80c1-94fbdf3183ab",
+      "ConcordiaCourseId": "007210"
+    },
+    {
+      "Id": "e69bf70f-46e4-46d3-ba1c-fb2b97fd4772",
+      "ConcordiaCourseId": "007211"
+    },
+    {
+      "Id": "d7ea38c5-5c6b-4f9b-ac3f-8483a8fd5f98",
+      "ConcordiaCourseId": "007215"
+    },
+    {
+      "Id": "63efdd9f-f9cc-472f-a6c5-3345cb9fa2fe",
+      "ConcordiaCourseId": "007216"
+    },
+    {
+      "Id": "181efdb4-d40e-476e-8136-dceb69745ba8",
+      "ConcordiaCourseId": "007217"
+    },
+    {
+      "Id": "a6998978-fe2b-4554-9fef-2286021b6363",
+      "ConcordiaCourseId": "007218"
+    },
+    {
+      "Id": "0f4912eb-ac84-4ec0-9bc6-7d852179c23b",
+      "ConcordiaCourseId": "007222"
+    },
+    {
+      "Id": "1e26b9f5-91bc-4fef-b79d-40c456889439",
+      "ConcordiaCourseId": "007228"
+    },
+    {
+      "Id": "8e358248-b063-453f-b0c9-432c2da38fcc",
+      "ConcordiaCourseId": "007233"
+    },
+    {
+      "Id": "5fb5259b-965b-4e85-9728-f554fb525ada",
+      "ConcordiaCourseId": "007234"
+    },
+    {
+      "Id": "cd4f24ab-626c-4e9c-8cd7-40cf3360bde3",
+      "ConcordiaCourseId": "007235"
+    },
+    {
+      "Id": "afefc1a3-afae-4405-bf87-1d433975e1c4",
+      "ConcordiaCourseId": "007238"
+    },
+    {
+      "Id": "0868ba37-4980-4b79-88a0-8d47f7faf05a",
+      "ConcordiaCourseId": "007250"
+    },
+    {
+      "Id": "4c87dd82-fd3a-4482-9955-05914798a07e",
+      "ConcordiaCourseId": "007252"
+    },
+    {
+      "Id": "4dca7171-91fc-4226-9cbd-b500ec0a7fab",
+      "ConcordiaCourseId": "007265"
+    },
+    {
+      "Id": "605015a2-f9b9-4675-bdb4-7809682d0b3f",
+      "ConcordiaCourseId": "007266"
+    },
+    {
+      "Id": "36f20eec-3e02-43c4-aa53-3765ebcd94f9",
+      "ConcordiaCourseId": "007268"
+    },
+    {
+      "Id": "a2665305-4af2-46a5-b1fe-7a83fe8e4030",
+      "ConcordiaCourseId": "007269"
+    },
+    {
+      "Id": "e6d2bb07-16bb-44f7-887d-be58548fe179",
+      "ConcordiaCourseId": "007270"
+    },
+    {
+      "Id": "2b8ed935-1aff-4bfa-beef-c107ca241a7e",
+      "ConcordiaCourseId": "007272"
+    },
+    {
+      "Id": "2f695c36-7b85-4397-9264-8ba21b3fa907",
+      "ConcordiaCourseId": "007277"
+    },
+    {
+      "Id": "54fa43b5-be63-47e0-9e5e-84f7d7796641",
+      "ConcordiaCourseId": "007278"
+    },
+    {
+      "Id": "87e7a26e-a6ae-448f-a07b-b33c3665e89f",
+      "ConcordiaCourseId": "007281"
+    },
+    {
+      "Id": "3cd5f030-4ae5-4d62-b405-f6acfe0d7af8",
+      "ConcordiaCourseId": "007286"
+    },
+    {
+      "Id": "fb1ea86e-3d1a-4284-9504-27da0fe9a2d0",
+      "ConcordiaCourseId": "007287"
+    },
+    {
+      "Id": "120ec767-8828-4b6a-a01f-ff7028e78fca",
+      "ConcordiaCourseId": "007297"
+    },
+    {
+      "Id": "a0ada449-c3b9-49f3-8818-b7c7ab01f192",
+      "ConcordiaCourseId": "007300"
+    },
+    {
+      "Id": "01012dac-2390-4241-bedd-4cf3db36a284",
+      "ConcordiaCourseId": "007301"
+    },
+    {
+      "Id": "87676780-0dba-440f-9dff-d9121b41169a",
+      "ConcordiaCourseId": "007302"
+    },
+    {
+      "Id": "0fb95978-2ad9-4d67-8187-dadf51dc731b",
+      "ConcordiaCourseId": "007306"
+    },
+    {
+      "Id": "b2aee232-055b-4f7a-af3e-7a9eef2ef3a9",
+      "ConcordiaCourseId": "007308"
+    },
+    {
+      "Id": "be1a8cd1-f32c-4920-a05e-84232ff4b8af",
+      "ConcordiaCourseId": "007310"
+    },
+    {
+      "Id": "7a6ea753-0ac6-4a15-805d-33e1a1340829",
+      "ConcordiaCourseId": "007311"
+    },
+    {
+      "Id": "a2b246a3-5bce-4b9f-a591-601a59201ba8",
+      "ConcordiaCourseId": "007312"
+    },
+    {
+      "Id": "a196bfbc-ed52-4f24-82b5-ff30706917e7",
+      "ConcordiaCourseId": "007313"
+    },
+    {
+      "Id": "c8d5363d-1632-420d-bdd1-fd9f0f5b66bc",
+      "ConcordiaCourseId": "007314"
+    },
+    {
+      "Id": "8246c4c6-6a89-4804-b53f-d6f9cda2bcdc",
+      "ConcordiaCourseId": "007315"
+    },
+    {
+      "Id": "dd27e8a4-bfcd-419c-a22c-acce2f432a27",
+      "ConcordiaCourseId": "007335"
+    },
+    {
+      "Id": "3d9dc62f-951b-4c14-8b4c-7c554ba81f2c",
+      "ConcordiaCourseId": "007352"
+    },
+    {
+      "Id": "fcdbd712-a3ab-46bc-a727-4874430a3d33",
+      "ConcordiaCourseId": "007353"
+    },
+    {
+      "Id": "02345f80-6adb-45f5-9aff-012a0d5b86bd",
+      "ConcordiaCourseId": "007354"
+    },
+    {
+      "Id": "517265e6-74cd-48d0-b945-0a5196453471",
+      "ConcordiaCourseId": "007355"
+    },
+    {
+      "Id": "79ca9780-9ed2-44f4-b315-9b6ff60ba91e",
+      "ConcordiaCourseId": "007356"
+    },
+    {
+      "Id": "d9801d43-40cb-43a2-af63-0373e50ba945",
+      "ConcordiaCourseId": "007358"
+    },
+    {
+      "Id": "c34a6a72-8ba7-4ca2-9ebb-946d9736bc86",
+      "ConcordiaCourseId": "007360"
+    },
+    {
+      "Id": "8ee4f38f-03e7-4848-afdd-49853122cfd7",
+      "ConcordiaCourseId": "007361"
+    },
+    {
+      "Id": "b72111ce-ebeb-48ef-a1bd-9b7c4e8d2020",
+      "ConcordiaCourseId": "007370"
+    },
+    {
+      "Id": "4b712265-bb5b-4b6c-8a75-432ade3988ac",
+      "ConcordiaCourseId": "007371"
+    },
+    {
+      "Id": "4554606b-96bb-41a8-8c49-f3d68306f1d5",
+      "ConcordiaCourseId": "007379"
+    },
+    {
+      "Id": "39fb6919-e170-46f7-91a2-964865dae996",
+      "ConcordiaCourseId": "007380"
+    },
+    {
+      "Id": "1300aa3b-bb45-44d5-be23-ba9390e95b41",
+      "ConcordiaCourseId": "007382"
+    },
+    {
+      "Id": "906231b3-f9e2-4fb1-901c-c5cf3830ca38",
+      "ConcordiaCourseId": "007394"
+    },
+    {
+      "Id": "8ab7e20c-d55a-408f-b561-ea0e80d3163c",
+      "ConcordiaCourseId": "007397"
+    },
+    {
+      "Id": "5145a7d2-dcb1-4fde-8718-8ef0667c62bd",
+      "ConcordiaCourseId": "007398"
+    },
+    {
+      "Id": "67eb41be-c092-4508-bbb2-f2f83958cb8a",
+      "ConcordiaCourseId": "007399"
+    },
+    {
+      "Id": "84d1b687-8fc9-4309-8c32-322ed184babb",
+      "ConcordiaCourseId": "007400"
+    },
+    {
+      "Id": "d88aff76-b50c-406d-9db1-24d1d189ccd4",
+      "ConcordiaCourseId": "007402"
+    },
+    {
+      "Id": "0f0504b1-d371-448f-8ee7-f78d16ace85c",
+      "ConcordiaCourseId": "007403"
+    },
+    {
+      "Id": "97e9ce29-dba2-47e4-8e30-76afd9fe73b8",
+      "ConcordiaCourseId": "007423"
+    },
+    {
+      "Id": "f18ffe84-0476-4746-9750-d56cecd6f075",
+      "ConcordiaCourseId": "007426"
+    },
+    {
+      "Id": "08dbe7bd-fcba-448d-95b0-85ebec755ba9",
+      "ConcordiaCourseId": "007445"
+    },
+    {
+      "Id": "008aca3f-cd87-4538-883d-0b9a7b78d580",
+      "ConcordiaCourseId": "007447"
+    },
+    {
+      "Id": "806c2458-9fd5-4b5a-8140-9aedac99627a",
+      "ConcordiaCourseId": "007458"
+    },
+    {
+      "Id": "e5adc98d-c50c-41f1-b8ad-15ccd29d8003",
+      "ConcordiaCourseId": "007467"
+    },
+    {
+      "Id": "ed99819b-78e6-4ed3-bec1-d88c9d4d57ee",
+      "ConcordiaCourseId": "007470"
+    },
+    {
+      "Id": "46098a69-dc14-41e9-b27b-7518ba5a3308",
+      "ConcordiaCourseId": "040484"
+    },
+    {
+      "Id": "06387218-0116-4b58-987d-78109eb3bd44",
+      "ConcordiaCourseId": "040485"
+    },
+    {
+      "Id": "1efe090d-4515-4b5b-9492-63f041a4e1f3",
+      "ConcordiaCourseId": "040487"
+    },
+    {
+      "Id": "87fee476-86c3-4ae6-9efc-c1dc8d3afb57",
+      "ConcordiaCourseId": "040488"
+    },
+    {
+      "Id": "a6a9ecca-bb1f-4a4d-8592-fc58d0bb6900",
+      "ConcordiaCourseId": "040489"
+    },
+    {
+      "Id": "97915456-a48d-44a9-a5ef-ba30ef4c7b10",
+      "ConcordiaCourseId": "040490"
+    },
+    {
+      "Id": "d09c42ca-6390-4046-9b6d-3a2d37f0d6f9",
+      "ConcordiaCourseId": "040491"
+    },
+    {
+      "Id": "6096d57e-9a94-47ef-8a74-364a3c2d9b90",
+      "ConcordiaCourseId": "040492"
+    },
+    {
+      "Id": "d5b3fd6e-8a57-4058-8fe2-4d43a00fa088",
+      "ConcordiaCourseId": "040493"
+    },
+    {
+      "Id": "5c2bd0a7-52df-4e34-b44b-6a4535abe5b9",
+      "ConcordiaCourseId": "040494"
+    },
+    {
+      "Id": "a5b137be-8aea-4348-a397-814dd7d7239c",
+      "ConcordiaCourseId": "040495"
+    },
+    {
+      "Id": "be05f5de-eb80-4061-9d9a-a2e6ee0a9c8c",
+      "ConcordiaCourseId": "040496"
+    },
+    {
+      "Id": "3ba279c4-63ff-4e63-ab40-7ce90590c61e",
+      "ConcordiaCourseId": "040497"
+    },
+    {
+      "Id": "f474f069-3ef0-4910-82d0-24cc47da9fdc",
+      "ConcordiaCourseId": "040499"
+    },
+    {
+      "Id": "efea227c-140c-481a-98c6-e68ac716827e",
+      "ConcordiaCourseId": "040500"
+    },
+    {
+      "Id": "85b351bc-e19b-451e-a7f5-bbced572c4c6",
+      "ConcordiaCourseId": "040501"
+    },
+    {
+      "Id": "ac8d2ded-18d1-4ae1-b49b-7b442a3b13d4",
+      "ConcordiaCourseId": "040502"
+    },
+    {
+      "Id": "8666eee8-194c-4ef3-a265-5fac17718596",
+      "ConcordiaCourseId": "040503"
+    },
+    {
+      "Id": "b285f0ae-e4d5-4843-9bd9-0559a865776f",
+      "ConcordiaCourseId": "040504"
+    },
+    {
+      "Id": "d928bb74-1f0b-4f87-bb14-c471ef8f5e02",
+      "ConcordiaCourseId": "040505"
+    },
+    {
+      "Id": "409c9e27-3e53-4b15-a2cf-fd4266e60347",
+      "ConcordiaCourseId": "040506"
+    },
+    {
+      "Id": "ddc3e165-588b-4b0c-a0d6-d4063b9b3892",
+      "ConcordiaCourseId": "040508"
+    },
+    {
+      "Id": "3127dcf1-6236-4075-b487-e84c9be3d67d",
+      "ConcordiaCourseId": "040509"
+    },
+    {
+      "Id": "253d53b2-7b59-475e-834e-4c9d3f1df1cd",
+      "ConcordiaCourseId": "040520"
+    },
+    {
+      "Id": "80d3a83f-63db-4f3a-a37b-a2c69449cb46",
+      "ConcordiaCourseId": "040521"
+    },
+    {
+      "Id": "a626cb18-510c-4cda-a943-e1ffbf95d324",
+      "ConcordiaCourseId": "040522"
+    },
+    {
+      "Id": "8cbfd7c2-3bb7-4c61-8e44-95466c7a5c9e",
+      "ConcordiaCourseId": "040523"
+    },
+    {
+      "Id": "da7eb946-a16d-4b32-bf0b-8bb5cb6bef39",
+      "ConcordiaCourseId": "045968"
+    },
+    {
+      "Id": "7d139185-9073-4cd6-8646-0e86e1c765f5",
+      "ConcordiaCourseId": "045974"
+    },
+    {
+      "Id": "6aee749d-b5a3-44b2-a26b-4d87d5495240",
+      "ConcordiaCourseId": "046635"
+    },
+    {
+      "Id": "51f68b2c-f117-4b6b-86d6-bbcf97b6fb5a",
+      "ConcordiaCourseId": "046636"
+    },
+    {
+      "Id": "bcb4aaf1-b590-46c9-9693-e7ab0464c7a1",
+      "ConcordiaCourseId": "046637"
+    },
+    {
+      "Id": "9904474c-8054-4472-b50e-ded817e7cdaa",
+      "ConcordiaCourseId": "046638"
+    },
+    {
+      "Id": "27a2fb4a-36a4-4b79-841d-c5d087c52bea",
+      "ConcordiaCourseId": "048017"
+    },
+    {
+      "Id": "287de213-810c-496e-b881-97308d971a05",
+      "ConcordiaCourseId": "048660"
+    },
+    {
+      "Id": "9591220d-8419-4d92-af8c-6ec3128acc62",
+      "ConcordiaCourseId": "048968"
+    },
+    {
+      "Id": "9557f3fc-5bf8-44e2-9482-73c764fbbb3d",
+      "ConcordiaCourseId": "049619"
+    },
+    {
+      "Id": "6ce536fd-1856-419a-9fd6-e885160d3622",
+      "ConcordiaCourseId": "049634"
+    },
+    {
+      "Id": "773d2370-ce69-4d2e-a18e-27fefe2f9e2f",
+      "ConcordiaCourseId": "049635"
+    },
+    {
+      "Id": "dc0ab236-3a43-4996-ac6e-805389c50fcb",
+      "ConcordiaCourseId": "049636"
+    },
+    {
+      "Id": "3274e723-83e0-40e9-9e2d-95a44678aebd",
+      "ConcordiaCourseId": "049637"
+    },
+    {
+      "Id": "c701d054-189a-4f43-8356-332ea63e74b0",
+      "ConcordiaCourseId": "049638"
+    },
+    {
+      "Id": "de127d6f-82aa-4ea4-a93f-b91b46cb8a06",
+      "ConcordiaCourseId": "049639"
+    },
+    {
+      "Id": "1a90c6b8-2676-4562-841c-cb45e938f6c7",
+      "ConcordiaCourseId": "050040"
+    },
+    {
+      "Id": "c7334ae7-9245-4ee9-9657-c13cfd99a290",
+      "ConcordiaCourseId": "050041"
+    },
+    {
+      "Id": "5f9dfaf2-14bf-422d-9ecc-7dc2cc09ef3e",
+      "ConcordiaCourseId": "050355"
+    },
+    {
+      "Id": "91ec035a-aae0-4ca7-873b-924afb22dafe",
+      "ConcordiaCourseId": "050357"
+    },
+    {
+      "Id": "e51f75ab-99d0-4c45-b36e-c97b43a03892",
+      "ConcordiaCourseId": "050421"
+    },
+    {
+      "Id": "6a6acc5e-71a8-4c9f-a87d-eefe6f44e8c8",
+      "ConcordiaCourseId": "050789"
+    },
+    {
+      "Id": "8be22cdd-7cb3-4824-9635-376f0d32eae4",
+      "ConcordiaCourseId": "050791"
+    },
+    {
+      "Id": "eae654a5-60d9-4d77-9f1b-3489c52e2936",
+      "ConcordiaCourseId": "007654"
+    },
+    {
+      "Id": "ee0b97f5-3c01-46bc-ab55-bd7bd3c91b70",
+      "ConcordiaCourseId": "007655"
+    },
+    {
+      "Id": "a2a5052a-1da6-4081-b0d7-c9b712d47c13",
+      "ConcordiaCourseId": "007661"
+    },
+    {
+      "Id": "952ef1fe-b62f-4230-8c5f-2447d992412d",
+      "ConcordiaCourseId": "007662"
+    },
+    {
+      "Id": "930973d5-299b-4b43-9169-c6e6d9ebf590",
+      "ConcordiaCourseId": "007664"
+    },
+    {
+      "Id": "1ff09ce3-3063-4e57-9dcd-865563bdd521",
+      "ConcordiaCourseId": "007665"
+    },
+    {
+      "Id": "d549d5e7-44b3-4004-a896-aaf733301d5f",
+      "ConcordiaCourseId": "007666"
+    },
+    {
+      "Id": "6a5ba7eb-35f8-4f36-9566-d65b5c3e0404",
+      "ConcordiaCourseId": "007669"
+    },
+    {
+      "Id": "1f27af4b-6292-4fd8-beb1-3a294c8ad028",
+      "ConcordiaCourseId": "007670"
+    },
+    {
+      "Id": "d56508b7-f292-4cf7-b885-2c3dacfa5019",
+      "ConcordiaCourseId": "007673"
+    },
+    {
+      "Id": "d6cb27f8-2880-48c7-9e3a-f70af811928a",
+      "ConcordiaCourseId": "007674"
+    },
+    {
+      "Id": "78df2bdf-60be-49e7-8850-001675964e6a",
+      "ConcordiaCourseId": "007675"
+    },
+    {
+      "Id": "5ffd60b2-57ce-4492-aa35-a6334e23c342",
+      "ConcordiaCourseId": "007678"
+    },
+    {
+      "Id": "0bfa8da2-47bf-4ad4-ab36-05407a1d880f",
+      "ConcordiaCourseId": "007679"
+    },
+    {
+      "Id": "a95c4a2a-0c8d-47e5-9a20-2ee6b5b7128b",
+      "ConcordiaCourseId": "007680"
+    },
+    {
+      "Id": "06a18a74-0c8a-4670-8d73-a8a7e04b6d09",
+      "ConcordiaCourseId": "007681"
+    },
+    {
+      "Id": "80d32112-4779-4f8d-a438-c5e04e9619ee",
+      "ConcordiaCourseId": "007683"
+    },
+    {
+      "Id": "8b758972-d603-4a91-90de-ac0435914afb",
+      "ConcordiaCourseId": "007684"
+    },
+    {
+      "Id": "b2eb71b0-34dd-420d-ac04-2e198373af4b",
+      "ConcordiaCourseId": "007685"
+    },
+    {
+      "Id": "cc542ab4-80d1-482e-b6a7-220d7ff41c54",
+      "ConcordiaCourseId": "007686"
+    },
+    {
+      "Id": "6a16300e-28ed-4834-9554-1ca81420f644",
+      "ConcordiaCourseId": "007689"
+    },
+    {
+      "Id": "fa7f0f69-1e1f-40e7-82cc-95f76fdaa620",
+      "ConcordiaCourseId": "007691"
+    },
+    {
+      "Id": "49f00ed3-ecfe-4cb3-8486-f410fccb9c0d",
+      "ConcordiaCourseId": "007692"
+    },
+    {
+      "Id": "d125a9e3-ea1e-4cb9-b14a-ee366ef04c6e",
+      "ConcordiaCourseId": "007693"
+    },
+    {
+      "Id": "803b95c9-3d2d-42a7-bbe7-dc2573098d66",
+      "ConcordiaCourseId": "007695"
+    },
+    {
+      "Id": "394c0c4c-8efe-4231-8797-92a473b04c8b",
+      "ConcordiaCourseId": "007696"
+    },
+    {
+      "Id": "e6aaab90-d428-4947-9cd7-eaf2b49deb1c",
+      "ConcordiaCourseId": "007697"
+    },
+    {
+      "Id": "a7092468-ebb0-403b-af82-0d87e8725820",
+      "ConcordiaCourseId": "007698"
+    },
+    {
+      "Id": "24919316-b029-41b1-aee9-022cc912c202",
+      "ConcordiaCourseId": "007699"
+    },
+    {
+      "Id": "ee982c4a-5ea3-47d6-897e-7b4242dd2eac",
+      "ConcordiaCourseId": "007701"
+    },
+    {
+      "Id": "3e22dbe8-94be-4b40-8260-e22242d7249e",
+      "ConcordiaCourseId": "007702"
+    },
+    {
+      "Id": "bc5eb93a-a861-4f9e-89f2-bce6d368ed80",
+      "ConcordiaCourseId": "007715"
+    },
+    {
+      "Id": "c3e1e592-9303-4e20-ae29-10af5fbfea0b",
+      "ConcordiaCourseId": "007716"
+    },
+    {
+      "Id": "c8dc9f76-164d-4f2b-9995-2c557c7586f7",
+      "ConcordiaCourseId": "007718"
+    },
+    {
+      "Id": "8fa357ec-9f59-47b2-91d9-a534240dd9a3",
+      "ConcordiaCourseId": "007719"
+    },
+    {
+      "Id": "82049eaa-4451-45a1-ba7d-01f652752df1",
+      "ConcordiaCourseId": "007720"
+    },
+    {
+      "Id": "25fdcaf0-924c-4edd-9ce1-d9149721e531",
+      "ConcordiaCourseId": "007727"
+    },
+    {
+      "Id": "96ef7fd3-e172-40fe-9376-4b6d6db21acc",
+      "ConcordiaCourseId": "007729"
+    },
+    {
+      "Id": "80626e21-55a5-4a28-ad14-bc84470f9e52",
+      "ConcordiaCourseId": "007730"
+    },
+    {
+      "Id": "5be1245f-be74-4446-b830-40c06b398582",
+      "ConcordiaCourseId": "007734"
+    },
+    {
+      "Id": "f659b0ef-8904-45da-b6b7-b60409116f75",
+      "ConcordiaCourseId": "007735"
+    },
+    {
+      "Id": "bf729c66-b8df-4893-8d9d-4d026c4b00e6",
+      "ConcordiaCourseId": "007739"
+    },
+    {
+      "Id": "012fafe2-bf6d-4c75-83b6-5f24f7f1342b",
+      "ConcordiaCourseId": "007742"
+    },
+    {
+      "Id": "d9dccf57-513b-4fe2-8743-99e60536c677",
+      "ConcordiaCourseId": "007751"
+    },
+    {
+      "Id": "1327cc84-17e6-4d76-a0b6-d22bd1582469",
+      "ConcordiaCourseId": "007752"
+    },
+    {
+      "Id": "b711958d-6740-452f-a25d-ea4a3972cc41",
+      "ConcordiaCourseId": "007753"
+    },
+    {
+      "Id": "19205e68-34af-4213-9c30-b1c57bff9e37",
+      "ConcordiaCourseId": "007754"
+    },
+    {
+      "Id": "e3caaa7d-5f4a-4088-80dd-5582a17b9c15",
+      "ConcordiaCourseId": "007755"
+    },
+    {
+      "Id": "3eed171d-3789-43d4-a7c3-4e894a72e337",
+      "ConcordiaCourseId": "007756"
+    },
+    {
+      "Id": "dbcf591a-1138-40be-9e68-98b8c34d59c6",
+      "ConcordiaCourseId": "007757"
+    },
+    {
+      "Id": "8776b77d-9c49-4678-8513-4cc858814077",
+      "ConcordiaCourseId": "007758"
+    },
+    {
+      "Id": "8797907d-0ace-4b41-be02-452b0030df69",
+      "ConcordiaCourseId": "007759"
+    },
+    {
+      "Id": "2255511f-b1ac-4c9f-b0e3-0fafd5dacae9",
+      "ConcordiaCourseId": "007777"
+    },
+    {
+      "Id": "15a16f00-eda5-4e3c-948a-32310247c6c4",
+      "ConcordiaCourseId": "007781"
+    },
+    {
+      "Id": "de897dc3-7d3c-47d0-9838-7926a85a6d23",
+      "ConcordiaCourseId": "007784"
+    },
+    {
+      "Id": "6de2fea5-9280-454b-a066-de0489b2dc83",
+      "ConcordiaCourseId": "007789"
+    },
+    {
+      "Id": "4b841da9-aa7e-44c8-8bcb-c2adb057851d",
+      "ConcordiaCourseId": "007816"
+    },
+    {
+      "Id": "26a05ae1-0118-4909-a938-a28bd78744e2",
+      "ConcordiaCourseId": "007817"
+    },
+    {
+      "Id": "747fbb8e-fd38-4a3e-b81c-3d1b11238734",
+      "ConcordiaCourseId": "007818"
+    },
+    {
+      "Id": "a94f3bcb-e18d-4ee6-bca9-ccf1c506f182",
+      "ConcordiaCourseId": "007821"
+    },
+    {
+      "Id": "69371c71-45a2-460f-b45c-f523209a7b92",
+      "ConcordiaCourseId": "007822"
+    },
+    {
+      "Id": "73f6b4dc-04ba-4a42-9b06-b9b57a5fcda2",
+      "ConcordiaCourseId": "007823"
+    },
+    {
+      "Id": "4edf762e-d915-4dcd-ba3b-3a8fb0763cf3",
+      "ConcordiaCourseId": "007824"
+    },
+    {
+      "Id": "f9d8b046-98c7-428a-97df-79666a70d885",
+      "ConcordiaCourseId": "007825"
+    },
+    {
+      "Id": "0d81f25d-7750-4ac3-af17-45eb3489f6aa",
+      "ConcordiaCourseId": "007826"
+    },
+    {
+      "Id": "baf9211e-0d50-4101-b633-2966a14ab983",
+      "ConcordiaCourseId": "007827"
+    },
+    {
+      "Id": "6d9092c6-9e98-4672-b309-04f683acfcf6",
+      "ConcordiaCourseId": "007828"
+    },
+    {
+      "Id": "e859a6a6-55ce-4fa4-8429-cbf18cc8e4e2",
+      "ConcordiaCourseId": "007829"
+    },
+    {
+      "Id": "9624b8e1-92cf-41cb-bccf-03f94ef21b45",
+      "ConcordiaCourseId": "007830"
+    },
+    {
+      "Id": "3cae46b0-8799-476d-80f8-d96476cccecc",
+      "ConcordiaCourseId": "007831"
+    },
+    {
+      "Id": "3836f765-bdc4-4316-a7cc-97778f48a767",
+      "ConcordiaCourseId": "007832"
+    },
+    {
+      "Id": "0f238f9b-ac1f-49f0-9636-f74de12c9882",
+      "ConcordiaCourseId": "007833"
+    },
+    {
+      "Id": "9d9c6cc9-6bde-46af-bcc3-aba8c223b45a",
+      "ConcordiaCourseId": "040532"
+    },
+    {
+      "Id": "7a634a9c-f6a0-4157-8f48-850c6c0580f4",
+      "ConcordiaCourseId": "040562"
+    },
+    {
+      "Id": "5a886963-a0d4-451f-90c3-c06148f400e5",
+      "ConcordiaCourseId": "040563"
+    },
+    {
+      "Id": "c2dba775-7508-44c5-b2be-4090dcb0e412",
+      "ConcordiaCourseId": "040564"
+    },
+    {
+      "Id": "f8cbb757-9262-4d31-bd28-9ac386109ecb",
+      "ConcordiaCourseId": "046639"
+    },
+    {
+      "Id": "28081010-52f1-4029-a58b-255d72411279",
+      "ConcordiaCourseId": "046640"
+    },
+    {
+      "Id": "4b5c9078-76e3-49a6-a838-dcd01c627c0b",
+      "ConcordiaCourseId": "046641"
+    },
+    {
+      "Id": "a7acf7a9-a1d4-481d-a64b-1b9185c8c283",
+      "ConcordiaCourseId": "046642"
+    },
+    {
+      "Id": "6c5f4fa7-0e8d-4a8f-b378-afd012f72310",
+      "ConcordiaCourseId": "046643"
+    },
+    {
+      "Id": "c9db4c6c-30ff-47cd-89db-fcdd0eb8e508",
+      "ConcordiaCourseId": "047211"
+    },
+    {
+      "Id": "b1256dc6-3296-4f21-bc49-e2473a6a2640",
+      "ConcordiaCourseId": "047212"
+    },
+    {
+      "Id": "8efea7e5-32f9-4c6a-aa71-97740d348f97",
+      "ConcordiaCourseId": "047213"
+    },
+    {
+      "Id": "9a7013f6-37ee-4754-bdbe-5047b9b6b12a",
+      "ConcordiaCourseId": "047214"
+    },
+    {
+      "Id": "383aa8da-2b21-43d3-8f0b-028ab6de2534",
+      "ConcordiaCourseId": "047215"
+    },
+    {
+      "Id": "e01f3e2e-63bd-4d5e-bcb4-1fdf0957a2eb",
+      "ConcordiaCourseId": "047216"
+    },
+    {
+      "Id": "6b007e76-7ec9-4c14-9a86-48e9ddee1e1d",
+      "ConcordiaCourseId": "047217"
+    },
+    {
+      "Id": "5a706a0c-808e-47ea-9747-46be3cb25a6f",
+      "ConcordiaCourseId": "047554"
+    },
+    {
+      "Id": "07022dd1-678c-4d3f-bf54-2928548f6efa",
+      "ConcordiaCourseId": "047555"
+    },
+    {
+      "Id": "0250cf65-9d2e-4c76-968c-5b0ff240e6ec",
+      "ConcordiaCourseId": "047984"
+    },
+    {
+      "Id": "1ae03a55-3314-4b1a-9575-91d52ada4b30",
+      "ConcordiaCourseId": "047985"
+    },
+    {
+      "Id": "27c4498d-e4dc-4c64-88bf-9aca50a5d7dc",
+      "ConcordiaCourseId": "050378"
+    },
+    {
+      "Id": "c967b85b-f375-4832-8c89-90d73a8ed702",
+      "ConcordiaCourseId": "050439"
+    },
+    {
+      "Id": "65cec985-79dc-4110-9bef-d0873a09f6f2",
+      "ConcordiaCourseId": "050634"
+    },
+    {
+      "Id": "fcd44555-cc30-47e6-879b-beff011c5639",
+      "ConcordiaCourseId": "050639"
+    },
+    {
+      "Id": "63fbdff7-214a-4530-999e-35fb5308455b",
+      "ConcordiaCourseId": "050640"
+    },
+    {
+      "Id": "9597e9a3-25c3-452a-998d-ac59b68de0c3",
+      "ConcordiaCourseId": "050641"
+    },
+    {
+      "Id": "b7755fce-d696-4b92-b455-cdaabf6e02dc",
+      "ConcordiaCourseId": "050642"
+    },
+    {
+      "Id": "27b1f9ea-ac6f-44dd-b30d-b518167d4826",
+      "ConcordiaCourseId": "050643"
+    },
+    {
+      "Id": "233399b6-2128-4a87-81ff-751baaf5d141",
+      "ConcordiaCourseId": "050644"
+    },
+    {
+      "Id": "64f0ba8f-e345-4476-b33d-8b6bee35f0c3",
+      "ConcordiaCourseId": "050645"
+    },
+    {
+      "Id": "d2d0ddd1-f2ee-4463-960a-83dcbbc1c712",
+      "ConcordiaCourseId": "050646"
+    },
+    {
+      "Id": "a8947443-edb6-4dfe-93bc-10ab743404cb",
+      "ConcordiaCourseId": "050647"
+    },
+    {
+      "Id": "f56e0ee5-80d6-4ee1-aaec-2ac8d0724717",
+      "ConcordiaCourseId": "050648"
+    },
+    {
+      "Id": "d2c4263c-d846-4d74-b658-8ea5a9d0d45f",
+      "ConcordiaCourseId": "050649"
+    },
+    {
+      "Id": "1d718b5b-78c1-45a6-825c-3cc588d3e638",
+      "ConcordiaCourseId": "007958"
+    },
+    {
+      "Id": "12fed358-e002-498d-bdd0-0ef0ee4c1f9d",
+      "ConcordiaCourseId": "007960"
+    },
+    {
+      "Id": "929efd61-3504-4e19-810f-c8c5a19a4ca3",
+      "ConcordiaCourseId": "007961"
+    },
+    {
+      "Id": "16185114-d578-49e3-b7ce-79a9a3362b0b",
+      "ConcordiaCourseId": "007962"
+    },
+    {
+      "Id": "e2a2bd4f-96b3-48f6-b551-e1f3e49c9bc4",
+      "ConcordiaCourseId": "007963"
+    },
+    {
+      "Id": "3f81174d-4323-4f6a-857e-a188b0fe1dfa",
+      "ConcordiaCourseId": "007964"
+    },
+    {
+      "Id": "c7dd57b1-6b96-4fa3-9ecd-9e66309f975f",
+      "ConcordiaCourseId": "007966"
+    },
+    {
+      "Id": "72a1132e-27d7-4fa0-a8e5-697cbf877166",
+      "ConcordiaCourseId": "007967"
+    },
+    {
+      "Id": "b0a5d85d-4448-465d-b8fc-b6bd9e91d9ec",
+      "ConcordiaCourseId": "007971"
+    },
+    {
+      "Id": "c77eb232-cd5d-41d8-8000-bf5d276362ec",
+      "ConcordiaCourseId": "007973"
+    },
+    {
+      "Id": "67fb1a62-8d0e-4a8f-9a3a-84000b247573",
+      "ConcordiaCourseId": "007976"
+    },
+    {
+      "Id": "665d03dd-1b6a-4c5a-bc97-971d8511e16c",
+      "ConcordiaCourseId": "007977"
+    },
+    {
+      "Id": "84adabe0-4ee6-4527-ad82-5e9da18c1d25",
+      "ConcordiaCourseId": "007978"
+    },
+    {
+      "Id": "09205c9a-2113-43e3-9f4c-d79f9a9ebd8f",
+      "ConcordiaCourseId": "007980"
+    },
+    {
+      "Id": "f8b04f46-9c36-4aa8-a02d-779d464a6dcd",
+      "ConcordiaCourseId": "007981"
+    },
+    {
+      "Id": "2a7e26c9-98fb-4fec-a10c-d2d8c3468466",
+      "ConcordiaCourseId": "007985"
+    },
+    {
+      "Id": "0e2a4816-ce8e-45d0-a116-35d6dd39c0ce",
+      "ConcordiaCourseId": "007986"
+    },
+    {
+      "Id": "61bef8a1-13b5-4a5d-957c-06ddfb6d92a5",
+      "ConcordiaCourseId": "007987"
+    },
+    {
+      "Id": "1eafcd6a-b227-41bf-9d2f-d6e2be0d3f4b",
+      "ConcordiaCourseId": "007988"
+    },
+    {
+      "Id": "aea8cf1a-405b-419d-8e91-0a2e75d4ec5b",
+      "ConcordiaCourseId": "007989"
+    },
+    {
+      "Id": "979c6b75-b46d-4b9e-a4ac-f054beb564a4",
+      "ConcordiaCourseId": "007990"
+    },
+    {
+      "Id": "3975622e-b09b-44e8-aac5-c0bb2976205e",
+      "ConcordiaCourseId": "007991"
+    },
+    {
+      "Id": "c2836a96-2853-41aa-86ef-91306905eb13",
+      "ConcordiaCourseId": "007992"
+    },
+    {
+      "Id": "cd7b7eef-1091-4e8c-9f9b-2a5ea69f0670",
+      "ConcordiaCourseId": "007993"
+    },
+    {
+      "Id": "d4d0b5e7-6fbc-4594-bfa6-aba4cc0f77bd",
+      "ConcordiaCourseId": "007994"
+    },
+    {
+      "Id": "df76c810-c9a9-4128-97c4-34e502e6ff8d",
+      "ConcordiaCourseId": "007995"
+    },
+    {
+      "Id": "387c8cea-b918-49ad-8e91-7285e477c416",
+      "ConcordiaCourseId": "007996"
+    },
+    {
+      "Id": "2e7738e5-9a74-4f5e-bbe2-1ba84ec41e0c",
+      "ConcordiaCourseId": "007997"
+    },
+    {
+      "Id": "d978609c-1ecb-4b75-837a-727837175cd2",
+      "ConcordiaCourseId": "007998"
+    },
+    {
+      "Id": "463d165a-58f2-4f17-bac8-b33ff1f3709b",
+      "ConcordiaCourseId": "007999"
+    },
+    {
+      "Id": "0f27ce0f-57bf-4f2f-8283-117c4ffb177f",
+      "ConcordiaCourseId": "008000"
+    },
+    {
+      "Id": "ac5dd716-8b6a-4bfc-86b6-35d7c02a0fa1",
+      "ConcordiaCourseId": "008001"
+    },
+    {
+      "Id": "6372d4b3-c77f-4081-9385-e0ee9871152e",
+      "ConcordiaCourseId": "008002"
+    },
+    {
+      "Id": "1dc0002d-0e1d-4b55-8f29-e48b1653250f",
+      "ConcordiaCourseId": "008004"
+    },
+    {
+      "Id": "b219357e-f114-4c9a-845c-7ad9aa6f277e",
+      "ConcordiaCourseId": "008007"
+    },
+    {
+      "Id": "bab64165-dfa2-407c-a5e0-41a23d547134",
+      "ConcordiaCourseId": "008008"
+    },
+    {
+      "Id": "cd8b221a-f019-459f-b0cd-b24a1c94e90b",
+      "ConcordiaCourseId": "008009"
+    },
+    {
+      "Id": "6e580793-e811-4a94-a3cc-489ce87b2e97",
+      "ConcordiaCourseId": "008011"
+    },
+    {
+      "Id": "5921bd15-4325-4b87-bcbd-62f750cd317c",
+      "ConcordiaCourseId": "008012"
+    },
+    {
+      "Id": "0cd1c718-13f2-4cac-af5f-216d7af4c506",
+      "ConcordiaCourseId": "008013"
+    },
+    {
+      "Id": "779c13d2-2970-4730-9744-261c5b8905a5",
+      "ConcordiaCourseId": "008015"
+    },
+    {
+      "Id": "ec5bfbb3-782b-450b-9986-6744c4482e28",
+      "ConcordiaCourseId": "008017"
+    },
+    {
+      "Id": "b233c1c0-deb2-4254-9665-1778522e4f74",
+      "ConcordiaCourseId": "008019"
+    },
+    {
+      "Id": "44323ae0-4d08-4114-9d9e-8464e5b792e7",
+      "ConcordiaCourseId": "008020"
+    },
+    {
+      "Id": "aa0e9acf-d9ac-43c5-aa4b-c9452177d6a8",
+      "ConcordiaCourseId": "008021"
+    },
+    {
+      "Id": "f23aedce-608c-4f7e-9356-0833aa8c4084",
+      "ConcordiaCourseId": "008022"
+    },
+    {
+      "Id": "4a1a4033-e1b1-4a74-adb8-510a69a9c6f4",
+      "ConcordiaCourseId": "008049"
+    },
+    {
+      "Id": "a1104883-764a-464e-98e0-63ab14245654",
+      "ConcordiaCourseId": "008051"
+    },
+    {
+      "Id": "64817c19-88cc-428a-a37f-01e247f7b9f3",
+      "ConcordiaCourseId": "008052"
+    },
+    {
+      "Id": "63e5575a-8385-41c2-a165-65481848577f",
+      "ConcordiaCourseId": "008053"
+    },
+    {
+      "Id": "fa3e6b82-98de-4a85-8df1-b6d2db85f6c4",
+      "ConcordiaCourseId": "008054"
+    },
+    {
+      "Id": "098fa650-e82e-40f0-9941-6175d6186fe9",
+      "ConcordiaCourseId": "008060"
+    },
+    {
+      "Id": "4e2289ef-c663-4266-a565-599b66549177",
+      "ConcordiaCourseId": "008062"
+    },
+    {
+      "Id": "30c6e4e6-13f4-4fb1-bc59-bac3e4234709",
+      "ConcordiaCourseId": "008064"
+    },
+    {
+      "Id": "5a391f49-61e1-4638-ae69-550d4813cde3",
+      "ConcordiaCourseId": "008067"
+    },
+    {
+      "Id": "7fb9237d-a569-4b00-8a35-357b624e4857",
+      "ConcordiaCourseId": "008068"
+    },
+    {
+      "Id": "de0230d6-09a7-4b6a-99d3-6978284f093a",
+      "ConcordiaCourseId": "008071"
+    },
+    {
+      "Id": "ac2c6766-883b-4223-bc4c-356b33f58832",
+      "ConcordiaCourseId": "008072"
+    },
+    {
+      "Id": "0bb7d356-3b35-4747-b057-eef1a9710647",
+      "ConcordiaCourseId": "008073"
+    },
+    {
+      "Id": "46416215-5d1b-4177-81b6-37606e4dcb72",
+      "ConcordiaCourseId": "008075"
+    },
+    {
+      "Id": "4114b670-da44-41be-83d1-cb7dfb9bf62d",
+      "ConcordiaCourseId": "008079"
+    },
+    {
+      "Id": "98f16d11-ff64-4e16-9055-9494978df7e8",
+      "ConcordiaCourseId": "008081"
+    },
+    {
+      "Id": "1a487272-a879-468e-a4c8-748115e42841",
+      "ConcordiaCourseId": "008084"
+    },
+    {
+      "Id": "b8e02d65-6bd4-4136-939a-9d1b1d578d60",
+      "ConcordiaCourseId": "008088"
+    },
+    {
+      "Id": "b8b81089-e6d5-49a6-95cf-422e09df7512",
+      "ConcordiaCourseId": "008090"
+    },
+    {
+      "Id": "e9bfe2a9-1208-46e7-895b-9716adef8855",
+      "ConcordiaCourseId": "008092"
+    },
+    {
+      "Id": "215e0f71-66d6-47f7-a814-c4d389e897b1",
+      "ConcordiaCourseId": "008099"
+    },
+    {
+      "Id": "6c1bbae8-ca74-42c5-857b-c600a63f78ae",
+      "ConcordiaCourseId": "008100"
+    },
+    {
+      "Id": "880c4aef-8aa0-4811-a694-b650523ee50f",
+      "ConcordiaCourseId": "008101"
+    },
+    {
+      "Id": "fab97112-2cdf-47e2-8cb6-95dfdb67bf20",
+      "ConcordiaCourseId": "008102"
+    },
+    {
+      "Id": "455b87f0-6bc3-464a-a64b-6241f8e05db8",
+      "ConcordiaCourseId": "008103"
+    },
+    {
+      "Id": "7ad076d3-ff36-4bb9-a147-ddfa3bd1df36",
+      "ConcordiaCourseId": "008104"
+    },
+    {
+      "Id": "a612a28a-d7ac-4030-bb8e-2dc0631e7d7a",
+      "ConcordiaCourseId": "008113"
+    },
+    {
+      "Id": "0f7c65ed-2021-4a88-b50d-4f6a23a7dfbd",
+      "ConcordiaCourseId": "008114"
+    },
+    {
+      "Id": "9ea3162c-0f02-40fa-acaa-782bd1a5c04c",
+      "ConcordiaCourseId": "008115"
+    },
+    {
+      "Id": "95ee8caf-84ee-4194-9d0a-3ce262cbba11",
+      "ConcordiaCourseId": "008116"
+    },
+    {
+      "Id": "1625472d-ac9b-45ea-a641-4b027bed7b46",
+      "ConcordiaCourseId": "008117"
+    },
+    {
+      "Id": "8de87293-fa3a-44a2-8fb8-a8901919919a",
+      "ConcordiaCourseId": "008147"
+    },
+    {
+      "Id": "4ef62839-fc48-4a90-b320-9491e737063b",
+      "ConcordiaCourseId": "008162"
+    },
+    {
+      "Id": "31abc65f-25d1-4455-9925-5acd6b215de8",
+      "ConcordiaCourseId": "008175"
+    },
+    {
+      "Id": "300eeed2-f918-4b92-acf2-95343340eba1",
+      "ConcordiaCourseId": "008177"
+    },
+    {
+      "Id": "6ab592d3-da62-428d-bba9-f1b10d6e4598",
+      "ConcordiaCourseId": "040571"
+    },
+    {
+      "Id": "adf6ad80-1d46-4d8e-9a73-92d7b1b02fc5",
+      "ConcordiaCourseId": "040572"
+    },
+    {
+      "Id": "dcc5832e-4be9-47ed-8ef8-f35a45477811",
+      "ConcordiaCourseId": "040574"
+    },
+    {
+      "Id": "5116cc7b-1792-495c-b74d-808e7f36696c",
+      "ConcordiaCourseId": "040575"
+    },
+    {
+      "Id": "30391e1a-e4a1-49f4-97b5-e7220785a6c4",
+      "ConcordiaCourseId": "040576"
+    },
+    {
+      "Id": "8a568ab4-e91e-474d-acbe-00c939520e85",
+      "ConcordiaCourseId": "040577"
+    },
+    {
+      "Id": "2781b7bd-991c-4b01-a6a0-f9093422772f",
+      "ConcordiaCourseId": "040578"
+    },
+    {
+      "Id": "6035cdfc-7091-463b-a357-6e1f74b1b9cf",
+      "ConcordiaCourseId": "040579"
+    },
+    {
+      "Id": "d6c57105-646c-4382-bd1b-b6502fddc6da",
+      "ConcordiaCourseId": "040581"
+    },
+    {
+      "Id": "6bf24e10-5662-42cb-af13-20ddca4c7ba7",
+      "ConcordiaCourseId": "040582"
+    },
+    {
+      "Id": "a82e1080-9069-4aa9-8627-8270528593e8",
+      "ConcordiaCourseId": "040583"
+    },
+    {
+      "Id": "7c7576af-8ba9-4ed3-a0f4-0671bf84f30e",
+      "ConcordiaCourseId": "040584"
+    },
+    {
+      "Id": "944b49da-7adb-494d-8e94-6a13b7cf56c7",
+      "ConcordiaCourseId": "040585"
+    },
+    {
+      "Id": "fe4bbe40-ebfb-400d-b977-07da9034ef0d",
+      "ConcordiaCourseId": "046644"
+    },
+    {
+      "Id": "c594d39f-4481-4847-9750-dca775b24983",
+      "ConcordiaCourseId": "046646"
+    },
+    {
+      "Id": "4e813991-26d2-4794-a5e9-aac280558f23",
+      "ConcordiaCourseId": "046647"
+    },
+    {
+      "Id": "5fe54f92-9eae-43bb-a6e8-b0d44d22ccf5",
+      "ConcordiaCourseId": "046648"
+    },
+    {
+      "Id": "0305b193-f6a5-4467-a365-e3516efc4dce",
+      "ConcordiaCourseId": "046649"
+    },
+    {
+      "Id": "cae5378b-b6f9-4d13-845b-3e33ede383b5",
+      "ConcordiaCourseId": "046650"
+    },
+    {
+      "Id": "d882c80d-c501-438e-9e35-b7ae85cffc66",
+      "ConcordiaCourseId": "047561"
+    },
+    {
+      "Id": "df5b2cdb-7b7d-4466-81bc-6e8cd34cb9f6",
+      "ConcordiaCourseId": "047710"
+    },
+    {
+      "Id": "b19756ea-b7ee-46db-8825-661b6677330a",
+      "ConcordiaCourseId": "047715"
+    },
+    {
+      "Id": "4013ccb7-d71b-42e1-bd6b-2569175a6f8d",
+      "ConcordiaCourseId": "048397"
+    },
+    {
+      "Id": "b9d14100-3f1b-44b7-a9c5-4d0f76420d32",
+      "ConcordiaCourseId": "048410"
+    },
+    {
+      "Id": "95c85961-a5fb-47a2-854e-930c57996d16",
+      "ConcordiaCourseId": "048413"
+    },
+    {
+      "Id": "48f84136-02cd-4616-8679-fe7a1b6d44bf",
+      "ConcordiaCourseId": "048717"
+    },
+    {
+      "Id": "d245463d-79ab-4760-896e-d9d9bf5b48fe",
+      "ConcordiaCourseId": "048718"
+    },
+    {
+      "Id": "32cf88ae-6634-4790-9c27-6554c454a51d",
+      "ConcordiaCourseId": "048719"
+    },
+    {
+      "Id": "e327dd1a-6326-4ebf-bc09-fade65b8469b",
+      "ConcordiaCourseId": "048955"
+    },
+    {
+      "Id": "86cd7338-f08c-44f4-9596-385d57b2dd65",
+      "ConcordiaCourseId": "049051"
+    },
+    {
+      "Id": "42aeff23-38a9-4a2d-9dbc-deccb42f2686",
+      "ConcordiaCourseId": "049327"
+    },
+    {
+      "Id": "86a73c67-efb1-4a42-ad40-e35d4c2602a8",
+      "ConcordiaCourseId": "049356"
+    },
+    {
+      "Id": "1d527270-219e-4ceb-96cd-d5a21a869194",
+      "ConcordiaCourseId": "049359"
+    },
+    {
+      "Id": "b021d874-9240-4bac-975a-b2a76bd80ab7",
+      "ConcordiaCourseId": "050061"
+    },
+    {
+      "Id": "596288f8-639a-469e-9fa2-02aa7fc9bad0",
+      "ConcordiaCourseId": "050186"
+    },
+    {
+      "Id": "17e6659e-5175-4389-938b-fd87d4a18c4c",
+      "ConcordiaCourseId": "050277"
+    },
+    {
+      "Id": "2603e4ee-2266-4aec-8090-eb05329c3834",
+      "ConcordiaCourseId": "050430"
+    },
+    {
+      "Id": "3a72c1de-00c9-471c-a35b-c5c080b7a7df",
+      "ConcordiaCourseId": "050627"
+    },
+    {
+      "Id": "c802ef7f-f962-43a3-8291-8efc1290fc34",
+      "ConcordiaCourseId": "050692"
+    },
+    {
+      "Id": "8720620a-5b4d-417b-ac0b-6c25cd044d4c",
+      "ConcordiaCourseId": "008346"
+    },
+    {
+      "Id": "cb989775-7b88-4b50-bb45-48d1d2b68b15",
+      "ConcordiaCourseId": "008347"
+    },
+    {
+      "Id": "2c225846-ddbe-472f-94fa-857023a028fe",
+      "ConcordiaCourseId": "008353"
+    },
+    {
+      "Id": "a235d9fd-11f6-4063-9646-19e3073794f7",
+      "ConcordiaCourseId": "008354"
+    },
+    {
+      "Id": "ada83760-9489-47d5-b023-1b03be2e7ee2",
+      "ConcordiaCourseId": "008355"
+    },
+    {
+      "Id": "af9407ea-a73d-4c62-bf98-159515077124",
+      "ConcordiaCourseId": "008356"
+    },
+    {
+      "Id": "41d9ef27-ddf4-47f5-868a-6a9899e31064",
+      "ConcordiaCourseId": "008358"
+    },
+    {
+      "Id": "94407529-cea0-4f5e-a53d-735cf55f6288",
+      "ConcordiaCourseId": "008363"
+    },
+    {
+      "Id": "07ceb2c0-36ae-4905-b225-2d2247b8c492",
+      "ConcordiaCourseId": "008364"
+    },
+    {
+      "Id": "71d2ef16-5873-48b6-a53d-2043ed343133",
+      "ConcordiaCourseId": "008365"
+    },
+    {
+      "Id": "f2405714-bd0b-4e44-a5f7-c557aaed04cd",
+      "ConcordiaCourseId": "008366"
+    },
+    {
+      "Id": "7aed01f9-2e13-44dd-b28e-572907cf3e93",
+      "ConcordiaCourseId": "008368"
+    },
+    {
+      "Id": "cc39637f-f315-4495-8b98-581340b33fcb",
+      "ConcordiaCourseId": "008369"
+    },
+    {
+      "Id": "ec098acd-e416-449d-8d78-80d14cadaa77",
+      "ConcordiaCourseId": "008370"
+    },
+    {
+      "Id": "4dadbcae-f7e8-409e-b967-8a1c0ad70e35",
+      "ConcordiaCourseId": "008372"
+    },
+    {
+      "Id": "6392db52-81ba-4cea-bd93-e29b3aab3bef",
+      "ConcordiaCourseId": "008373"
+    },
+    {
+      "Id": "a79aea9e-abca-4308-b684-36386d2c15e1",
+      "ConcordiaCourseId": "008374"
+    },
+    {
+      "Id": "5084686e-6725-45f9-ba91-3f7da7c91030",
+      "ConcordiaCourseId": "008375"
+    },
+    {
+      "Id": "f8acc12c-3a1c-45b7-b076-129c5d838fc8",
+      "ConcordiaCourseId": "008377"
+    },
+    {
+      "Id": "3a49a78c-dbe8-4ce7-9030-de182bec24b2",
+      "ConcordiaCourseId": "008378"
+    },
+    {
+      "Id": "42ca528a-bef9-4d86-b100-5df5fade3993",
+      "ConcordiaCourseId": "008396"
+    },
+    {
+      "Id": "c63fe6a1-d218-4fdf-89be-85213a8f4923",
+      "ConcordiaCourseId": "008399"
+    },
+    {
+      "Id": "ff322805-e19c-4d68-b95a-7a9a2b3cc7db",
+      "ConcordiaCourseId": "008401"
+    },
+    {
+      "Id": "0c8c2eb9-7f19-4fba-916e-2148f52b5992",
+      "ConcordiaCourseId": "008407"
+    },
+    {
+      "Id": "90a53693-fcc9-4f26-8c21-7401c0df1328",
+      "ConcordiaCourseId": "008409"
+    },
+    {
+      "Id": "de9a7078-01eb-4cae-9176-41be42b0030b",
+      "ConcordiaCourseId": "008410"
+    },
+    {
+      "Id": "75278512-be75-4d74-8a7e-b95e1eb4eee1",
+      "ConcordiaCourseId": "008416"
+    },
+    {
+      "Id": "cd49911f-6a27-4051-84ed-3bd3eaf01021",
+      "ConcordiaCourseId": "008417"
+    },
+    {
+      "Id": "abb5b0e4-e370-4f03-8f93-210179629635",
+      "ConcordiaCourseId": "008419"
+    },
+    {
+      "Id": "bd28fb90-26e0-4776-9298-d039c81ad10d",
+      "ConcordiaCourseId": "008425"
+    },
+    {
+      "Id": "dde6fd1e-d4d5-4765-b78e-886a55580ad5",
+      "ConcordiaCourseId": "008426"
+    },
+    {
+      "Id": "69695a96-e396-41fd-9560-bb30d31de33a",
+      "ConcordiaCourseId": "008427"
+    },
+    {
+      "Id": "1ce71474-d2f5-45a9-9a1d-2488ac416525",
+      "ConcordiaCourseId": "008428"
+    },
+    {
+      "Id": "36be106d-ec70-4dd6-acc1-5ea79de1b9b6",
+      "ConcordiaCourseId": "047233"
+    },
+    {
+      "Id": "5e5ebe85-f4a0-4b11-980a-ee41ba3b0a5c",
+      "ConcordiaCourseId": "047234"
+    },
+    {
+      "Id": "899ebf1b-1972-4695-8df0-8169cafe3675",
+      "ConcordiaCourseId": "047235"
+    },
+    {
+      "Id": "07bf9b29-380b-4514-b57a-1c4442b5a988",
+      "ConcordiaCourseId": "008430"
+    },
+    {
+      "Id": "9ac96095-e7fe-4ffc-b6b7-648a0589f757",
+      "ConcordiaCourseId": "008432"
+    },
+    {
+      "Id": "49d271c7-d99c-401d-9f36-b93d8bfef256",
+      "ConcordiaCourseId": "008435"
+    },
+    {
+      "Id": "b7a372fa-8bae-4c31-ae6f-5894817e0cfe",
+      "ConcordiaCourseId": "008440"
+    },
+    {
+      "Id": "655644b7-8d84-4e92-9c4f-fb436047c020",
+      "ConcordiaCourseId": "008441"
+    },
+    {
+      "Id": "56bb176e-8600-4042-b65e-3f20ed355e7d",
+      "ConcordiaCourseId": "008444"
+    },
+    {
+      "Id": "a015b9f3-18cd-468c-b4ec-a0864205dc23",
+      "ConcordiaCourseId": "008451"
+    },
+    {
+      "Id": "082f2fdb-c429-4e3f-b5c4-45ee63b79e55",
+      "ConcordiaCourseId": "008455"
+    },
+    {
+      "Id": "7dea82af-bb9f-4c15-9863-187a16ccaa67",
+      "ConcordiaCourseId": "008460"
+    },
+    {
+      "Id": "c721d404-dcc4-44a5-a28b-96186a04964b",
+      "ConcordiaCourseId": "008466"
+    },
+    {
+      "Id": "c71051d2-7b5e-4b84-8a00-90e4437229a3",
+      "ConcordiaCourseId": "008470"
+    },
+    {
+      "Id": "af6d5df2-0641-4f9e-ad93-7d13a37a121f",
+      "ConcordiaCourseId": "008475"
+    },
+    {
+      "Id": "8f938d03-dbad-4b02-adb0-76d580576676",
+      "ConcordiaCourseId": "008476"
+    },
+    {
+      "Id": "5847ba08-c928-4d62-b10b-9a76ad2ff39f",
+      "ConcordiaCourseId": "008481"
+    },
+    {
+      "Id": "7990150d-a66b-4f68-aa22-e34ca6563292",
+      "ConcordiaCourseId": "008485"
+    },
+    {
+      "Id": "03f42263-b7e6-49f2-be20-c44791987db9",
+      "ConcordiaCourseId": "040595"
+    },
+    {
+      "Id": "56e8eb74-2c92-4275-be87-c38842ccf657",
+      "ConcordiaCourseId": "040597"
+    },
+    {
+      "Id": "73393236-30fd-427b-b41c-900b2903afb8",
+      "ConcordiaCourseId": "044022"
+    },
+    {
+      "Id": "4ffbf014-437e-4ef1-8e31-cdc42ee85ac9",
+      "ConcordiaCourseId": "047224"
+    },
+    {
+      "Id": "717ec4f9-9e3e-43de-9707-a1691cbd5d1b",
+      "ConcordiaCourseId": "047502"
+    },
+    {
+      "Id": "f650f5a8-eeca-4261-8aa9-f352674c93bd",
+      "ConcordiaCourseId": "048038"
+    },
+    {
+      "Id": "56624bfe-143f-45dc-bac2-2874a42e05cd",
+      "ConcordiaCourseId": "048379"
+    },
+    {
+      "Id": "ea382e7d-b56c-470d-ae47-afd56ab01b33",
+      "ConcordiaCourseId": "048387"
+    },
+    {
+      "Id": "e6999242-fd99-487f-b56a-0f66b974b98e",
+      "ConcordiaCourseId": "048976"
+    },
+    {
+      "Id": "47e332aa-e0a7-48c1-b384-5e31cb1c2f2c",
+      "ConcordiaCourseId": "049371"
+    },
+    {
+      "Id": "2b884554-1c25-4ef3-a3d7-c7f1263fcf12",
+      "ConcordiaCourseId": "050303"
+    },
+    {
+      "Id": "e84856ab-8a96-4abe-9190-675e17e74111",
+      "ConcordiaCourseId": "050358"
+    },
+    {
+      "Id": "a1c9f591-e304-4b7a-9c49-3fe889fb10da",
+      "ConcordiaCourseId": "050449"
+    },
+    {
+      "Id": "fa23d7d9-1929-4ea0-8be4-d784c1bb19a9",
+      "ConcordiaCourseId": "050499"
+    },
+    {
+      "Id": "617bc5d1-d638-4b86-90c5-5b29aae256dd",
+      "ConcordiaCourseId": "008573"
+    },
+    {
+      "Id": "8fbb146e-8625-421e-bffc-63ecdef7c8ab",
+      "ConcordiaCourseId": "008575"
+    },
+    {
+      "Id": "a6c7a6b2-58eb-4ffe-83b9-8c43d188772a",
+      "ConcordiaCourseId": "008578"
+    },
+    {
+      "Id": "5d60b9d7-6b07-43fe-bdc0-62123362dec9",
+      "ConcordiaCourseId": "008582"
+    },
+    {
+      "Id": "0a4b53e1-a51c-4c04-81b8-0eb0edd81336",
+      "ConcordiaCourseId": "008583"
+    },
+    {
+      "Id": "67b06767-07c7-4705-9ed6-e1a8ad6ef86b",
+      "ConcordiaCourseId": "008585"
+    },
+    {
+      "Id": "e22675bc-694b-4ee2-a390-eac0ed2d8aeb",
+      "ConcordiaCourseId": "008586"
+    },
+    {
+      "Id": "6d17853a-bd7a-48e4-8607-1e7f164737bf",
+      "ConcordiaCourseId": "008588"
+    },
+    {
+      "Id": "459452f7-474c-4120-896e-01d4ecdb49bc",
+      "ConcordiaCourseId": "008599"
+    },
+    {
+      "Id": "f52c5409-65d7-4a37-853f-7daac114b260",
+      "ConcordiaCourseId": "008601"
+    },
+    {
+      "Id": "04b3ed29-5ca7-429b-980b-a75f52e38c4d",
+      "ConcordiaCourseId": "008604"
+    },
+    {
+      "Id": "0fd1a6ed-7943-4d64-a879-f9247dc2546d",
+      "ConcordiaCourseId": "008605"
+    },
+    {
+      "Id": "dc7b2c28-ee3b-4277-84a6-b7a5ade2c866",
+      "ConcordiaCourseId": "008610"
+    },
+    {
+      "Id": "5ead40ed-64e5-49cb-9052-0baa46831b8c",
+      "ConcordiaCourseId": "008614"
+    },
+    {
+      "Id": "b4d36565-3be6-46d5-8c96-e70fc41d699d",
+      "ConcordiaCourseId": "008617"
+    },
+    {
+      "Id": "e5ec248b-d8ae-406d-b5b0-d221975132a4",
+      "ConcordiaCourseId": "008620"
+    },
+    {
+      "Id": "59a088a6-3a5b-4cf9-ab00-c2b676c22575",
+      "ConcordiaCourseId": "008624"
+    },
+    {
+      "Id": "73d4438d-3243-4a85-9c8c-f208023c24d1",
+      "ConcordiaCourseId": "008626"
+    },
+    {
+      "Id": "3cbb12a9-7be5-4750-a88e-1bb29442922c",
+      "ConcordiaCourseId": "008627"
+    },
+    {
+      "Id": "c6ed4fc9-7a2b-4d1f-bb67-e887c32ad0f9",
+      "ConcordiaCourseId": "008629"
+    },
+    {
+      "Id": "e3808976-4ea7-4a64-ab07-e57d37916b3b",
+      "ConcordiaCourseId": "008633"
+    },
+    {
+      "Id": "26ac7eb8-73f7-40b5-b10b-5f0b76be0aa3",
+      "ConcordiaCourseId": "008634"
+    },
+    {
+      "Id": "f3c01889-cefc-4ded-a670-dd0cc47a8f41",
+      "ConcordiaCourseId": "008638"
+    },
+    {
+      "Id": "e76bd999-dea4-475c-a9f3-f1e3d0c2cbdd",
+      "ConcordiaCourseId": "008643"
+    },
+    {
+      "Id": "7bcd8360-635b-4062-88b3-8b87fd9277fd",
+      "ConcordiaCourseId": "008645"
+    },
+    {
+      "Id": "710d769e-3855-4625-a4b0-17b84e9d7101",
+      "ConcordiaCourseId": "008647"
+    },
+    {
+      "Id": "5e48b941-b153-4270-bdbe-65f2327a9966",
+      "ConcordiaCourseId": "008651"
+    },
+    {
+      "Id": "49feb96e-0673-477a-856a-6e276f020e35",
+      "ConcordiaCourseId": "008657"
+    },
+    {
+      "Id": "8e78a60c-16a5-4982-9776-f816e50d27e3",
+      "ConcordiaCourseId": "008663"
+    },
+    {
+      "Id": "69477571-578b-4bab-b572-7a1a5358532d",
+      "ConcordiaCourseId": "008665"
+    },
+    {
+      "Id": "ed6e2b9d-bd0f-457f-ad04-a57f5669952e",
+      "ConcordiaCourseId": "008666"
+    },
+    {
+      "Id": "1abd2a02-2eb1-429e-b280-95dd341111d4",
+      "ConcordiaCourseId": "008727"
+    },
+    {
+      "Id": "644bc3b3-1ca4-4f4c-88c2-f1579ffbb3ea",
+      "ConcordiaCourseId": "008733"
+    },
+    {
+      "Id": "ea6f6421-2813-44ea-a2cc-79b0081e0a86",
+      "ConcordiaCourseId": "008734"
+    },
+    {
+      "Id": "f41d7420-f33e-470f-b904-4148ed420eaf",
+      "ConcordiaCourseId": "008737"
+    },
+    {
+      "Id": "75fa2f37-97c3-419d-9977-ea82195603ad",
+      "ConcordiaCourseId": "008740"
+    },
+    {
+      "Id": "f92ca999-a732-4bd5-a2bc-16043489c6ea",
+      "ConcordiaCourseId": "008744"
+    },
+    {
+      "Id": "be52120e-562d-402d-894c-067d9e1cd3b3",
+      "ConcordiaCourseId": "008747"
+    },
+    {
+      "Id": "bb73d0a0-b9d0-47fc-ad50-59a00ed3658b",
+      "ConcordiaCourseId": "008750"
+    },
+    {
+      "Id": "4941c561-df0d-4ed4-938c-2870ffbaf298",
+      "ConcordiaCourseId": "008757"
+    },
+    {
+      "Id": "a9d1f7eb-af70-4c68-8889-7663fdc3e30b",
+      "ConcordiaCourseId": "008761"
+    },
+    {
+      "Id": "88a43b7e-d60d-42fe-b16f-b28351d66be6",
+      "ConcordiaCourseId": "008774"
+    },
+    {
+      "Id": "cb4d47f8-c0c6-436d-8d2e-668b3f9aa3ab",
+      "ConcordiaCourseId": "008775"
+    },
+    {
+      "Id": "6d2aeaee-4663-4745-9fde-c6a2354feeca",
+      "ConcordiaCourseId": "008776"
+    },
+    {
+      "Id": "76adec4c-87be-4711-8b3b-26453adc1f20",
+      "ConcordiaCourseId": "008779"
+    },
+    {
+      "Id": "25a59360-3327-4d20-a9ce-8c7f62d10021",
+      "ConcordiaCourseId": "008782"
+    },
+    {
+      "Id": "e8466d7a-da04-4ce7-836d-bc374297b674",
+      "ConcordiaCourseId": "008784"
+    },
+    {
+      "Id": "284bf3ac-ecfc-4e0d-af99-c014dc773666",
+      "ConcordiaCourseId": "008787"
+    },
+    {
+      "Id": "6939873f-689b-4317-9d76-864f8b70747a",
+      "ConcordiaCourseId": "008789"
+    },
+    {
+      "Id": "15eb628b-dc87-448e-8fc4-b2eaa0a5f047",
+      "ConcordiaCourseId": "008792"
+    },
+    {
+      "Id": "f4e5b635-2b8e-4d58-bd36-f85c86e7c015",
+      "ConcordiaCourseId": "008796"
+    },
+    {
+      "Id": "209e5cfb-e282-4e44-99b3-371fcfbc2bd8",
+      "ConcordiaCourseId": "008803"
+    },
+    {
+      "Id": "56550aa5-2b13-48b8-ab58-5fe2442e3ba6",
+      "ConcordiaCourseId": "008806"
+    },
+    {
+      "Id": "e613538c-e3d9-4471-b810-b12727ca356c",
+      "ConcordiaCourseId": "008810"
+    },
+    {
+      "Id": "26650629-eefd-41d4-98c4-091e4cfe7243",
+      "ConcordiaCourseId": "008814"
+    },
+    {
+      "Id": "9450f6c0-15d4-4f17-a363-cac3f9ba7edf",
+      "ConcordiaCourseId": "008817"
+    },
+    {
+      "Id": "5e45cd19-155a-4160-a6cf-c37cee7d8800",
+      "ConcordiaCourseId": "008826"
+    },
+    {
+      "Id": "0af1014d-3bb5-4075-ba27-8e31766ec490",
+      "ConcordiaCourseId": "008833"
+    },
+    {
+      "Id": "8c7426cc-ce51-40ba-af2b-5479578fb069",
+      "ConcordiaCourseId": "008838"
+    },
+    {
+      "Id": "611349c5-f120-4561-9a2f-d2e2db51a762",
+      "ConcordiaCourseId": "008842"
+    },
+    {
+      "Id": "1281fc26-f61e-47eb-b972-ca4be7fe2355",
+      "ConcordiaCourseId": "008846"
+    },
+    {
+      "Id": "e041f3c8-6e40-432e-92e6-1540e9cd9c0b",
+      "ConcordiaCourseId": "008848"
+    },
+    {
+      "Id": "f273804b-7e59-4a32-906b-b6a78fb6fe98",
+      "ConcordiaCourseId": "008850"
+    },
+    {
+      "Id": "674f2d8b-fa88-4ef5-a101-c5e0d75322be",
+      "ConcordiaCourseId": "008852"
+    },
+    {
+      "Id": "6713b78b-1266-42b9-a006-76cd1d6c06f0",
+      "ConcordiaCourseId": "008854"
+    },
+    {
+      "Id": "a9b4475a-7413-475a-8402-57e438121f23",
+      "ConcordiaCourseId": "008856"
+    },
+    {
+      "Id": "9e8ee081-0a68-4fb8-bdd4-02b996654c89",
+      "ConcordiaCourseId": "008859"
+    },
+    {
+      "Id": "b68259ef-ccfa-42ee-92c4-2dd9d2c0b9a0",
+      "ConcordiaCourseId": "008860"
+    },
+    {
+      "Id": "cf4c9713-af04-4326-a70f-a1989c65133f",
+      "ConcordiaCourseId": "008861"
+    },
+    {
+      "Id": "6113133f-bf17-4619-ab6b-53c1b7cac82a",
+      "ConcordiaCourseId": "008866"
+    },
+    {
+      "Id": "8a3bb4cd-1fd0-49e7-b602-03a7315d00c1",
+      "ConcordiaCourseId": "008868"
+    },
+    {
+      "Id": "3418aabb-1f63-4d28-9086-c3727c5ba721",
+      "ConcordiaCourseId": "008870"
+    },
+    {
+      "Id": "99f79dfd-3c51-420a-bf95-ff008d85b009",
+      "ConcordiaCourseId": "008871"
+    },
+    {
+      "Id": "df5d80c0-982d-4d53-898e-60fe1e817526",
+      "ConcordiaCourseId": "008874"
+    },
+    {
+      "Id": "b0a76614-5f0c-42a3-b36a-07734507a682",
+      "ConcordiaCourseId": "008877"
+    },
+    {
+      "Id": "e0865d5d-3eb2-4b33-a387-64f5843bde89",
+      "ConcordiaCourseId": "008879"
+    },
+    {
+      "Id": "66c2be5f-3e62-47e3-b275-4a629dedbccb",
+      "ConcordiaCourseId": "008881"
+    },
+    {
+      "Id": "4a07b8ca-064a-4dd3-9d03-9551eccf8e67",
+      "ConcordiaCourseId": "008882"
+    },
+    {
+      "Id": "c8767762-fedd-465b-97d9-995853353615",
+      "ConcordiaCourseId": "008885"
+    },
+    {
+      "Id": "ca756516-070e-4e77-bf63-b7b329ee83d5",
+      "ConcordiaCourseId": "008887"
+    },
+    {
+      "Id": "42dcffd6-80b0-4093-9ac5-ff06ae071655",
+      "ConcordiaCourseId": "008904"
+    },
+    {
+      "Id": "5c85bc35-7a8d-446f-a138-4fdfc904fb30",
+      "ConcordiaCourseId": "008907"
+    },
+    {
+      "Id": "f827383c-0999-4844-bb3e-09264dca670a",
+      "ConcordiaCourseId": "008909"
+    },
+    {
+      "Id": "1f179266-fb0d-40d8-bed0-aece9cdfa60c",
+      "ConcordiaCourseId": "008913"
+    },
+    {
+      "Id": "ae825272-438a-42fa-9640-10e991629482",
+      "ConcordiaCourseId": "008916"
+    },
+    {
+      "Id": "4e1dd0fb-3c6f-46be-a645-b11279a24afb",
+      "ConcordiaCourseId": "008917"
+    },
+    {
+      "Id": "e42bc52d-f3eb-4363-8b9a-1ab4acdb464b",
+      "ConcordiaCourseId": "008918"
+    },
+    {
+      "Id": "08cf349d-6787-4578-986e-d266adbce096",
+      "ConcordiaCourseId": "008919"
+    },
+    {
+      "Id": "c3f87512-adfa-4c74-9e69-2d9f72291e73",
+      "ConcordiaCourseId": "008921"
+    },
+    {
+      "Id": "d9d1b1ed-c1ac-4dd3-82bb-be4f135bfb75",
+      "ConcordiaCourseId": "008922"
+    },
+    {
+      "Id": "9594d257-2883-43de-ad1f-2c2a05041120",
+      "ConcordiaCourseId": "008923"
+    },
+    {
+      "Id": "884bcb86-e6f8-4b9e-b32d-3c5fc3286cb6",
+      "ConcordiaCourseId": "008924"
+    },
+    {
+      "Id": "cbbc2730-0018-4b0c-97fe-1a9b9aa4f2e4",
+      "ConcordiaCourseId": "008928"
+    },
+    {
+      "Id": "42f0c4d4-0d91-49cb-96b5-2ff8cb896743",
+      "ConcordiaCourseId": "008929"
+    },
+    {
+      "Id": "91bb2b89-8f86-4326-b308-332eb0ba0d0f",
+      "ConcordiaCourseId": "008931"
+    },
+    {
+      "Id": "1b153a19-5dc7-427d-951d-7db5d2445803",
+      "ConcordiaCourseId": "008932"
+    },
+    {
+      "Id": "89a60672-4087-42f4-9595-215065c35620",
+      "ConcordiaCourseId": "008933"
+    },
+    {
+      "Id": "0896eaac-4e09-4b0b-8bd1-75531f17fb2b",
+      "ConcordiaCourseId": "008934"
+    },
+    {
+      "Id": "ceb35e26-1eda-4617-b1cf-890b826aae7b",
+      "ConcordiaCourseId": "008936"
+    },
+    {
+      "Id": "c0ec03e0-9b12-40e2-8dbe-2e7f0d344f64",
+      "ConcordiaCourseId": "008938"
+    },
+    {
+      "Id": "a1e5a70b-1e37-41e7-b4cc-dd012f79aab7",
+      "ConcordiaCourseId": "008939"
+    },
+    {
+      "Id": "2dd9e4d9-0ae5-4711-866e-f5b477785803",
+      "ConcordiaCourseId": "008940"
+    },
+    {
+      "Id": "6f99458e-bf9f-41bf-a68a-2b34e0af8310",
+      "ConcordiaCourseId": "008941"
+    },
+    {
+      "Id": "6db5ef8d-ad06-41ff-a5c8-cdf3239fe1cd",
+      "ConcordiaCourseId": "008942"
+    },
+    {
+      "Id": "5861a77b-4ae3-42a0-848b-6d08396454c4",
+      "ConcordiaCourseId": "008943"
+    },
+    {
+      "Id": "8a5cd2b7-3604-440c-bab0-c69c024480bd",
+      "ConcordiaCourseId": "008944"
+    },
+    {
+      "Id": "600c5a07-52e6-477e-85d5-d1a814c7aa3f",
+      "ConcordiaCourseId": "008945"
+    },
+    {
+      "Id": "0a195c3f-08e9-4c65-b375-0241feb11102",
+      "ConcordiaCourseId": "008947"
+    },
+    {
+      "Id": "cc758979-116d-4f54-9a11-129dbf6c5eb1",
+      "ConcordiaCourseId": "008948"
+    },
+    {
+      "Id": "8acff74e-480c-49f3-ac55-cec8d8e0799f",
+      "ConcordiaCourseId": "008950"
+    },
+    {
+      "Id": "35665f1d-ee30-489e-951f-e05cd3bfb9a2",
+      "ConcordiaCourseId": "008951"
+    },
+    {
+      "Id": "da44d0e3-bb85-4467-8235-d230b07d3af6",
+      "ConcordiaCourseId": "008952"
+    },
+    {
+      "Id": "a769019b-7d16-4a2e-a74b-037161369830",
+      "ConcordiaCourseId": "008954"
+    },
+    {
+      "Id": "2bae6465-de32-4d24-992d-dd6dc3d464bd",
+      "ConcordiaCourseId": "008956"
+    },
+    {
+      "Id": "45dfa1b0-9cbe-4b0a-98b9-c5435d8d111e",
+      "ConcordiaCourseId": "008957"
+    },
+    {
+      "Id": "94e062a8-2bf6-432d-96ff-5679433da714",
+      "ConcordiaCourseId": "009021"
+    },
+    {
+      "Id": "a57f48f3-7ec3-4dc3-b30a-127a7444f0af",
+      "ConcordiaCourseId": "009022"
+    },
+    {
+      "Id": "90c2f598-442d-437a-bcb4-d87aaa82560e",
+      "ConcordiaCourseId": "009068"
+    },
+    {
+      "Id": "5689999a-aa09-423d-a6b1-91de8ccd5d77",
+      "ConcordiaCourseId": "009073"
+    },
+    {
+      "Id": "86835927-9fa4-45c6-92b3-6680a1ba1702",
+      "ConcordiaCourseId": "009078"
+    },
+    {
+      "Id": "34ae6ecc-50d7-42d3-a27d-4f98a035605c",
+      "ConcordiaCourseId": "009083"
+    },
+    {
+      "Id": "bc7b5433-d1a6-43ff-b2da-d29baa708ced",
+      "ConcordiaCourseId": "009086"
+    },
+    {
+      "Id": "66e43d70-ce71-4635-a605-b30b401afe3a",
+      "ConcordiaCourseId": "009088"
+    },
+    {
+      "Id": "d45c3640-f218-4130-94bc-0ec26b586aa6",
+      "ConcordiaCourseId": "009100"
+    },
+    {
+      "Id": "d3a94073-07b6-424f-997e-a3160dd8a0f8",
+      "ConcordiaCourseId": "009114"
+    },
+    {
+      "Id": "933baed8-c404-41e9-aaa0-6fa808ea5a06",
+      "ConcordiaCourseId": "009121"
+    },
+    {
+      "Id": "e1062366-24c0-4b32-a58f-d0442e0ff31e",
+      "ConcordiaCourseId": "009131"
+    },
+    {
+      "Id": "56f0da4c-8cd9-44a3-a8e2-08c598a03d98",
+      "ConcordiaCourseId": "009138"
+    },
+    {
+      "Id": "5534b4d1-cf50-49de-9b14-ccaac58fbf2c",
+      "ConcordiaCourseId": "009147"
+    },
+    {
+      "Id": "5e73d724-e3d7-4473-890d-5307b5989cc1",
+      "ConcordiaCourseId": "009154"
+    },
+    {
+      "Id": "07f68b06-3c8e-4334-8e53-b18ea5f71f74",
+      "ConcordiaCourseId": "009162"
+    },
+    {
+      "Id": "97f576f4-d9f6-42b3-977f-410ba666b8b1",
+      "ConcordiaCourseId": "009170"
+    },
+    {
+      "Id": "6ab8731e-55b7-4638-ac59-01f925cb76f1",
+      "ConcordiaCourseId": "009202"
+    },
+    {
+      "Id": "b3ed7eb4-5446-4818-b013-7c0056ef486f",
+      "ConcordiaCourseId": "009208"
+    },
+    {
+      "Id": "e27097b0-ea26-4ad2-9abb-6728014737d3",
+      "ConcordiaCourseId": "009218"
+    },
+    {
+      "Id": "8fd27632-1226-48fe-9c94-b0d9518f66ee",
+      "ConcordiaCourseId": "009220"
+    },
+    {
+      "Id": "0a622dc4-8176-4881-bfcf-99265a9aecf9",
+      "ConcordiaCourseId": "009263"
+    },
+    {
+      "Id": "58e49555-8f4d-4397-a162-b8dd7166bedb",
+      "ConcordiaCourseId": "009264"
+    },
+    {
+      "Id": "f7c0dd7f-872e-49e1-8cd5-1249d67861d3",
+      "ConcordiaCourseId": "009270"
+    },
+    {
+      "Id": "d5bd3125-5a03-4f3a-aacd-a31881552e15",
+      "ConcordiaCourseId": "009271"
+    },
+    {
+      "Id": "9ee23f24-e19b-4edb-bfc2-173179319fee",
+      "ConcordiaCourseId": "009272"
+    },
+    {
+      "Id": "82607e0c-0832-497f-aff3-d37be3f144c3",
+      "ConcordiaCourseId": "009275"
+    },
+    {
+      "Id": "f832d8d3-68dd-42ef-983f-f0363b7c5706",
+      "ConcordiaCourseId": "009278"
+    },
+    {
+      "Id": "bebd2929-917d-4c84-9f0d-97f2c7486cbb",
+      "ConcordiaCourseId": "009283"
+    },
+    {
+      "Id": "5e2b5623-5f68-4ce6-883b-2be04b64ce6c",
+      "ConcordiaCourseId": "009286"
+    },
+    {
+      "Id": "227562cf-1894-4074-99d1-f6bb4014edfa",
+      "ConcordiaCourseId": "009289"
+    },
+    {
+      "Id": "110c03c4-f931-4623-a4c3-0ac832e007c0",
+      "ConcordiaCourseId": "009291"
+    },
+    {
+      "Id": "fefe9f1b-6f5b-49e7-9873-51c6b22cec9e",
+      "ConcordiaCourseId": "009293"
+    },
+    {
+      "Id": "a11f45de-69e9-455f-b85c-9252eb4549b1",
+      "ConcordiaCourseId": "009302"
+    },
+    {
+      "Id": "de817489-a844-4993-8ca4-868bca81235e",
+      "ConcordiaCourseId": "009305"
+    },
+    {
+      "Id": "4d994037-5bd0-4ee4-8178-85e39de0b6af",
+      "ConcordiaCourseId": "009308"
+    },
+    {
+      "Id": "fd117019-df00-4160-b58d-75842d07b9d5",
+      "ConcordiaCourseId": "009311"
+    },
+    {
+      "Id": "a0bc834c-9d03-4654-addb-7309132a9b59",
+      "ConcordiaCourseId": "009314"
+    },
+    {
+      "Id": "3d23df80-7f86-40cc-89c0-b7939b43b909",
+      "ConcordiaCourseId": "009317"
+    },
+    {
+      "Id": "9d493c30-acae-4104-98cd-47932807ed19",
+      "ConcordiaCourseId": "009321"
+    },
+    {
+      "Id": "504ba6e1-5891-4919-a0be-f07f029e35f1",
+      "ConcordiaCourseId": "009327"
+    },
+    {
+      "Id": "da1352c5-bdf3-49c2-a29a-25f2cdc8b7fa",
+      "ConcordiaCourseId": "009328"
+    },
+    {
+      "Id": "d22f9ebc-2de5-49fa-afe7-411120f8a1b4",
+      "ConcordiaCourseId": "009329"
+    },
+    {
+      "Id": "de367997-d0f5-4a63-88fb-7f25d4961b05",
+      "ConcordiaCourseId": "009334"
+    },
+    {
+      "Id": "1079ab05-1eeb-485a-8bc3-b9933619a73a",
+      "ConcordiaCourseId": "009339"
+    },
+    {
+      "Id": "8a81ca46-9614-4db5-8ed5-e52d031ac2b1",
+      "ConcordiaCourseId": "009344"
+    },
+    {
+      "Id": "0874c06a-d438-4dd6-8a6b-046f83910b24",
+      "ConcordiaCourseId": "009348"
+    },
+    {
+      "Id": "23aa1705-c4bc-4850-95fd-e485cc1223c1",
+      "ConcordiaCourseId": "009351"
+    },
+    {
+      "Id": "9d2098a7-6234-4c61-b44e-a90b2d81b5ae",
+      "ConcordiaCourseId": "009355"
+    },
+    {
+      "Id": "acf32df4-1164-41fe-a708-cbd40a532df3",
+      "ConcordiaCourseId": "009359"
+    },
+    {
+      "Id": "b113db07-f092-4e31-9bec-a606c95b49ea",
+      "ConcordiaCourseId": "009364"
+    },
+    {
+      "Id": "36d24a7e-0e42-48d2-9ccd-1326741230a3",
+      "ConcordiaCourseId": "009367"
+    },
+    {
+      "Id": "66f94571-4e41-4913-8fb2-57dfc3b26b4e",
+      "ConcordiaCourseId": "009370"
+    },
+    {
+      "Id": "8aef7db0-a82c-4931-abdb-218a6bd4c690",
+      "ConcordiaCourseId": "009373"
+    },
+    {
+      "Id": "5d08c164-ca7d-4f88-89d2-13ab2390fd98",
+      "ConcordiaCourseId": "009376"
+    },
+    {
+      "Id": "0d03c780-65f9-4eb0-ad1b-c5743eea729e",
+      "ConcordiaCourseId": "009378"
+    },
+    {
+      "Id": "91de201e-416e-4792-9067-ff158e75cc64",
+      "ConcordiaCourseId": "009381"
+    },
+    {
+      "Id": "d0d4cba4-8d59-4e2e-9db3-326b877242b0",
+      "ConcordiaCourseId": "009383"
+    },
+    {
+      "Id": "559154a4-0fd3-40fa-8660-97bdc3c46303",
+      "ConcordiaCourseId": "009384"
+    },
+    {
+      "Id": "f1b3bd78-984d-47ea-9719-46a38c30f197",
+      "ConcordiaCourseId": "009386"
+    },
+    {
+      "Id": "f22f7c1d-f1df-4870-9ef7-343f3759f16c",
+      "ConcordiaCourseId": "009389"
+    },
+    {
+      "Id": "b13d8e37-a70b-42d4-82cd-a594f42b040b",
+      "ConcordiaCourseId": "009393"
+    },
+    {
+      "Id": "b5ecabb0-8a71-4eb6-b9ed-593d0b2cd970",
+      "ConcordiaCourseId": "009397"
+    },
+    {
+      "Id": "679e3b27-40c3-41c9-831d-ca9f54c8fa56",
+      "ConcordiaCourseId": "009400"
+    },
+    {
+      "Id": "2d20dbb2-2154-4c32-a9d2-43efe57441b9",
+      "ConcordiaCourseId": "009402"
+    },
+    {
+      "Id": "0c02b6c8-70bd-4a92-8a00-6061a50d5f1c",
+      "ConcordiaCourseId": "009405"
+    },
+    {
+      "Id": "ec5725c5-2c10-4742-bc09-cf837acdb14f",
+      "ConcordiaCourseId": "009407"
+    },
+    {
+      "Id": "bc65dc2c-7e04-4df5-8fb6-f63ce6eba346",
+      "ConcordiaCourseId": "009411"
+    },
+    {
+      "Id": "610513a7-71b6-4e51-85c4-1c968181ca44",
+      "ConcordiaCourseId": "009414"
+    },
+    {
+      "Id": "7ae31ad0-75db-4e00-bca7-5073aa460f83",
+      "ConcordiaCourseId": "009418"
+    },
+    {
+      "Id": "ec5c3d80-acae-4941-80a3-ee37bbe5701e",
+      "ConcordiaCourseId": "009421"
+    },
+    {
+      "Id": "8f8ae5e6-1334-4012-b931-50149994c0e4",
+      "ConcordiaCourseId": "009424"
+    },
+    {
+      "Id": "8b5cfc79-9b7b-45d9-894d-2e4aea6e7ac9",
+      "ConcordiaCourseId": "009426"
+    },
+    {
+      "Id": "37c728c1-56e7-41e6-bf62-50277d1f2203",
+      "ConcordiaCourseId": "009429"
+    },
+    {
+      "Id": "22fad56f-4edf-480e-94a5-9a0cb7437e9d",
+      "ConcordiaCourseId": "009432"
+    },
+    {
+      "Id": "1569b788-1f24-40be-b72c-65670529201c",
+      "ConcordiaCourseId": "009435"
+    },
+    {
+      "Id": "890c72b4-e392-4a95-a66d-ef0bc160db42",
+      "ConcordiaCourseId": "009438"
+    },
+    {
+      "Id": "3b464f4f-6c48-48de-b844-3aa46db56a91",
+      "ConcordiaCourseId": "009441"
+    },
+    {
+      "Id": "556828cf-bc7c-4fd5-9b6d-633af7d009ea",
+      "ConcordiaCourseId": "009444"
+    },
+    {
+      "Id": "48ecde6a-99a8-440d-b675-16c9926d9f8b",
+      "ConcordiaCourseId": "009445"
+    },
+    {
+      "Id": "043bb53c-5b6d-4c8e-b1ef-a5d356abe8a6",
+      "ConcordiaCourseId": "009447"
+    },
+    {
+      "Id": "e4663596-b31e-4f02-85c2-f1c1c901a1e8",
+      "ConcordiaCourseId": "009449"
+    },
+    {
+      "Id": "99cdca72-2024-4395-8f15-f35fb20048ba",
+      "ConcordiaCourseId": "009451"
+    },
+    {
+      "Id": "52670447-4151-4ec1-85ce-79943e3e68ea",
+      "ConcordiaCourseId": "009453"
+    },
+    {
+      "Id": "85f5d2d3-430d-4b28-8d71-f59fbd85c034",
+      "ConcordiaCourseId": "009455"
+    },
+    {
+      "Id": "33b4d092-f6da-432f-baea-40ad9993dd9e",
+      "ConcordiaCourseId": "009459"
+    },
+    {
+      "Id": "541a7a05-27e7-445c-970a-31223dde29a9",
+      "ConcordiaCourseId": "009461"
+    },
+    {
+      "Id": "8232452f-6886-4df7-ac51-38029382fec8",
+      "ConcordiaCourseId": "009468"
+    },
+    {
+      "Id": "38db0196-f3bb-48de-b6a7-501fea00010a",
+      "ConcordiaCourseId": "009470"
+    },
+    {
+      "Id": "35e38e0e-e2df-47ad-8664-ca9c291427f3",
+      "ConcordiaCourseId": "009480"
+    },
+    {
+      "Id": "eb393828-47b2-468a-83c7-c3ea63a37596",
+      "ConcordiaCourseId": "009481"
+    },
+    {
+      "Id": "c4599cb6-25c1-4441-bafd-c79d5541b2fe",
+      "ConcordiaCourseId": "009482"
+    },
+    {
+      "Id": "7f1b6b81-a5da-4330-9700-420881c071b2",
+      "ConcordiaCourseId": "009484"
+    },
+    {
+      "Id": "ac8a57a9-5f52-450e-89ad-46ee67eb7e55",
+      "ConcordiaCourseId": "009485"
+    },
+    {
+      "Id": "5e65f231-e7fe-45d2-a9e5-d1088f509cd5",
+      "ConcordiaCourseId": "009486"
+    },
+    {
+      "Id": "6daf0ab7-5891-4a0e-94d3-f47d0f50b5d1",
+      "ConcordiaCourseId": "044023"
+    },
+    {
+      "Id": "362a4bb7-063a-48ef-8a02-1e4adff39e95",
+      "ConcordiaCourseId": "045333"
+    },
+    {
+      "Id": "16b4ce43-fd6b-4943-b815-346faaa891a6",
+      "ConcordiaCourseId": "045335"
+    },
+    {
+      "Id": "1cc2a679-3bb5-4df7-a2bd-bf739f57b864",
+      "ConcordiaCourseId": "045336"
+    },
+    {
+      "Id": "e370ab5b-8be9-4571-a765-7d1f6e63cf6d",
+      "ConcordiaCourseId": "045337"
+    },
+    {
+      "Id": "b0c9baed-382e-4df0-a62a-34f573b46c4d",
+      "ConcordiaCourseId": "045339"
+    },
+    {
+      "Id": "548bd3a4-6af6-45ac-9587-8c660de6bd9a",
+      "ConcordiaCourseId": "045340"
+    },
+    {
+      "Id": "4948fff0-5314-44d8-90f6-542b954db208",
+      "ConcordiaCourseId": "045342"
+    },
+    {
+      "Id": "c9aa768f-e087-4c28-a863-27144278dc8f",
+      "ConcordiaCourseId": "046651"
+    },
+    {
+      "Id": "19ce277f-fc2f-4407-9577-49c95707f75d",
+      "ConcordiaCourseId": "046652"
+    },
+    {
+      "Id": "f89488e8-36de-479a-9328-1e9f53d863c4",
+      "ConcordiaCourseId": "046653"
+    },
+    {
+      "Id": "63c147aa-5743-4ca2-bc7a-52b5292fe0ec",
+      "ConcordiaCourseId": "046654"
+    },
+    {
+      "Id": "0b7c5df5-188f-4fe1-9dd1-3b6af5f979e8",
+      "ConcordiaCourseId": "046655"
+    },
+    {
+      "Id": "7dfe9c26-013f-4eda-a7cc-1073aad16ef0",
+      "ConcordiaCourseId": "046656"
+    },
+    {
+      "Id": "c2a357c6-9063-4e7f-892c-553daad59df4",
+      "ConcordiaCourseId": "046657"
+    },
+    {
+      "Id": "55580d7a-b504-4717-b7ca-2ab9b6e85734",
+      "ConcordiaCourseId": "046658"
+    },
+    {
+      "Id": "39e807ec-0cc0-4f65-a7da-1ef67ff34535",
+      "ConcordiaCourseId": "046659"
+    },
+    {
+      "Id": "c5ab7780-d196-4412-a1fd-656b82a61eea",
+      "ConcordiaCourseId": "046660"
+    },
+    {
+      "Id": "2b12728f-c7f0-4659-ab21-74e60bc0391b",
+      "ConcordiaCourseId": "046661"
+    },
+    {
+      "Id": "e64dc45d-3722-411d-a14f-8fb5027325a1",
+      "ConcordiaCourseId": "046662"
+    },
+    {
+      "Id": "56f46abe-b0aa-44bc-97d5-be4eb6949128",
+      "ConcordiaCourseId": "046663"
+    },
+    {
+      "Id": "24750d12-b9e5-46cf-b047-adda35bd0f7a",
+      "ConcordiaCourseId": "047196"
+    },
+    {
+      "Id": "3ce88768-c81e-4412-8f0f-b26e3795c7dd",
+      "ConcordiaCourseId": "047575"
+    },
+    {
+      "Id": "4c3b9eb7-b70b-430d-9016-bda9ac6ee27c",
+      "ConcordiaCourseId": "047576"
+    },
+    {
+      "Id": "4af5bdb4-83ed-4182-a168-5d7d3e7316ba",
+      "ConcordiaCourseId": "047577"
+    },
+    {
+      "Id": "89f26a48-b7a8-45cd-a29b-0c884ca25883",
+      "ConcordiaCourseId": "047578"
+    },
+    {
+      "Id": "1e1a872a-d347-4438-a63c-94a1da7836be",
+      "ConcordiaCourseId": "047579"
+    },
+    {
+      "Id": "12ddc3c1-6737-4b72-9363-0b35a5aec4b4",
+      "ConcordiaCourseId": "047580"
+    },
+    {
+      "Id": "e549a5ab-5b8f-4e57-be6a-4697f0a31f70",
+      "ConcordiaCourseId": "047581"
+    },
+    {
+      "Id": "39a044b1-0e1d-42e4-8da6-a600517b5346",
+      "ConcordiaCourseId": "047582"
+    },
+    {
+      "Id": "2b96fe45-245f-444c-b85d-fc1129377393",
+      "ConcordiaCourseId": "047583"
+    },
+    {
+      "Id": "190dd97b-ff49-4f24-9103-1010f5781908",
+      "ConcordiaCourseId": "048472"
+    },
+    {
+      "Id": "a0e472c6-5970-4073-a365-d8da7ba38cef",
+      "ConcordiaCourseId": "049604"
+    },
+    {
+      "Id": "b4a9dcd9-7b6a-44ad-ae57-91b6e4cf801c",
+      "ConcordiaCourseId": "050153"
+    },
+    {
+      "Id": "d4eeeacd-62a8-451f-b8e6-25e075cb5b87",
+      "ConcordiaCourseId": "050379"
+    },
+    {
+      "Id": "722dd728-5309-4d77-946e-0f1a7fdfe1a6",
+      "ConcordiaCourseId": "009939"
+    },
+    {
+      "Id": "1ce69831-efd2-4e91-8396-5b283ad0d75b",
+      "ConcordiaCourseId": "009941"
+    },
+    {
+      "Id": "98538f31-15df-4dac-9ae7-9221b7f083d6",
+      "ConcordiaCourseId": "009951"
+    },
+    {
+      "Id": "2eae373e-899a-41de-9bfd-d39968c2c629",
+      "ConcordiaCourseId": "009960"
+    },
+    {
+      "Id": "5c0527b8-f196-4cfb-8843-1aaa31f45612",
+      "ConcordiaCourseId": "009964"
+    },
+    {
+      "Id": "8ede4229-c0f0-4ece-a434-dee645c4a23a",
+      "ConcordiaCourseId": "009965"
+    },
+    {
+      "Id": "e55367dc-0e99-41e2-b86e-659d15110bbd",
+      "ConcordiaCourseId": "009966"
+    },
+    {
+      "Id": "e7786719-d5e0-4006-9653-aab11a76bd55",
+      "ConcordiaCourseId": "009967"
+    },
+    {
+      "Id": "e6ceeb10-6905-415b-aa91-82f9dcdbc39a",
+      "ConcordiaCourseId": "009968"
+    },
+    {
+      "Id": "f6fa0a9c-e220-41b1-bd6c-18e53104fe47",
+      "ConcordiaCourseId": "009977"
+    },
+    {
+      "Id": "848d17f5-219b-4a00-ae52-e2c79fac66b9",
+      "ConcordiaCourseId": "009979"
+    },
+    {
+      "Id": "a981618e-7f4d-4646-bcd5-161b329ef7fc",
+      "ConcordiaCourseId": "009985"
+    },
+    {
+      "Id": "98c35971-6cbd-45b1-a107-d3bcead4b381",
+      "ConcordiaCourseId": "009999"
+    },
+    {
+      "Id": "1806c778-1733-4736-97cd-c8d363c6a705",
+      "ConcordiaCourseId": "010005"
+    },
+    {
+      "Id": "4ed7f416-ff91-41e9-9bcb-cc15b4b50a24",
+      "ConcordiaCourseId": "010009"
+    },
+    {
+      "Id": "11a1467e-d43b-44c6-b3ca-ce75dd3e7c3a",
+      "ConcordiaCourseId": "010010"
+    },
+    {
+      "Id": "b9074685-fd72-4a22-8f66-56ca067e41e6",
+      "ConcordiaCourseId": "010015"
+    },
+    {
+      "Id": "96ac755b-6fa3-4c3e-ace4-ed280476708a",
+      "ConcordiaCourseId": "010016"
+    },
+    {
+      "Id": "4d3ec0f3-c089-433d-b9ca-03588e76b329",
+      "ConcordiaCourseId": "010025"
+    },
+    {
+      "Id": "3317497f-c059-4b02-ab06-1433be72cad9",
+      "ConcordiaCourseId": "010082"
+    },
+    {
+      "Id": "9a2b3e9a-fb4d-47c0-9072-482a633f9277",
+      "ConcordiaCourseId": "010085"
+    },
+    {
+      "Id": "8b2c8293-a3d4-483b-be5b-d9f4dbcf2e7a",
+      "ConcordiaCourseId": "010087"
+    },
+    {
+      "Id": "5d3feb6c-84f8-4ef1-ba62-6e99feabb654",
+      "ConcordiaCourseId": "010091"
+    },
+    {
+      "Id": "910a6d32-090b-42e7-a0bd-b3440cdf1305",
+      "ConcordiaCourseId": "010093"
+    },
+    {
+      "Id": "19eb3f3c-ee06-4d15-a75b-39701045533a",
+      "ConcordiaCourseId": "010096"
+    },
+    {
+      "Id": "93616520-db32-4c72-8b5d-53d800e1904c",
+      "ConcordiaCourseId": "010097"
+    },
+    {
+      "Id": "6f09d864-e59b-4f91-b407-bbad0a13ddeb",
+      "ConcordiaCourseId": "010100"
+    },
+    {
+      "Id": "140a3a17-1250-49b0-9850-c314d6484c85",
+      "ConcordiaCourseId": "010102"
+    },
+    {
+      "Id": "4beb64ec-78d0-4fb8-bc67-c0869544b476",
+      "ConcordiaCourseId": "010104"
+    },
+    {
+      "Id": "b8ac3cd6-9042-431d-a73a-a4bfd2b899fc",
+      "ConcordiaCourseId": "010105"
+    },
+    {
+      "Id": "16f4418d-879c-4384-b59f-745cab8ba591",
+      "ConcordiaCourseId": "010106"
+    },
+    {
+      "Id": "c2e0de3a-a261-4bda-ab48-81d496af0a60",
+      "ConcordiaCourseId": "010108"
+    },
+    {
+      "Id": "f94ab34e-b93d-4539-bac1-4a8035fc0d43",
+      "ConcordiaCourseId": "010110"
+    },
+    {
+      "Id": "52d3eb24-2f9d-41ba-a5fb-131191bebfc4",
+      "ConcordiaCourseId": "010125"
+    },
+    {
+      "Id": "a80cae41-23da-46f5-baa8-cbc265ea4315",
+      "ConcordiaCourseId": "010128"
+    },
+    {
+      "Id": "9c79615c-4508-450a-93b9-74e5317f1424",
+      "ConcordiaCourseId": "010134"
+    },
+    {
+      "Id": "f5a0eff9-a19b-4b44-976c-d6182280f516",
+      "ConcordiaCourseId": "010140"
+    },
+    {
+      "Id": "a4d79c29-c6b8-4839-a396-afc004146335",
+      "ConcordiaCourseId": "010148"
+    },
+    {
+      "Id": "acb10404-81d1-41e6-804a-1cd136c12715",
+      "ConcordiaCourseId": "010160"
+    },
+    {
+      "Id": "ffde5c15-b7c8-4697-af77-6b428d9d50b8",
+      "ConcordiaCourseId": "010176"
+    },
+    {
+      "Id": "a786ce39-7da3-4998-9932-08e2f703b5e2",
+      "ConcordiaCourseId": "010184"
+    },
+    {
+      "Id": "806b443b-573b-42fb-a626-ebee1225ab68",
+      "ConcordiaCourseId": "010185"
+    },
+    {
+      "Id": "50d63c6c-8872-40cc-95ee-0ad2e3fa8789",
+      "ConcordiaCourseId": "010186"
+    },
+    {
+      "Id": "9f93e7f7-9209-43b8-9659-7f71840699da",
+      "ConcordiaCourseId": "010188"
+    },
+    {
+      "Id": "0dd87bb7-a5f3-44e4-ad8d-9d62f84f9491",
+      "ConcordiaCourseId": "010191"
+    },
+    {
+      "Id": "2bfdd187-e83c-49d9-8b2d-38d479758513",
+      "ConcordiaCourseId": "010193"
+    },
+    {
+      "Id": "d751ed80-9d7e-40f9-82e8-bae67fc0667f",
+      "ConcordiaCourseId": "010197"
+    },
+    {
+      "Id": "8bd17cb6-329a-4857-87c8-a6aed31b89b0",
+      "ConcordiaCourseId": "010200"
+    },
+    {
+      "Id": "8b2044de-b37f-4fc5-a413-fcc1881bf4d4",
+      "ConcordiaCourseId": "010205"
+    },
+    {
+      "Id": "959e47c6-6788-4647-b3ce-9a61a820d6c7",
+      "ConcordiaCourseId": "010211"
+    },
+    {
+      "Id": "1b1430ff-7e34-42e4-a122-b34b8d1a3941",
+      "ConcordiaCourseId": "010227"
+    },
+    {
+      "Id": "59419898-261e-467c-b4f5-215daef66263",
+      "ConcordiaCourseId": "010243"
+    },
+    {
+      "Id": "532c156e-b19b-4b80-ae60-dce4b3498c74",
+      "ConcordiaCourseId": "010244"
+    },
+    {
+      "Id": "cd700847-33c3-47ad-957b-0c861b47369e",
+      "ConcordiaCourseId": "010245"
+    },
+    {
+      "Id": "5e5d5a25-f49e-4391-83e0-6a0d87436b14",
+      "ConcordiaCourseId": "040631"
+    },
+    {
+      "Id": "4587009a-5892-4419-b383-400c8fefaed4",
+      "ConcordiaCourseId": "040632"
+    },
+    {
+      "Id": "b4097478-2324-450b-a5e2-c937fa14056c",
+      "ConcordiaCourseId": "040633"
+    },
+    {
+      "Id": "77457d2d-660e-4c02-aa5d-f73cd0eded0d",
+      "ConcordiaCourseId": "040634"
+    },
+    {
+      "Id": "b1312613-a130-4ac8-8296-02d25a7e79b8",
+      "ConcordiaCourseId": "040635"
+    },
+    {
+      "Id": "c73ea31c-7b69-4c57-be1d-596bfd881210",
+      "ConcordiaCourseId": "040637"
+    },
+    {
+      "Id": "710c47f3-e281-48bb-93c7-b2e52b1edbad",
+      "ConcordiaCourseId": "040638"
+    },
+    {
+      "Id": "d3182ab6-74cf-441d-9fbf-1d0b088528ba",
+      "ConcordiaCourseId": "040639"
+    },
+    {
+      "Id": "8546d5df-4439-4b08-9a9a-f6f957e1c99d",
+      "ConcordiaCourseId": "046664"
+    },
+    {
+      "Id": "648dfa52-88bc-4d57-8fee-ae3e350a2524",
+      "ConcordiaCourseId": "046665"
+    },
+    {
+      "Id": "6057df6c-e0d2-47ad-8dec-fad13e1109e5",
+      "ConcordiaCourseId": "046666"
+    },
+    {
+      "Id": "8a35cde2-90db-48d1-ae17-a67dd46d62e4",
+      "ConcordiaCourseId": "048036"
+    },
+    {
+      "Id": "e2e92471-e766-4781-8380-ce2d933a64e1",
+      "ConcordiaCourseId": "048037"
+    },
+    {
+      "Id": "a1e8442c-a483-49be-9812-2a5451f970eb",
+      "ConcordiaCourseId": "049033"
+    },
+    {
+      "Id": "1374ac4a-0f8d-4d38-87af-c8944f9d0576",
+      "ConcordiaCourseId": "049330"
+    },
+    {
+      "Id": "5ba8b558-8966-4f3f-9bdd-40ce8810b230",
+      "ConcordiaCourseId": "049354"
+    },
+    {
+      "Id": "7b43c09e-6f11-4ccf-bc80-27b4be0372b5",
+      "ConcordiaCourseId": "049413"
+    },
+    {
+      "Id": "64e7c9c9-1668-4af7-a489-e9a6abc5ba7f",
+      "ConcordiaCourseId": "049694"
+    },
+    {
+      "Id": "3fdd7fd3-511f-47e1-8385-e0f74043a0f8",
+      "ConcordiaCourseId": "049824"
+    },
+    {
+      "Id": "ac143baf-1b26-4565-8f20-e0994689bec2",
+      "ConcordiaCourseId": "049853"
+    },
+    {
+      "Id": "c08197a1-0db9-4453-946b-3858d95a0c6f",
+      "ConcordiaCourseId": "050057"
+    },
+    {
+      "Id": "9999ac34-8b44-4712-ba88-dfc8c7e55e91",
+      "ConcordiaCourseId": "046667"
+    },
+    {
+      "Id": "b53f744a-b362-4581-aa5d-11488228a2b1",
+      "ConcordiaCourseId": "010409"
+    },
+    {
+      "Id": "cdcf335c-747f-466b-ace1-c69177f763f8",
+      "ConcordiaCourseId": "010410"
+    },
+    {
+      "Id": "1cf04452-7282-4cc2-b951-473d2e40923c",
+      "ConcordiaCourseId": "010411"
+    },
+    {
+      "Id": "ace6350a-3dce-4aa6-a713-49c280ac49d1",
+      "ConcordiaCourseId": "010412"
+    },
+    {
+      "Id": "dc473d80-b9e6-4f02-8c4d-5ccfd1712cea",
+      "ConcordiaCourseId": "010415"
+    },
+    {
+      "Id": "d72c83a3-d4fe-436a-b8b5-4ba4802e1bac",
+      "ConcordiaCourseId": "040652"
+    },
+    {
+      "Id": "a6341af2-a04c-474a-9e25-c186331a58c5",
+      "ConcordiaCourseId": "040657"
+    },
+    {
+      "Id": "d8eb50a2-7b4d-48b0-9795-45591806f258",
+      "ConcordiaCourseId": "046668"
+    },
+    {
+      "Id": "bf100606-3603-4ae0-8354-41d52bc4d6ae",
+      "ConcordiaCourseId": "046669"
+    },
+    {
+      "Id": "02cb3e90-ffbc-476e-b5ae-ce5725e72d76",
+      "ConcordiaCourseId": "048024"
+    },
+    {
+      "Id": "55551bc6-5730-4ca9-adf0-b69b00aead4b",
+      "ConcordiaCourseId": "048025"
+    },
+    {
+      "Id": "8dc53e84-8772-4a8e-82c7-e25931099eb2",
+      "ConcordiaCourseId": "048026"
+    },
+    {
+      "Id": "b3676fdf-5dd6-4825-ada1-0fa275d35e2e",
+      "ConcordiaCourseId": "048027"
+    },
+    {
+      "Id": "9a5af9b9-290f-459e-a2f7-41cc32641ac9",
+      "ConcordiaCourseId": "048028"
+    },
+    {
+      "Id": "753cbcaa-e020-4c4a-ae86-1f71c3bd04e0",
+      "ConcordiaCourseId": "048029"
+    },
+    {
+      "Id": "1de0179a-7b79-4ad6-99c5-a1bdf535ff18",
+      "ConcordiaCourseId": "048460"
+    },
+    {
+      "Id": "b6da43cf-0b8c-41ae-a57b-1514951f55b0",
+      "ConcordiaCourseId": "049255"
+    },
+    {
+      "Id": "645c22db-c0a7-4eba-a321-9cbf8a8bc871",
+      "ConcordiaCourseId": "050542"
+    },
+    {
+      "Id": "c25da6ae-7b21-4d88-9e00-962809d2bccb",
+      "ConcordiaCourseId": "050543"
+    },
+    {
+      "Id": "12c06b22-1ea6-44f3-88ef-73b1d1bbebb9",
+      "ConcordiaCourseId": "010426"
+    },
+    {
+      "Id": "65d33201-ed91-452d-afa8-00ef5af9e750",
+      "ConcordiaCourseId": "010427"
+    },
+    {
+      "Id": "0a47b41a-d2d5-4870-a17e-1f8d6f5651c9",
+      "ConcordiaCourseId": "010428"
+    },
+    {
+      "Id": "a70decae-c3cf-4fbc-87e8-0282266a98f4",
+      "ConcordiaCourseId": "010429"
+    },
+    {
+      "Id": "4c8deb37-8ec1-450f-a2a9-f1090cff1e3f",
+      "ConcordiaCourseId": "010434"
+    },
+    {
+      "Id": "90e85f47-fdb9-4f1d-9a71-6e8177f80750",
+      "ConcordiaCourseId": "046670"
+    },
+    {
+      "Id": "cf9072cc-b097-425a-84c2-b0204e4e118c",
+      "ConcordiaCourseId": "010459"
+    },
+    {
+      "Id": "728bb257-3381-415f-92ca-b5069c9530ca",
+      "ConcordiaCourseId": "010460"
+    },
+    {
+      "Id": "393590a8-2ae1-4d54-9e8f-24c412eedb0a",
+      "ConcordiaCourseId": "010462"
+    },
+    {
+      "Id": "06c8a485-dd86-4f7b-a666-af07bafdcb69",
+      "ConcordiaCourseId": "010467"
+    },
+    {
+      "Id": "a513e876-4e49-4ac1-ad82-2fc4527313c3",
+      "ConcordiaCourseId": "010470"
+    },
+    {
+      "Id": "f0e34cc5-69fa-420a-a2c1-ec6c2b5948fa",
+      "ConcordiaCourseId": "010475"
+    },
+    {
+      "Id": "50bc987d-4fd3-442d-87ec-488e17f9354e",
+      "ConcordiaCourseId": "010476"
+    },
+    {
+      "Id": "33060182-f854-4c85-836f-5daac88bbfeb",
+      "ConcordiaCourseId": "010477"
+    },
+    {
+      "Id": "92da89fd-ae56-42a4-8c43-4ce4bbfcac4b",
+      "ConcordiaCourseId": "010479"
+    },
+    {
+      "Id": "24d64461-c980-4b97-8ecc-cb50da29012f",
+      "ConcordiaCourseId": "010483"
+    },
+    {
+      "Id": "00830f2f-8555-488d-a5b7-6788627efba8",
+      "ConcordiaCourseId": "010487"
+    },
+    {
+      "Id": "a5f13207-0eaf-4543-bddf-f3d7ef06f313",
+      "ConcordiaCourseId": "010490"
+    },
+    {
+      "Id": "a4b68e72-a147-427d-945a-b1b6cdba6c68",
+      "ConcordiaCourseId": "010493"
+    },
+    {
+      "Id": "bb677cb2-2a6a-4ed7-b5e7-e16c14eed40c",
+      "ConcordiaCourseId": "010496"
+    },
+    {
+      "Id": "af49e972-02a6-44e8-aa69-a96abf64ceff",
+      "ConcordiaCourseId": "010497"
+    },
+    {
+      "Id": "b1a895fc-7a89-47e8-8040-058e8750c5d2",
+      "ConcordiaCourseId": "010501"
+    },
+    {
+      "Id": "ebdbf02b-3e31-4bb5-8667-92e1e7acad13",
+      "ConcordiaCourseId": "010503"
+    },
+    {
+      "Id": "73e2e1a9-6f4f-4222-9582-70fb5b553d55",
+      "ConcordiaCourseId": "010517"
+    },
+    {
+      "Id": "3e0774f8-1b9b-44e2-9fea-064e7eda902e",
+      "ConcordiaCourseId": "010518"
+    },
+    {
+      "Id": "5964466a-32dd-447d-88a7-9e730ba756eb",
+      "ConcordiaCourseId": "010521"
+    },
+    {
+      "Id": "5ee16ed8-9e4b-417a-b6b1-bdd22f9486db",
+      "ConcordiaCourseId": "010527"
+    },
+    {
+      "Id": "6db8c6fe-d347-4f93-862b-00931f7e7724",
+      "ConcordiaCourseId": "010531"
+    },
+    {
+      "Id": "0a649307-0dcd-40b5-ad5e-09e873239360",
+      "ConcordiaCourseId": "010535"
+    },
+    {
+      "Id": "60c95d09-4b78-42e3-b6a9-d01bb51da960",
+      "ConcordiaCourseId": "010536"
+    },
+    {
+      "Id": "f6c302ee-3e46-4def-a1bf-d74ddf8e5d50",
+      "ConcordiaCourseId": "010537"
+    },
+    {
+      "Id": "3318fc65-33d6-4c88-95ca-48333d33be6a",
+      "ConcordiaCourseId": "010538"
+    },
+    {
+      "Id": "ae795107-1611-4972-8e0f-c7b0e16e7612",
+      "ConcordiaCourseId": "010540"
+    },
+    {
+      "Id": "066f92d4-06af-4a57-a4e3-6cad9dc986da",
+      "ConcordiaCourseId": "010541"
+    },
+    {
+      "Id": "9f597c9f-f846-4b97-8611-90224c2aa66b",
+      "ConcordiaCourseId": "010543"
+    },
+    {
+      "Id": "ff42d4f5-7efd-4297-ba2e-f3edff3825be",
+      "ConcordiaCourseId": "010544"
+    },
+    {
+      "Id": "c7dbbfd0-e703-49ae-95d4-38afb879a635",
+      "ConcordiaCourseId": "010545"
+    },
+    {
+      "Id": "99b32ff9-3570-4f95-b7f9-863bfcff02d5",
+      "ConcordiaCourseId": "010546"
+    },
+    {
+      "Id": "b211ca04-08e7-4bd9-85b5-eb48d28be3b0",
+      "ConcordiaCourseId": "010548"
+    },
+    {
+      "Id": "9b7668d4-ae47-4eef-8fe6-f835e96d6075",
+      "ConcordiaCourseId": "037731"
+    },
+    {
+      "Id": "020c367f-19f7-406e-a5ab-8151d1c9a35a",
+      "ConcordiaCourseId": "040666"
+    },
+    {
+      "Id": "5122f770-07e8-4da7-b4ff-fdd67aaf1b3f",
+      "ConcordiaCourseId": "010553"
+    },
+    {
+      "Id": "de956d5b-260a-41b1-9c78-293c8973f528",
+      "ConcordiaCourseId": "010560"
+    },
+    {
+      "Id": "0c6e4191-5606-41ab-ab84-aa74ea5711ee",
+      "ConcordiaCourseId": "010561"
+    },
+    {
+      "Id": "4fd9e23f-0e01-44e7-b1a7-cb0515d57b2b",
+      "ConcordiaCourseId": "010562"
+    },
+    {
+      "Id": "2b361e56-f46b-4c26-8650-12a64a9b9ba2",
+      "ConcordiaCourseId": "010566"
+    },
+    {
+      "Id": "b3168532-1768-4db7-ba36-26544cfb08d2",
+      "ConcordiaCourseId": "010568"
+    },
+    {
+      "Id": "59daafea-1faf-410d-bef6-51beac7cf854",
+      "ConcordiaCourseId": "010573"
+    },
+    {
+      "Id": "faa61af2-38c1-4a10-a4b6-4db20024d876",
+      "ConcordiaCourseId": "010574"
+    },
+    {
+      "Id": "2c3b9ed0-87ab-45c4-9e13-2bb3da0aceda",
+      "ConcordiaCourseId": "010580"
+    },
+    {
+      "Id": "eea95a07-559b-46b7-9e6e-9ef3e7724b3c",
+      "ConcordiaCourseId": "010588"
+    },
+    {
+      "Id": "fa98c43f-46ae-45d4-b641-b4e75e34d2bb",
+      "ConcordiaCourseId": "010590"
+    },
+    {
+      "Id": "5c65142a-8736-4ce7-8a5a-424c0bfb4c4f",
+      "ConcordiaCourseId": "010593"
+    },
+    {
+      "Id": "6a7a51d5-3aa3-49f4-bf7b-853e21c6e112",
+      "ConcordiaCourseId": "010601"
+    },
+    {
+      "Id": "d6ac239f-0b4e-4ffc-93b9-c105fec2659b",
+      "ConcordiaCourseId": "010602"
+    },
+    {
+      "Id": "0bea3bb1-26fb-4ff0-8a3e-349a763ba4bc",
+      "ConcordiaCourseId": "010603"
+    },
+    {
+      "Id": "90fc8c19-fc68-4089-bb80-66df4a295c0e",
+      "ConcordiaCourseId": "010604"
+    },
+    {
+      "Id": "aa779ec1-262e-42d5-914e-f22f5621d817",
+      "ConcordiaCourseId": "010605"
+    },
+    {
+      "Id": "0105068b-fe06-414f-aee7-d6d82e7f5b72",
+      "ConcordiaCourseId": "010606"
+    },
+    {
+      "Id": "7ed11dea-5c7f-4de9-aff8-3e604ecbf65a",
+      "ConcordiaCourseId": "010614"
+    },
+    {
+      "Id": "138c1b7b-0a7c-4e7c-b656-5dad9aa165e8",
+      "ConcordiaCourseId": "010615"
+    },
+    {
+      "Id": "05a1cb6d-3291-4432-99be-dfce5a69ef50",
+      "ConcordiaCourseId": "010616"
+    },
+    {
+      "Id": "4eb65d7f-edf2-4526-b096-2071ea1adb04",
+      "ConcordiaCourseId": "010620"
+    },
+    {
+      "Id": "8a226e21-43c2-4e5d-9569-b73598df0a95",
+      "ConcordiaCourseId": "010622"
+    },
+    {
+      "Id": "c2d0c310-5ce2-4e00-8c19-0aa0dd460871",
+      "ConcordiaCourseId": "010625"
+    },
+    {
+      "Id": "a5a7fc0b-e889-4461-af9b-9f9618ddbfd2",
+      "ConcordiaCourseId": "010629"
+    },
+    {
+      "Id": "01fea137-04d8-47c4-b5d5-4de7ec335a98",
+      "ConcordiaCourseId": "010630"
+    },
+    {
+      "Id": "9e560a38-6199-4e3f-b00c-c832b32fdd1e",
+      "ConcordiaCourseId": "010631"
+    },
+    {
+      "Id": "43b2e3a9-e647-42b8-a326-11e6410e644e",
+      "ConcordiaCourseId": "010632"
+    },
+    {
+      "Id": "4ef0bf78-cad4-4d53-a552-07239afdab70",
+      "ConcordiaCourseId": "010633"
+    },
+    {
+      "Id": "34ef89fb-b836-4467-bcab-cb71cff8b617",
+      "ConcordiaCourseId": "010634"
+    },
+    {
+      "Id": "e674925f-0a4b-404d-aa1f-97db2955e908",
+      "ConcordiaCourseId": "010635"
+    },
+    {
+      "Id": "a46a76a8-60b6-4ece-9bc4-10258bb16701",
+      "ConcordiaCourseId": "010641"
+    },
+    {
+      "Id": "4732e31b-8f12-4da8-abc2-b4e96a494791",
+      "ConcordiaCourseId": "010642"
+    },
+    {
+      "Id": "215dc360-6ed2-403a-b61b-9ed71f53b8b6",
+      "ConcordiaCourseId": "010643"
+    },
+    {
+      "Id": "d79447d1-5c94-4f5a-b4a4-8377071411f8",
+      "ConcordiaCourseId": "010644"
+    },
+    {
+      "Id": "4f079879-afb3-4fd2-8037-fddd4f89a82a",
+      "ConcordiaCourseId": "010670"
+    },
+    {
+      "Id": "4aea9c4f-c51a-4e55-b2c0-26dfb0526e04",
+      "ConcordiaCourseId": "010679"
+    },
+    {
+      "Id": "93860669-685c-4f55-bcf8-3c02aad7b010",
+      "ConcordiaCourseId": "010682"
+    },
+    {
+      "Id": "87a1e35d-7403-44bc-862b-9aa722ecd074",
+      "ConcordiaCourseId": "010683"
+    },
+    {
+      "Id": "85a57b79-76d4-4ab2-abef-c69a974f28f7",
+      "ConcordiaCourseId": "010684"
+    },
+    {
+      "Id": "536fbe89-a9d9-4ab9-86b2-c3e6fd6e5e62",
+      "ConcordiaCourseId": "010686"
+    },
+    {
+      "Id": "63611b7e-e5e1-4d00-bbd5-8a76b78dc8a3",
+      "ConcordiaCourseId": "010687"
+    },
+    {
+      "Id": "2142a1e3-6543-4fbb-bb6a-81fd38831dd1",
+      "ConcordiaCourseId": "010688"
+    },
+    {
+      "Id": "a8d3d8c5-8d5c-4201-aa2d-047947c194ea",
+      "ConcordiaCourseId": "010689"
+    },
+    {
+      "Id": "34abc02f-ea52-4d44-96d4-7577a5dfdfb0",
+      "ConcordiaCourseId": "010698"
+    },
+    {
+      "Id": "c18c20de-2a4d-46b5-b63e-edc35fa7b059",
+      "ConcordiaCourseId": "010699"
+    },
+    {
+      "Id": "ba99919c-b7b9-4a68-b6cf-20f9b8bafc14",
+      "ConcordiaCourseId": "010704"
+    },
+    {
+      "Id": "ccdc8838-4618-41bc-b26e-e506926534c1",
+      "ConcordiaCourseId": "010711"
+    },
+    {
+      "Id": "ef2e4458-df0c-4b9e-9f7c-5cb22df02f76",
+      "ConcordiaCourseId": "010720"
+    },
+    {
+      "Id": "ef0a1949-b22c-454d-981c-61169ec4ef44",
+      "ConcordiaCourseId": "010721"
+    },
+    {
+      "Id": "3b3fc73b-9179-48dc-b012-6e6e5b8aeb1c",
+      "ConcordiaCourseId": "010722"
+    },
+    {
+      "Id": "71908f58-27fa-4578-a950-83053669dbaa",
+      "ConcordiaCourseId": "037732"
+    },
+    {
+      "Id": "b4aeeae3-2616-40ef-8e6a-932afae450c6",
+      "ConcordiaCourseId": "037733"
+    },
+    {
+      "Id": "5df316b7-9471-4c76-b6a8-1fc34ae86cce",
+      "ConcordiaCourseId": "040678"
+    },
+    {
+      "Id": "28271cc8-96cb-4105-ba31-615f386b042a",
+      "ConcordiaCourseId": "040686"
+    },
+    {
+      "Id": "fabcb3a7-37a8-4f88-8c06-44c49639da19",
+      "ConcordiaCourseId": "040687"
+    },
+    {
+      "Id": "5405c4bf-60c2-4576-8d4f-627faeab9929",
+      "ConcordiaCourseId": "040690"
+    },
+    {
+      "Id": "3f76b254-b64a-4e3e-957e-79256331c10c",
+      "ConcordiaCourseId": "040691"
+    },
+    {
+      "Id": "362e49ef-d481-463a-96a1-ad6227a54fda",
+      "ConcordiaCourseId": "040692"
+    },
+    {
+      "Id": "884bd9c1-e98f-4935-8557-d5cd8ef4f33d",
+      "ConcordiaCourseId": "040696"
+    },
+    {
+      "Id": "8ac8a9b5-dd5f-4699-be79-25368ac91288",
+      "ConcordiaCourseId": "040698"
+    },
+    {
+      "Id": "4315ae41-8462-428f-bc21-e1e5314c5312",
+      "ConcordiaCourseId": "040699"
+    },
+    {
+      "Id": "018275ac-2d22-4d91-8930-85a36398d834",
+      "ConcordiaCourseId": "040700"
+    },
+    {
+      "Id": "6b6433a7-b1d8-4c35-bdb0-c0501e2756b6",
+      "ConcordiaCourseId": "040701"
+    },
+    {
+      "Id": "0ab9ca56-04d6-473c-a707-e8cc87cd608a",
+      "ConcordiaCourseId": "040702"
+    },
+    {
+      "Id": "ab74c4d4-950c-467d-8dbf-8c55692c2d3e",
+      "ConcordiaCourseId": "040704"
+    },
+    {
+      "Id": "4fdb2e1d-18c0-4da2-a450-e1f2c4b21dbb",
+      "ConcordiaCourseId": "040705"
+    },
+    {
+      "Id": "71d00f8e-1ff2-49a3-bf4c-4866a1a39028",
+      "ConcordiaCourseId": "040707"
+    },
+    {
+      "Id": "d5ea4662-cbf6-42e8-9da7-e208f73dc548",
+      "ConcordiaCourseId": "040719"
+    },
+    {
+      "Id": "f1456e4a-2c95-45aa-be3c-ead0c4483254",
+      "ConcordiaCourseId": "050824"
+    },
+    {
+      "Id": "8cec02c2-93b2-479b-9f08-b2de92882764",
+      "ConcordiaCourseId": "050825"
+    },
+    {
+      "Id": "6da993f0-03b7-403a-87a9-bb9434e16a8d",
+      "ConcordiaCourseId": "050827"
+    },
+    {
+      "Id": "38eb2195-7d66-48ac-8c1b-79e0e0269b82",
+      "ConcordiaCourseId": "050829"
+    },
+    {
+      "Id": "26286dec-a4f6-4f21-a4fe-ba15acabb87c",
+      "ConcordiaCourseId": "050830"
+    },
+    {
+      "Id": "22b4b0a3-e19e-4dad-b850-7ec753bbbb96",
+      "ConcordiaCourseId": "010726"
+    },
+    {
+      "Id": "574f8f27-67e4-4008-b567-aeff0bc1395b",
+      "ConcordiaCourseId": "010727"
+    },
+    {
+      "Id": "62a57268-83da-4eb0-b047-4c0f2179d804",
+      "ConcordiaCourseId": "010728"
+    },
+    {
+      "Id": "abcfadce-0596-4ba9-9c97-8ce7de5e70ee",
+      "ConcordiaCourseId": "010730"
+    },
+    {
+      "Id": "11f3b86a-6428-4899-a42f-9d5cf60b83bd",
+      "ConcordiaCourseId": "010732"
+    },
+    {
+      "Id": "2d636de3-6a94-45e2-996f-6edb3082dcb1",
+      "ConcordiaCourseId": "010734"
+    },
+    {
+      "Id": "7d3392bd-b965-4edf-864a-fc8546be7362",
+      "ConcordiaCourseId": "010735"
+    },
+    {
+      "Id": "0e4acca8-f695-47ef-a783-b4925a6f6d20",
+      "ConcordiaCourseId": "010736"
+    },
+    {
+      "Id": "1908bc90-8857-4ff8-86f4-73afbff97ed1",
+      "ConcordiaCourseId": "010737"
+    },
+    {
+      "Id": "73ff1791-4240-42b1-9eb3-bdbe29c108c7",
+      "ConcordiaCourseId": "010738"
+    },
+    {
+      "Id": "923cc23b-4791-4ddf-a032-862be6f17b01",
+      "ConcordiaCourseId": "010739"
+    },
+    {
+      "Id": "b1aa5615-bad9-4555-a7cf-401dcb5155cd",
+      "ConcordiaCourseId": "010741"
+    },
+    {
+      "Id": "96473f38-8172-4477-ae02-e2140aefe887",
+      "ConcordiaCourseId": "010760"
+    },
+    {
+      "Id": "04c937c0-80d3-492a-b38a-965f42900a9f",
+      "ConcordiaCourseId": "010761"
+    },
+    {
+      "Id": "9576aa61-4f51-4376-8600-8c423d5a73f0",
+      "ConcordiaCourseId": "010772"
+    },
+    {
+      "Id": "d8dd6265-7159-44cd-aa17-59f5869ee716",
+      "ConcordiaCourseId": "010773"
+    },
+    {
+      "Id": "63da37e0-9219-4e8f-8380-7409eea2f1ca",
+      "ConcordiaCourseId": "010775"
+    },
+    {
+      "Id": "8aa75c90-d0c3-4db6-a262-002f6edd72b7",
+      "ConcordiaCourseId": "010776"
+    },
+    {
+      "Id": "bd2b6c47-86fc-4826-b924-91ca33e682d1",
+      "ConcordiaCourseId": "010777"
+    },
+    {
+      "Id": "3685ea83-68e5-448b-9cc2-a1465bddd922",
+      "ConcordiaCourseId": "010781"
+    },
+    {
+      "Id": "ab18024c-5354-4ec1-ad41-0443f0f685ce",
+      "ConcordiaCourseId": "010783"
+    },
+    {
+      "Id": "24f8eba6-dd16-4d13-a6d5-a1caf9713855",
+      "ConcordiaCourseId": "010802"
+    },
+    {
+      "Id": "60380534-df5e-4c33-ac39-093ca16f2f41",
+      "ConcordiaCourseId": "010803"
+    },
+    {
+      "Id": "e6285021-34e1-4ad6-a7fc-35df4b1c6d19",
+      "ConcordiaCourseId": "010804"
+    },
+    {
+      "Id": "63f7ca6b-c7a9-42d4-a1f8-7d1f19aa2cc0",
+      "ConcordiaCourseId": "010805"
+    },
+    {
+      "Id": "2f14792a-2473-4d2e-bdf3-8fbdc102aa1e",
+      "ConcordiaCourseId": "010806"
+    },
+    {
+      "Id": "d3a18b05-1236-472c-93f6-1626fedb26b8",
+      "ConcordiaCourseId": "010807"
+    },
+    {
+      "Id": "72acf280-e5c4-40e6-8e7d-5682e0886a59",
+      "ConcordiaCourseId": "010808"
+    },
+    {
+      "Id": "b8822dde-5467-474e-bff0-cafbb9e5d883",
+      "ConcordiaCourseId": "010813"
+    },
+    {
+      "Id": "cb955fe9-5f3c-4da1-8501-abf7ae3fdb36",
+      "ConcordiaCourseId": "010816"
+    },
+    {
+      "Id": "70e188f1-d794-4c8a-afc7-e773332cb9cc",
+      "ConcordiaCourseId": "010817"
+    },
+    {
+      "Id": "876eb232-1943-4440-831a-ffe87c806f0d",
+      "ConcordiaCourseId": "010819"
+    },
+    {
+      "Id": "da77ce46-dd58-4171-a381-c2c2040ccf69",
+      "ConcordiaCourseId": "010821"
+    },
+    {
+      "Id": "2e5a31e6-7102-49cf-8dbf-bea7a3634ed6",
+      "ConcordiaCourseId": "010824"
+    },
+    {
+      "Id": "3772b46b-127a-43ab-adbc-52c56fb0eb37",
+      "ConcordiaCourseId": "010825"
+    },
+    {
+      "Id": "a0651b3a-28b4-46de-abc8-6d15e0658e97",
+      "ConcordiaCourseId": "010826"
+    },
+    {
+      "Id": "216346d0-7003-4c36-8c6e-4ffce784d118",
+      "ConcordiaCourseId": "010830"
+    },
+    {
+      "Id": "c9cdde13-5a96-41c5-a5f5-46e0b644d8eb",
+      "ConcordiaCourseId": "010833"
+    },
+    {
+      "Id": "8b0250a6-031e-47e8-b9df-fa1eb15c8a96",
+      "ConcordiaCourseId": "010835"
+    },
+    {
+      "Id": "bb145ea8-b4f1-47f6-8f26-fc4df371407c",
+      "ConcordiaCourseId": "010861"
+    },
+    {
+      "Id": "f8d2d0c5-ec61-467e-989b-152e8b0863fc",
+      "ConcordiaCourseId": "010862"
+    },
+    {
+      "Id": "320f4e4f-ea2e-44e9-80fa-9257d0b8ad0c",
+      "ConcordiaCourseId": "010863"
+    },
+    {
+      "Id": "ca1ccc18-d71a-43b6-9446-5a5f740fa892",
+      "ConcordiaCourseId": "010866"
+    },
+    {
+      "Id": "beeb08ec-a369-44f6-bc4f-91cfd44c262e",
+      "ConcordiaCourseId": "010867"
+    },
+    {
+      "Id": "bb28b522-4e17-4517-bf0c-9d52d162094b",
+      "ConcordiaCourseId": "010868"
+    },
+    {
+      "Id": "99ac9f7c-1625-4ab8-a203-7a2f838808ea",
+      "ConcordiaCourseId": "040723"
+    },
+    {
+      "Id": "369cd3a0-9600-49e2-8591-70fabb7f51ef",
+      "ConcordiaCourseId": "046671"
+    },
+    {
+      "Id": "6c8e6ce9-b842-47ab-8796-321b24514e98",
+      "ConcordiaCourseId": "046672"
+    },
+    {
+      "Id": "ae43b022-31f0-4a0c-a161-920ce3ef5ca9",
+      "ConcordiaCourseId": "046673"
+    },
+    {
+      "Id": "de6fadcc-8cf1-4f7f-927b-63a65adfe015",
+      "ConcordiaCourseId": "046674"
+    },
+    {
+      "Id": "b660600d-2378-4e40-a8cd-865a2ee4afcd",
+      "ConcordiaCourseId": "046675"
+    },
+    {
+      "Id": "0598579d-1697-4b0c-83e6-6bb4e295a1c2",
+      "ConcordiaCourseId": "046676"
+    },
+    {
+      "Id": "d4af63f8-99fb-4cd5-83cd-076668202b74",
+      "ConcordiaCourseId": "046677"
+    },
+    {
+      "Id": "9cfb34ad-5d8f-4900-ac21-0001c5fd94b9",
+      "ConcordiaCourseId": "048760"
+    },
+    {
+      "Id": "c549c58d-9235-43d2-86f8-3cb17c7f3eba",
+      "ConcordiaCourseId": "048761"
+    },
+    {
+      "Id": "b84e3a10-77a6-4e80-9f3c-a2fe10d44e4e",
+      "ConcordiaCourseId": "049010"
+    },
+    {
+      "Id": "eef7d19e-ed33-40e0-8275-95b832819876",
+      "ConcordiaCourseId": "049011"
+    },
+    {
+      "Id": "6f21b6b1-ab07-4642-8bc5-731f9f15562e",
+      "ConcordiaCourseId": "049486"
+    },
+    {
+      "Id": "8a91a232-1321-424b-883c-766557dbd17f",
+      "ConcordiaCourseId": "049633"
+    },
+    {
+      "Id": "8290e072-cf0d-4663-84b5-fc3ede8b454d",
+      "ConcordiaCourseId": "046678"
+    },
+    {
+      "Id": "5fcf4ad1-bbe0-492b-b135-361e94ed1f60",
+      "ConcordiaCourseId": "050423"
+    },
+    {
+      "Id": "1a14e6ce-1bc2-4add-b5d3-6311d3e111e0",
+      "ConcordiaCourseId": "050424"
+    },
+    {
+      "Id": "8375070e-fd7b-4650-965d-6a901e5df0b4",
+      "ConcordiaCourseId": "050425"
+    },
+    {
+      "Id": "50657342-239e-43de-ada0-8ead843c808e",
+      "ConcordiaCourseId": "010945"
+    },
+    {
+      "Id": "6440fb94-371a-4f24-9066-f4d978d0bbe3",
+      "ConcordiaCourseId": "049688"
+    },
+    {
+      "Id": "a4257e4a-2356-4fc9-9dfd-d17b10bce033",
+      "ConcordiaCourseId": "050697"
+    },
+    {
+      "Id": "24f0abc8-4410-49ec-a8f3-ebf348936419",
+      "ConcordiaCourseId": "050698"
+    },
+    {
+      "Id": "631925fa-e3b3-4b6f-82f0-2b9ba47bec88",
+      "ConcordiaCourseId": "010946"
+    },
+    {
+      "Id": "ff2ed359-6d5e-4d9d-8732-a45a7ad13a13",
+      "ConcordiaCourseId": "010947"
+    },
+    {
+      "Id": "fa2e13f9-faf9-49c8-93d5-18a4b7928ae8",
+      "ConcordiaCourseId": "010949"
+    },
+    {
+      "Id": "5edfaf4c-315a-4f34-bed9-a170ed9b1118",
+      "ConcordiaCourseId": "010951"
+    },
+    {
+      "Id": "5434e0ca-5fed-4c0c-b598-a9ae48646c3d",
+      "ConcordiaCourseId": "010953"
+    },
+    {
+      "Id": "35bd177d-e910-4d20-9f25-a3496c85f523",
+      "ConcordiaCourseId": "010954"
+    },
+    {
+      "Id": "5a40ff4d-b414-463e-ad55-22778cdf27d0",
+      "ConcordiaCourseId": "010962"
+    },
+    {
+      "Id": "47d35697-b755-469b-a1b3-fa279329978a",
+      "ConcordiaCourseId": "010963"
+    },
+    {
+      "Id": "e037960b-2419-4840-8485-6390bc5622c9",
+      "ConcordiaCourseId": "010964"
+    },
+    {
+      "Id": "4e6e18e9-7f26-495c-8a4a-db44d557ff47",
+      "ConcordiaCourseId": "010967"
+    },
+    {
+      "Id": "8cf8b827-509b-4d49-82e2-b6eeac463054",
+      "ConcordiaCourseId": "010968"
+    },
+    {
+      "Id": "671ba9ba-ca15-4d81-9e98-a88e017e3b91",
+      "ConcordiaCourseId": "010969"
+    },
+    {
+      "Id": "0fb9695a-e646-4d6a-8766-e083ddf2a594",
+      "ConcordiaCourseId": "010974"
+    },
+    {
+      "Id": "39eda011-d199-4f59-9e0e-e678cc76fb30",
+      "ConcordiaCourseId": "010976"
+    },
+    {
+      "Id": "8f7e7115-7808-45d3-a517-6abb9e8fcc28",
+      "ConcordiaCourseId": "010978"
+    },
+    {
+      "Id": "bb40369f-d085-48a5-9c9a-cd40ca49bc49",
+      "ConcordiaCourseId": "010979"
+    },
+    {
+      "Id": "9aac1edc-8a9c-400d-9769-405c12319bf6",
+      "ConcordiaCourseId": "046679"
+    },
+    {
+      "Id": "db98a767-2812-4913-8b49-a40d21b24ec7",
+      "ConcordiaCourseId": "046680"
+    },
+    {
+      "Id": "6a945e00-5f9d-48e9-8fe5-cef6319a54b4",
+      "ConcordiaCourseId": "046681"
+    },
+    {
+      "Id": "6b7169aa-c9fe-447d-ac80-14b51f6af55f",
+      "ConcordiaCourseId": "046682"
+    },
+    {
+      "Id": "6471067d-033b-4ffb-8749-2119ed3d3c55",
+      "ConcordiaCourseId": "047383"
+    },
+    {
+      "Id": "3a96aed8-e8bf-4694-8a25-93cc27fa0fab",
+      "ConcordiaCourseId": "048888"
+    },
+    {
+      "Id": "d65510f9-9597-4772-b7d7-3c34f36796ef",
+      "ConcordiaCourseId": "050130"
+    },
+    {
+      "Id": "b5b472b6-e450-438d-8fe9-1e97aca2bbe5",
+      "ConcordiaCourseId": "010988"
+    },
+    {
+      "Id": "254e5c19-d854-4660-bb68-4f92c8042f45",
+      "ConcordiaCourseId": "010992"
+    },
+    {
+      "Id": "4f4ff7e7-564f-4f90-a384-fd17cfe8b543",
+      "ConcordiaCourseId": "046683"
+    },
+    {
+      "Id": "2a15c8fd-5e02-445a-ab71-b5577e18dbc1",
+      "ConcordiaCourseId": "046684"
+    },
+    {
+      "Id": "07a84575-e4a7-40a1-8253-932eeb12a104",
+      "ConcordiaCourseId": "046685"
+    },
+    {
+      "Id": "a47102b0-dbc7-4a7b-9c03-5e21470bd74f",
+      "ConcordiaCourseId": "047450"
+    },
+    {
+      "Id": "2a11a1b0-17c9-4c72-8913-72cd30c68ce7",
+      "ConcordiaCourseId": "047451"
+    },
+    {
+      "Id": "72170704-eb7d-4ced-b71a-37641b0fd6db",
+      "ConcordiaCourseId": "047452"
+    },
+    {
+      "Id": "a609c39a-a97e-4602-8ef8-c741b6cd7af9",
+      "ConcordiaCourseId": "048521"
+    },
+    {
+      "Id": "5b3fd58b-5882-4688-824d-d68b6fbb3a3f",
+      "ConcordiaCourseId": "050397"
+    },
+    {
+      "Id": "08d30ad9-d7ff-4972-b366-89adf4f40da8",
+      "ConcordiaCourseId": "050398"
+    },
+    {
+      "Id": "77656fa7-49a0-4be1-9615-88c37e6fddcc",
+      "ConcordiaCourseId": "050399"
+    },
+    {
+      "Id": "7b6ab9f8-417a-48cb-9ff9-fb8e3c1f460b",
+      "ConcordiaCourseId": "050400"
+    },
+    {
+      "Id": "ca8880a7-4280-409d-b76a-ffdc7a0483a3",
+      "ConcordiaCourseId": "050699"
+    },
+    {
+      "Id": "4194474d-334f-442a-9e42-a519c2d8495b",
+      "ConcordiaCourseId": "046686"
+    },
+    {
+      "Id": "36095b17-39c6-4d5c-bb84-25c241028adc",
+      "ConcordiaCourseId": "011057"
+    },
+    {
+      "Id": "06bf13da-fa53-4ebb-90f9-5639b5baffdb",
+      "ConcordiaCourseId": "011058"
+    },
+    {
+      "Id": "7fd6cfba-b26d-4818-aa87-698b441cd84a",
+      "ConcordiaCourseId": "011071"
+    },
+    {
+      "Id": "a43eafe5-7a1d-4de1-9a80-a9fa9ba3ac90",
+      "ConcordiaCourseId": "011074"
+    },
+    {
+      "Id": "7ea2ed46-ea8c-49ac-a08c-b8113e2e4df3",
+      "ConcordiaCourseId": "011076"
+    },
+    {
+      "Id": "6b70f08d-b809-4adc-9a1a-f6c7c9691e53",
+      "ConcordiaCourseId": "011077"
+    },
+    {
+      "Id": "cdcdc7d4-7b75-4ad5-9968-ecfc19dfda3e",
+      "ConcordiaCourseId": "011079"
+    },
+    {
+      "Id": "682900c6-1674-4a75-9e14-d9df4392d2a5",
+      "ConcordiaCourseId": "011082"
+    },
+    {
+      "Id": "5b1b883a-023f-4c6a-b235-17ff06e5662c",
+      "ConcordiaCourseId": "011083"
+    },
+    {
+      "Id": "548effeb-7c4f-4301-83f6-37625bdc4d5c",
+      "ConcordiaCourseId": "011084"
+    },
+    {
+      "Id": "4e261fe5-822d-40ef-acab-36d26d52448a",
+      "ConcordiaCourseId": "011085"
+    },
+    {
+      "Id": "d6a1f62d-2787-47c4-8104-7e2ece4f3bfe",
+      "ConcordiaCourseId": "011086"
+    },
+    {
+      "Id": "078a9675-a404-4257-9ecf-7e2ef90cfacd",
+      "ConcordiaCourseId": "011087"
+    },
+    {
+      "Id": "de640c53-b385-4626-bac5-4587c430a4a6",
+      "ConcordiaCourseId": "011088"
+    },
+    {
+      "Id": "c76f6280-5e07-47ad-a8ed-328d751cd92b",
+      "ConcordiaCourseId": "011089"
+    },
+    {
+      "Id": "58864ddf-3e54-4fef-bdfc-e3ff86287988",
+      "ConcordiaCourseId": "011093"
+    },
+    {
+      "Id": "ad1f79f6-0bca-4f34-bb0d-b226d4e17079",
+      "ConcordiaCourseId": "011094"
+    },
+    {
+      "Id": "9bf06f73-438a-475d-92be-ea6d71af1448",
+      "ConcordiaCourseId": "011106"
+    },
+    {
+      "Id": "03ac8317-f649-4ec4-b898-ca3c8c5e0870",
+      "ConcordiaCourseId": "011111"
+    },
+    {
+      "Id": "99b1c373-4a78-4127-8767-ffb96fb83129",
+      "ConcordiaCourseId": "011129"
+    },
+    {
+      "Id": "b9deacdc-ff29-4c32-8ae1-ae9e9e7b149d",
+      "ConcordiaCourseId": "011131"
+    },
+    {
+      "Id": "e8a80c75-bd9b-4cf3-b786-f007e7e64954",
+      "ConcordiaCourseId": "011132"
+    },
+    {
+      "Id": "cd4b8552-fb26-4095-b2e8-5efe8164e607",
+      "ConcordiaCourseId": "011134"
+    },
+    {
+      "Id": "8307c247-d49c-4352-ab12-816370f48f60",
+      "ConcordiaCourseId": "011135"
+    },
+    {
+      "Id": "b1ff0349-4fa4-4300-9c28-75c7518394cc",
+      "ConcordiaCourseId": "011138"
+    },
+    {
+      "Id": "109b6f8f-2743-4a22-9ed7-a0e78f1be38b",
+      "ConcordiaCourseId": "011143"
+    },
+    {
+      "Id": "441bc0a4-a84b-4dd6-9cb1-36b6dbe5ec3a",
+      "ConcordiaCourseId": "011149"
+    },
+    {
+      "Id": "1ddbbca8-e88e-47a6-b723-58a8adbd2ab8",
+      "ConcordiaCourseId": "011153"
+    },
+    {
+      "Id": "42d69a7f-187f-4369-ba6a-e378b773bd93",
+      "ConcordiaCourseId": "011154"
+    },
+    {
+      "Id": "8efb3de7-a7fb-4644-9a27-a0b50efb598a",
+      "ConcordiaCourseId": "011155"
+    },
+    {
+      "Id": "9164364b-da0d-445b-bc5c-790de9881a3e",
+      "ConcordiaCourseId": "011157"
+    },
+    {
+      "Id": "7c9ae56c-17ea-4086-9e2f-842591ecacfa",
+      "ConcordiaCourseId": "011158"
+    },
+    {
+      "Id": "6fed5eb5-489c-493d-8a69-4de1ee867b7f",
+      "ConcordiaCourseId": "011159"
+    },
+    {
+      "Id": "6101b613-45ab-456a-afd5-ffa1adca493f",
+      "ConcordiaCourseId": "011164"
+    },
+    {
+      "Id": "f9697904-e1c4-4a1a-8023-11dd950620a6",
+      "ConcordiaCourseId": "046687"
+    },
+    {
+      "Id": "cde04b0d-8fa3-46bb-961a-ce88e19743cb",
+      "ConcordiaCourseId": "047930"
+    },
+    {
+      "Id": "d3017a3b-b568-4dc5-925b-8c65f2b50a67",
+      "ConcordiaCourseId": "048100"
+    },
+    {
+      "Id": "c3b5e2b3-d711-4975-bb9a-7198adbfbf6c",
+      "ConcordiaCourseId": "048101"
+    },
+    {
+      "Id": "2badf671-25d4-4af9-9a55-28d6b1d006fd",
+      "ConcordiaCourseId": "048102"
+    },
+    {
+      "Id": "77ae0107-3eb6-4d7b-b9a9-e459a87bffed",
+      "ConcordiaCourseId": "048411"
+    },
+    {
+      "Id": "f4e5b5d9-d1ba-4597-a5e1-8df099fdba43",
+      "ConcordiaCourseId": "048420"
+    },
+    {
+      "Id": "6fa40ac5-5b52-40ee-ac76-eb3cbbe9c8d1",
+      "ConcordiaCourseId": "048912"
+    },
+    {
+      "Id": "5b1f2a27-952c-4c0f-9684-297f4a73f531",
+      "ConcordiaCourseId": "050470"
+    },
+    {
+      "Id": "9a0daaec-4f79-415a-a7ff-183175e09b10",
+      "ConcordiaCourseId": "011257"
+    },
+    {
+      "Id": "0c6a9aef-d63a-48aa-a621-0b9dbfbac93c",
+      "ConcordiaCourseId": "011258"
+    },
+    {
+      "Id": "02140bde-6852-4dc9-973d-dc512b6385e9",
+      "ConcordiaCourseId": "011259"
+    },
+    {
+      "Id": "c08ed733-6a19-4ee9-af8a-e133e3b7a5ad",
+      "ConcordiaCourseId": "011260"
+    },
+    {
+      "Id": "c2757a21-aef8-415f-bf25-bbbd1f3d875f",
+      "ConcordiaCourseId": "011261"
+    },
+    {
+      "Id": "8ad9d36c-af76-4b49-b8ef-753b69659fff",
+      "ConcordiaCourseId": "011264"
+    },
+    {
+      "Id": "65758f68-c28b-4fdd-be79-93da04a1c4f5",
+      "ConcordiaCourseId": "011265"
+    },
+    {
+      "Id": "74ec89f7-e205-4847-86d6-9e94b3f478dc",
+      "ConcordiaCourseId": "011266"
+    },
+    {
+      "Id": "6b389f7e-788f-4c86-9c10-975ebadd7d02",
+      "ConcordiaCourseId": "011267"
+    },
+    {
+      "Id": "cbbd9ec4-9bb1-479b-970f-d3ee89a63528",
+      "ConcordiaCourseId": "011268"
+    },
+    {
+      "Id": "628530c7-c732-4ae6-a6b5-6455b6ab4586",
+      "ConcordiaCourseId": "011269"
+    },
+    {
+      "Id": "c8be1caa-400f-4c98-993a-bfcba9e9221e",
+      "ConcordiaCourseId": "011270"
+    },
+    {
+      "Id": "0bf86b04-d1f4-44f8-89b5-9d5e61ee2c38",
+      "ConcordiaCourseId": "011271"
+    },
+    {
+      "Id": "b1e02255-fdc3-4634-9f1e-b639f9778568",
+      "ConcordiaCourseId": "011272"
+    },
+    {
+      "Id": "ce984262-8a92-4852-a904-b91878714502",
+      "ConcordiaCourseId": "011273"
+    },
+    {
+      "Id": "1feec4e5-571d-4cf2-a26c-99dfdf94113a",
+      "ConcordiaCourseId": "011274"
+    },
+    {
+      "Id": "f7d63259-32f8-4871-9843-2e40e34e910c",
+      "ConcordiaCourseId": "011275"
+    },
+    {
+      "Id": "24da1791-e253-4ac8-ab5b-e6dd97666b98",
+      "ConcordiaCourseId": "011276"
+    },
+    {
+      "Id": "6938b193-4b97-4523-8eb9-043580275600",
+      "ConcordiaCourseId": "011277"
+    },
+    {
+      "Id": "209671d6-e166-4807-be4f-0896b7bf4f41",
+      "ConcordiaCourseId": "011278"
+    },
+    {
+      "Id": "2440e886-93dc-4292-b40f-642f4bf706b9",
+      "ConcordiaCourseId": "011279"
+    },
+    {
+      "Id": "43f7a9a7-7858-4e6c-90a1-7de414dc8410",
+      "ConcordiaCourseId": "011281"
+    },
+    {
+      "Id": "403ea311-f39a-4feb-a8d9-eabdd1a99320",
+      "ConcordiaCourseId": "011282"
+    },
+    {
+      "Id": "fbee7429-964e-404e-9e82-7b8a1a511b6a",
+      "ConcordiaCourseId": "011283"
+    },
+    {
+      "Id": "09a9aa67-7975-40b6-a577-f316728a3b69",
+      "ConcordiaCourseId": "011284"
+    },
+    {
+      "Id": "7530fb42-934e-4940-bd75-4d3b4d826bf7",
+      "ConcordiaCourseId": "011285"
+    },
+    {
+      "Id": "73b388af-3aba-42c2-af79-708efb20fce0",
+      "ConcordiaCourseId": "011302"
+    },
+    {
+      "Id": "b33a101d-2752-43ec-8cb8-8dae94dc56fe",
+      "ConcordiaCourseId": "011305"
+    },
+    {
+      "Id": "3b3bd5b2-d56b-4c7f-a622-2c6207d9bb24",
+      "ConcordiaCourseId": "011306"
+    },
+    {
+      "Id": "b2b1ac31-fd27-48d5-8c39-10520c8f306a",
+      "ConcordiaCourseId": "011307"
+    },
+    {
+      "Id": "814ceddc-2659-4afd-b831-cb37520182c1",
+      "ConcordiaCourseId": "011309"
+    },
+    {
+      "Id": "78613939-54a6-4798-9aa4-cad9beb19ac1",
+      "ConcordiaCourseId": "011311"
+    },
+    {
+      "Id": "a9034085-341a-4ca9-bb2f-c64ac5d1516b",
+      "ConcordiaCourseId": "011312"
+    },
+    {
+      "Id": "5c126483-6139-4aca-bb02-f3ce90588ef8",
+      "ConcordiaCourseId": "011313"
+    },
+    {
+      "Id": "b78c4144-dcc1-4050-bdf4-757004ed713e",
+      "ConcordiaCourseId": "011314"
+    },
+    {
+      "Id": "640a8c6f-45bb-4c90-b857-d78e8a63618a",
+      "ConcordiaCourseId": "011315"
+    },
+    {
+      "Id": "fec8a133-612b-4dd5-9fb0-1c0a618e81b8",
+      "ConcordiaCourseId": "011316"
+    },
+    {
+      "Id": "3abf28ad-5198-4cd2-b743-a6ec9aeadfcd",
+      "ConcordiaCourseId": "011320"
+    },
+    {
+      "Id": "8b227978-2a81-42e4-8509-96a381d7e369",
+      "ConcordiaCourseId": "011321"
+    },
+    {
+      "Id": "04049ece-6d59-47f8-89f8-6b49f1f7c305",
+      "ConcordiaCourseId": "011322"
+    },
+    {
+      "Id": "66f5dcf8-085c-430f-b6aa-db27185c1c47",
+      "ConcordiaCourseId": "011324"
+    },
+    {
+      "Id": "a427ccd4-95f4-4ce3-908a-4e936015fcfa",
+      "ConcordiaCourseId": "011325"
+    },
+    {
+      "Id": "e7721ef3-fc21-4a30-a099-5d5adfbbb2cd",
+      "ConcordiaCourseId": "011331"
+    },
+    {
+      "Id": "6a71e987-32a3-44a1-9060-c6ccc65119ee",
+      "ConcordiaCourseId": "011332"
+    },
+    {
+      "Id": "ff925af0-7573-4ab5-aa1d-658fd7bbfde7",
+      "ConcordiaCourseId": "011333"
+    },
+    {
+      "Id": "d6ce2676-84ec-41e0-bf12-d78e62071a06",
+      "ConcordiaCourseId": "011335"
+    },
+    {
+      "Id": "c1729736-9d95-420f-99ab-9c7a792bb96b",
+      "ConcordiaCourseId": "011336"
+    },
+    {
+      "Id": "95ffa339-167c-481d-8394-e09e80713cc7",
+      "ConcordiaCourseId": "011337"
+    },
+    {
+      "Id": "3af1db09-5245-4f64-baaf-cf43d0e29cc3",
+      "ConcordiaCourseId": "011338"
+    },
+    {
+      "Id": "39e685ef-824e-46ac-98ec-8352af4df835",
+      "ConcordiaCourseId": "011339"
+    },
+    {
+      "Id": "cf057bfd-203f-4e2b-b17e-c543296ea42a",
+      "ConcordiaCourseId": "011343"
+    },
+    {
+      "Id": "08fefc81-1aaf-4231-b84a-a6438df77745",
+      "ConcordiaCourseId": "011345"
+    },
+    {
+      "Id": "aee70e26-b707-4e5b-bec5-b147d1bcca22",
+      "ConcordiaCourseId": "011347"
+    },
+    {
+      "Id": "33cba0e1-6ab2-471c-ae99-774165230702",
+      "ConcordiaCourseId": "011348"
+    },
+    {
+      "Id": "0a28c24d-9f73-4bc9-84e8-9267eb0d89b9",
+      "ConcordiaCourseId": "040738"
+    },
+    {
+      "Id": "ac7d241c-1e50-42a4-b304-0d608874909b",
+      "ConcordiaCourseId": "046062"
+    },
+    {
+      "Id": "61f45ea3-7c62-488c-ab46-09096519d4ed",
+      "ConcordiaCourseId": "046063"
+    },
+    {
+      "Id": "3aaeb095-dd9f-4bd3-8ea3-0cf06f3aeb62",
+      "ConcordiaCourseId": "046688"
+    },
+    {
+      "Id": "f84df47f-e002-4b5c-87cc-89e05e35c0c9",
+      "ConcordiaCourseId": "046689"
+    },
+    {
+      "Id": "cc85c61f-9e3f-4a43-948b-eaad7807a414",
+      "ConcordiaCourseId": "046690"
+    },
+    {
+      "Id": "fa3803be-1558-4cc0-b3a5-8bdd786faa18",
+      "ConcordiaCourseId": "048852"
+    },
+    {
+      "Id": "84b55444-a1eb-47e1-b8f3-2ecbcc14c8b5",
+      "ConcordiaCourseId": "049415"
+    },
+    {
+      "Id": "104093f4-f93e-402e-b027-3844adc3880c",
+      "ConcordiaCourseId": "049416"
+    },
+    {
+      "Id": "61898a1f-6954-4514-b853-d2eb13ef2b93",
+      "ConcordiaCourseId": "049417"
+    },
+    {
+      "Id": "7e5a3643-28f9-4e3f-8f74-b3d4e261a715",
+      "ConcordiaCourseId": "049418"
+    },
+    {
+      "Id": "634a3e07-f8cd-4811-9be6-516d533425d5",
+      "ConcordiaCourseId": "049419"
+    },
+    {
+      "Id": "899fe455-5203-42f5-bd8a-aadaf5da5d9b",
+      "ConcordiaCourseId": "049420"
+    },
+    {
+      "Id": "48085219-831a-4320-80ee-a48fc2f3ff12",
+      "ConcordiaCourseId": "049567"
+    },
+    {
+      "Id": "a5148794-de86-44a4-934c-ce07da0c8ec3",
+      "ConcordiaCourseId": "049568"
+    },
+    {
+      "Id": "0b96d9b1-c570-4e1a-872a-14603f8a42d2",
+      "ConcordiaCourseId": "049569"
+    },
+    {
+      "Id": "e9bf8055-e121-4f44-b8df-a1f93303c226",
+      "ConcordiaCourseId": "049570"
+    },
+    {
+      "Id": "06c8728a-2ce6-4264-8342-fb6a5e1af128",
+      "ConcordiaCourseId": "049571"
+    },
+    {
+      "Id": "eaba965d-945b-4d25-a78e-0a83859b31ec",
+      "ConcordiaCourseId": "049572"
+    },
+    {
+      "Id": "6e06523c-b79b-4d39-adb5-b556f01ceb0f",
+      "ConcordiaCourseId": "049573"
+    },
+    {
+      "Id": "8f51a7b4-e33e-442e-b502-0f71ea13841a",
+      "ConcordiaCourseId": "050005"
+    },
+    {
+      "Id": "53661ace-6ff7-4f7a-af49-3bb4a7fba4bd",
+      "ConcordiaCourseId": "050006"
+    },
+    {
+      "Id": "6ea31257-80eb-4f8b-9204-27f104cdbf7c",
+      "ConcordiaCourseId": "050007"
+    },
+    {
+      "Id": "c06d28dc-d452-475e-b8c9-25bd7cee1414",
+      "ConcordiaCourseId": "050279"
+    },
+    {
+      "Id": "0253da07-38c9-468f-b94f-850ae9f39b4d",
+      "ConcordiaCourseId": "050294"
+    },
+    {
+      "Id": "9d28a49f-ca6f-4cf5-a623-b874fb03064f",
+      "ConcordiaCourseId": "050295"
+    },
+    {
+      "Id": "1d926be0-2696-45bb-b035-2a4347c181d7",
+      "ConcordiaCourseId": "050296"
+    },
+    {
+      "Id": "870b41d5-faac-4e4e-a42d-81c3704c8053",
+      "ConcordiaCourseId": "050297"
+    },
+    {
+      "Id": "2c7cb9b3-243d-454b-b561-ab3f31b85ad5",
+      "ConcordiaCourseId": "050298"
+    },
+    {
+      "Id": "621db6dd-d970-47be-8071-a91d2cdbe119",
+      "ConcordiaCourseId": "050299"
+    },
+    {
+      "Id": "506dbef3-6af3-49db-ac6a-6771fdb36f8c",
+      "ConcordiaCourseId": "050300"
+    },
+    {
+      "Id": "28fa1501-31ce-4473-a9ac-c2cdbb564125",
+      "ConcordiaCourseId": "050301"
+    },
+    {
+      "Id": "66287cca-cf18-45ce-ab89-033991ea3c24",
+      "ConcordiaCourseId": "046691"
+    },
+    {
+      "Id": "81a993b7-ae02-4c7e-a195-00423abc6ba5",
+      "ConcordiaCourseId": "011349"
+    },
+    {
+      "Id": "9e794b22-5c33-472e-ba54-0b445c55b9d7",
+      "ConcordiaCourseId": "011352"
+    },
+    {
+      "Id": "56d6109e-646c-447c-acbe-a87d83a6b0b1",
+      "ConcordiaCourseId": "011353"
+    },
+    {
+      "Id": "f36b8815-7b17-4eed-91e4-b56739d3c1ca",
+      "ConcordiaCourseId": "011357"
+    },
+    {
+      "Id": "0ec142f1-b64b-42e5-856f-0720b36f2d87",
+      "ConcordiaCourseId": "011362"
+    },
+    {
+      "Id": "a343c4c4-4c47-464b-8255-81eadd648f08",
+      "ConcordiaCourseId": "011364"
+    },
+    {
+      "Id": "4d4fcd38-41f3-498f-af3a-1abf9dcc5785",
+      "ConcordiaCourseId": "011366"
+    },
+    {
+      "Id": "c69c3d31-964b-466b-8ee5-e26f15f170e4",
+      "ConcordiaCourseId": "011369"
+    },
+    {
+      "Id": "4b6122b9-6c86-4b32-b096-eca28d3f4b8b",
+      "ConcordiaCourseId": "011370"
+    },
+    {
+      "Id": "46033d2f-1f49-41eb-9401-8accdefa86ce",
+      "ConcordiaCourseId": "011371"
+    },
+    {
+      "Id": "491895ab-33d1-46f9-8662-9e842f356e43",
+      "ConcordiaCourseId": "011372"
+    },
+    {
+      "Id": "7249f642-01ed-4184-8bf2-a7e41468071f",
+      "ConcordiaCourseId": "011384"
+    },
+    {
+      "Id": "705f56b4-19a4-46a8-b899-cc4932dfadac",
+      "ConcordiaCourseId": "011388"
+    },
+    {
+      "Id": "e0450a02-cace-4a4c-9c1d-f375845cf84d",
+      "ConcordiaCourseId": "011391"
+    },
+    {
+      "Id": "f9d01887-a9c4-489d-b7b2-4d3754b59186",
+      "ConcordiaCourseId": "011392"
+    },
+    {
+      "Id": "61db28da-32eb-4707-8961-06712cff3ea0",
+      "ConcordiaCourseId": "040743"
+    },
+    {
+      "Id": "57a58f2c-1c91-4f6f-b58a-a7b55a40e186",
+      "ConcordiaCourseId": "040744"
+    },
+    {
+      "Id": "5149ae2a-e5b8-47a0-9319-7be8225d51f3",
+      "ConcordiaCourseId": "046692"
+    },
+    {
+      "Id": "353ea7ae-d32d-4de6-a1db-8ac6fb363045",
+      "ConcordiaCourseId": "046693"
+    },
+    {
+      "Id": "e31ac542-0455-4cab-b771-f3d1a1261e1d",
+      "ConcordiaCourseId": "048318"
+    },
+    {
+      "Id": "b5ce022a-b7f7-415a-bd2d-e96b788e6587",
+      "ConcordiaCourseId": "048319"
+    },
+    {
+      "Id": "0182d07a-80fb-4a1b-940e-47413056d14a",
+      "ConcordiaCourseId": "048320"
+    },
+    {
+      "Id": "952275e5-8d05-4a3b-8673-7126b0c2a4bc",
+      "ConcordiaCourseId": "048321"
+    },
+    {
+      "Id": "2cef1d15-ffaa-471d-99d6-030ef5081f3d",
+      "ConcordiaCourseId": "048322"
+    },
+    {
+      "Id": "0cbae377-87a9-4245-ab45-bdfce1659c65",
+      "ConcordiaCourseId": "048323"
+    },
+    {
+      "Id": "20b81424-7ff2-47ff-904c-2385ae8943d6",
+      "ConcordiaCourseId": "048324"
+    },
+    {
+      "Id": "206b6e4e-3332-47dd-a5da-f75447125fb0",
+      "ConcordiaCourseId": "048325"
+    },
+    {
+      "Id": "c052b501-38f2-41b2-95c5-8774d15b2e4e",
+      "ConcordiaCourseId": "048326"
+    },
+    {
+      "Id": "db8d2f28-b8ca-4f81-8a93-28b42ba98441",
+      "ConcordiaCourseId": "048327"
+    },
+    {
+      "Id": "f8e004b8-cdf8-4963-8c82-20f6d411ab78",
+      "ConcordiaCourseId": "048328"
+    },
+    {
+      "Id": "302af15a-72c7-482b-b9da-75c20f5abd8c",
+      "ConcordiaCourseId": "048330"
+    },
+    {
+      "Id": "29bfbba8-8b47-4c33-ab0c-8f2ab75b089b",
+      "ConcordiaCourseId": "048331"
+    },
+    {
+      "Id": "57876baf-8d51-4b83-8fb0-011d1dfdd0a5",
+      "ConcordiaCourseId": "048332"
+    },
+    {
+      "Id": "64848d6f-4f11-44f4-9c26-8c4c332fd78f",
+      "ConcordiaCourseId": "011409"
+    },
+    {
+      "Id": "b6294b9a-d01a-4c9d-ad17-9a4b8b243820",
+      "ConcordiaCourseId": "011412"
+    },
+    {
+      "Id": "c1b02ccd-dc28-46b1-a850-e4e06d65fd7f",
+      "ConcordiaCourseId": "011414"
+    },
+    {
+      "Id": "03385550-7407-4c8d-a2b9-3eecf1eeef44",
+      "ConcordiaCourseId": "011415"
+    },
+    {
+      "Id": "07ba57be-bfa8-4f28-b8b7-ce6d5c98d8ed",
+      "ConcordiaCourseId": "011417"
+    },
+    {
+      "Id": "57321d57-4c48-4df0-850d-fab9869d26e5",
+      "ConcordiaCourseId": "011418"
+    },
+    {
+      "Id": "4a0de234-9467-4e46-aa29-124482f70143",
+      "ConcordiaCourseId": "011419"
+    },
+    {
+      "Id": "9d61f79b-40f5-4963-8228-db2787c46ddd",
+      "ConcordiaCourseId": "011420"
+    },
+    {
+      "Id": "228aa72e-6cf1-4145-a798-633f5ed40cf2",
+      "ConcordiaCourseId": "011425"
+    },
+    {
+      "Id": "143c315d-2a56-4d57-93bf-84df2088778b",
+      "ConcordiaCourseId": "011426"
+    },
+    {
+      "Id": "a837c29a-b9c2-4871-aae1-2ecbef75f27e",
+      "ConcordiaCourseId": "011429"
+    },
+    {
+      "Id": "b3fd0d49-4d47-4b4a-a0f0-7f5fa017de23",
+      "ConcordiaCourseId": "011430"
+    },
+    {
+      "Id": "93b8e27c-fce2-464a-bd74-8015636fcb07",
+      "ConcordiaCourseId": "011431"
+    },
+    {
+      "Id": "90476aca-ef51-49fb-9af8-c5215a673008",
+      "ConcordiaCourseId": "011432"
+    },
+    {
+      "Id": "5793af99-6f6f-408e-9077-ab065203f405",
+      "ConcordiaCourseId": "011433"
+    },
+    {
+      "Id": "bfc46060-51bb-4404-a3f0-b8f8d9737b0c",
+      "ConcordiaCourseId": "011434"
+    },
+    {
+      "Id": "2ce9f0f1-58b2-4cb6-a6ec-4f6432ca7398",
+      "ConcordiaCourseId": "011436"
+    },
+    {
+      "Id": "3d5ba265-23c6-4bb5-8f58-ecfccea920c5",
+      "ConcordiaCourseId": "011437"
+    },
+    {
+      "Id": "d4c3927e-d36b-47a7-8631-f6211837d9f2",
+      "ConcordiaCourseId": "011438"
+    },
+    {
+      "Id": "e9f20402-16c7-4ed7-aad9-841214efc31c",
+      "ConcordiaCourseId": "011440"
+    },
+    {
+      "Id": "26613ab3-6bcd-41f7-8f19-2afce6ac2db3",
+      "ConcordiaCourseId": "011441"
+    },
+    {
+      "Id": "8f78e6bc-dc55-4de7-94c7-c69a5a6d9c46",
+      "ConcordiaCourseId": "011442"
+    },
+    {
+      "Id": "07a24b3e-bdc2-4070-8504-949cd20d8fff",
+      "ConcordiaCourseId": "011460"
+    },
+    {
+      "Id": "c783c795-95a4-4184-aa02-5dc7acaebec1",
+      "ConcordiaCourseId": "011462"
+    },
+    {
+      "Id": "61e2f1c8-55d8-4a45-be85-ef19210a4f81",
+      "ConcordiaCourseId": "011464"
+    },
+    {
+      "Id": "0b6312fa-c4d7-4199-8439-8e88081263e8",
+      "ConcordiaCourseId": "011465"
+    },
+    {
+      "Id": "90e6dbac-9dbb-4b4c-9b32-602b40f4cf35",
+      "ConcordiaCourseId": "040747"
+    },
+    {
+      "Id": "0564e220-a790-4ae6-b5e1-04a99229aff6",
+      "ConcordiaCourseId": "040748"
+    },
+    {
+      "Id": "062a91b6-5a02-409d-9162-6fe9c4914548",
+      "ConcordiaCourseId": "046694"
+    },
+    {
+      "Id": "a9de561f-f188-4f8a-945d-60c3fd413ffd",
+      "ConcordiaCourseId": "046695"
+    },
+    {
+      "Id": "097545e3-871f-4235-a898-6e9ddd18b1e9",
+      "ConcordiaCourseId": "048310"
+    },
+    {
+      "Id": "c52b734c-bc30-467c-968e-6ce6ad2cfefb",
+      "ConcordiaCourseId": "048311"
+    },
+    {
+      "Id": "994f9595-86ad-4487-baaf-0f8fec7cbbb3",
+      "ConcordiaCourseId": "049336"
+    },
+    {
+      "Id": "2c981c07-ecc7-4703-ab35-f228ba6a3fc9",
+      "ConcordiaCourseId": "049337"
+    },
+    {
+      "Id": "db9bfedb-eb02-4f5c-ae01-1551c57cf52e",
+      "ConcordiaCourseId": "049338"
+    },
+    {
+      "Id": "246ba9f1-2bd9-4c0a-83ea-f5770769436b",
+      "ConcordiaCourseId": "049339"
+    },
+    {
+      "Id": "5ebd2994-47de-47e8-b60b-fed8c6630ddf",
+      "ConcordiaCourseId": "049340"
+    },
+    {
+      "Id": "665c514b-77c9-4819-9d06-fc251ebc990d",
+      "ConcordiaCourseId": "049341"
+    },
+    {
+      "Id": "2485b8cf-fa9a-4926-9389-58a7ce88b4a7",
+      "ConcordiaCourseId": "049342"
+    },
+    {
+      "Id": "c2130342-8732-40c8-a83a-b1173ecd2a99",
+      "ConcordiaCourseId": "049343"
+    },
+    {
+      "Id": "a0c35193-bb5e-4486-ad3d-e8966bfcd6be",
+      "ConcordiaCourseId": "049344"
+    },
+    {
+      "Id": "d8f62475-48f8-4c5d-bb09-967f1cb48b56",
+      "ConcordiaCourseId": "049345"
+    },
+    {
+      "Id": "145e51f9-3b00-492a-b23d-ef085df9868b",
+      "ConcordiaCourseId": "011488"
+    },
+    {
+      "Id": "b2d0063e-f46c-40a3-a81e-fa38acd912f9",
+      "ConcordiaCourseId": "011492"
+    },
+    {
+      "Id": "9712f3a2-5fa7-4a7c-89ed-0944697358ac",
+      "ConcordiaCourseId": "011493"
+    },
+    {
+      "Id": "b8ef59a1-a960-4cad-b1cd-39ca59a75b97",
+      "ConcordiaCourseId": "011494"
+    },
+    {
+      "Id": "57b4453b-be2c-4dcd-8a98-a508c99152df",
+      "ConcordiaCourseId": "011495"
+    },
+    {
+      "Id": "d9d43de6-36cf-4cdb-a2bb-684698280c4c",
+      "ConcordiaCourseId": "011496"
+    },
+    {
+      "Id": "794ad4a5-cf17-4c72-83f6-6c0a7136240a",
+      "ConcordiaCourseId": "011497"
+    },
+    {
+      "Id": "7363fc45-68ba-4cff-9424-aac5d372c6ac",
+      "ConcordiaCourseId": "011498"
+    },
+    {
+      "Id": "552a684d-dcfd-4578-b823-1102a7e54b5f",
+      "ConcordiaCourseId": "011500"
+    },
+    {
+      "Id": "7a81a46d-add0-48c3-8eba-73f7ce1275c4",
+      "ConcordiaCourseId": "011504"
+    },
+    {
+      "Id": "14d203e4-a04e-4aca-bd58-c469fc22f2ea",
+      "ConcordiaCourseId": "011505"
+    },
+    {
+      "Id": "d82ac726-797a-40cd-a2eb-afc00bae24ff",
+      "ConcordiaCourseId": "011506"
+    },
+    {
+      "Id": "525b5f51-dc8f-4642-a9fc-8f4113878ad8",
+      "ConcordiaCourseId": "011509"
+    },
+    {
+      "Id": "380a2e27-de5b-4d57-9f80-6e235c4cec6d",
+      "ConcordiaCourseId": "011511"
+    },
+    {
+      "Id": "98d4401d-8c93-4583-bb04-b026f41db40c",
+      "ConcordiaCourseId": "011513"
+    },
+    {
+      "Id": "78eb1cce-9f3a-4a84-b1a9-5538ff4a5de9",
+      "ConcordiaCourseId": "011514"
+    },
+    {
+      "Id": "84348f26-19d4-4678-ab7c-cd934256e1ed",
+      "ConcordiaCourseId": "011515"
+    },
+    {
+      "Id": "4b4cb99c-d45c-447d-b231-2434545a5527",
+      "ConcordiaCourseId": "011518"
+    },
+    {
+      "Id": "dc237f98-41fe-4249-aa3a-9f573c602d6c",
+      "ConcordiaCourseId": "011538"
+    },
+    {
+      "Id": "203c83c3-cc6b-40b1-81be-0b3d1ad16255",
+      "ConcordiaCourseId": "011547"
+    },
+    {
+      "Id": "296bdab1-dd49-441f-9dd0-17c467dd2185",
+      "ConcordiaCourseId": "011555"
+    },
+    {
+      "Id": "ae785c07-e9e4-44bf-beec-84401ade6bc9",
+      "ConcordiaCourseId": "011556"
+    },
+    {
+      "Id": "69d38814-0cbe-42e6-b0c7-452887fbb856",
+      "ConcordiaCourseId": "011557"
+    },
+    {
+      "Id": "9fe82c7d-f759-4253-92aa-864beca4604d",
+      "ConcordiaCourseId": "011580"
+    },
+    {
+      "Id": "a8d95906-4c50-446d-81b2-286cb0c5ec98",
+      "ConcordiaCourseId": "011581"
+    },
+    {
+      "Id": "19e84b6f-0c91-4dbf-a3fc-09c35480285f",
+      "ConcordiaCourseId": "011587"
+    },
+    {
+      "Id": "09792d78-37c7-4150-866d-2eea4d260a1f",
+      "ConcordiaCourseId": "011592"
+    },
+    {
+      "Id": "455d71a7-a971-4e0a-be59-fe8b89133ccc",
+      "ConcordiaCourseId": "011600"
+    },
+    {
+      "Id": "84f71871-02dd-41f9-b8c5-e34f36662706",
+      "ConcordiaCourseId": "011601"
+    },
+    {
+      "Id": "b39df3c3-dad6-47ac-8269-1e2d46dd0a9f",
+      "ConcordiaCourseId": "011603"
+    },
+    {
+      "Id": "59240c53-c6a5-40ec-93bc-6bd12a364956",
+      "ConcordiaCourseId": "011604"
+    },
+    {
+      "Id": "3f778afe-91de-4f9e-a56b-1ba1ee5004cc",
+      "ConcordiaCourseId": "011606"
+    },
+    {
+      "Id": "1af24278-cd7e-4352-b93a-07c2864cabfe",
+      "ConcordiaCourseId": "011609"
+    },
+    {
+      "Id": "19ebf04f-298d-4b89-8aec-5dd9531df3f9",
+      "ConcordiaCourseId": "011610"
+    },
+    {
+      "Id": "da1e06eb-0d57-48fa-bd50-39cee5bf9c1f",
+      "ConcordiaCourseId": "011615"
+    },
+    {
+      "Id": "3c1e11ed-f75d-4405-b344-9e6c67e66027",
+      "ConcordiaCourseId": "011633"
+    },
+    {
+      "Id": "d4637b7d-df30-4995-928b-f11797b5b318",
+      "ConcordiaCourseId": "011720"
+    },
+    {
+      "Id": "30828f0a-1db3-404c-9259-3f76121fbfd1",
+      "ConcordiaCourseId": "011729"
+    },
+    {
+      "Id": "cbc84a44-dce0-422e-80fc-b41eff154f16",
+      "ConcordiaCourseId": "011735"
+    },
+    {
+      "Id": "96c5f1d3-1f11-4816-9476-72070d3cb973",
+      "ConcordiaCourseId": "011736"
+    },
+    {
+      "Id": "36ee9ce2-9da2-4f35-ba73-169becdb7dee",
+      "ConcordiaCourseId": "011737"
+    },
+    {
+      "Id": "488ae5a8-6e8a-4b92-976c-56fb279bfd56",
+      "ConcordiaCourseId": "011738"
+    },
+    {
+      "Id": "b88560fa-5c2c-4b49-ae28-2ce3dbafbb56",
+      "ConcordiaCourseId": "011743"
+    },
+    {
+      "Id": "d9d7f824-c051-4378-b923-9753d362d813",
+      "ConcordiaCourseId": "011756"
+    },
+    {
+      "Id": "e817cc68-36ad-4020-a696-4bbe533e879c",
+      "ConcordiaCourseId": "011758"
+    },
+    {
+      "Id": "aa103312-96af-4088-987c-e4ccf7af9dfa",
+      "ConcordiaCourseId": "040764"
+    },
+    {
+      "Id": "be320f72-15dc-44bf-adf8-753687bf0d86",
+      "ConcordiaCourseId": "040765"
+    },
+    {
+      "Id": "53d8d91a-f8d1-4389-91f0-0baae8dca7a1",
+      "ConcordiaCourseId": "040772"
+    },
+    {
+      "Id": "93f10fb5-ee51-447e-a106-07877ace0427",
+      "ConcordiaCourseId": "040773"
+    },
+    {
+      "Id": "08eda767-114b-4265-867c-d3eb53a9f076",
+      "ConcordiaCourseId": "040821"
+    },
+    {
+      "Id": "4837a59f-1aba-48af-b557-45d29dc6c99b",
+      "ConcordiaCourseId": "040822"
+    },
+    {
+      "Id": "6c96284c-4ad8-4272-98b4-87e03a08d84e",
+      "ConcordiaCourseId": "040823"
+    },
+    {
+      "Id": "7a6af50d-178e-461a-bce4-488a9a35f3b4",
+      "ConcordiaCourseId": "040824"
+    },
+    {
+      "Id": "80486230-7769-4841-9dce-3cc9b32505ee",
+      "ConcordiaCourseId": "045385"
+    },
+    {
+      "Id": "d9e09d99-eca8-465c-8a09-512e0cb7a3f8",
+      "ConcordiaCourseId": "045389"
+    },
+    {
+      "Id": "c94434a8-2ece-4f45-b239-2b789275c3e5",
+      "ConcordiaCourseId": "046696"
+    },
+    {
+      "Id": "d709d6ba-8015-4420-9b32-48011974d634",
+      "ConcordiaCourseId": "046697"
+    },
+    {
+      "Id": "e56e4301-b913-4a2d-bf5e-b162f2dcd8d7",
+      "ConcordiaCourseId": "046698"
+    },
+    {
+      "Id": "2019d2f5-9c8f-44ef-806b-b08e3bc93922",
+      "ConcordiaCourseId": "046699"
+    },
+    {
+      "Id": "35303c72-2ea7-4817-a74b-54da191c7085",
+      "ConcordiaCourseId": "046700"
+    },
+    {
+      "Id": "5934accd-1931-432e-8bfe-046e0576907c",
+      "ConcordiaCourseId": "046701"
+    },
+    {
+      "Id": "40a73f98-2964-463d-a5a6-d656ad78814e",
+      "ConcordiaCourseId": "046702"
+    },
+    {
+      "Id": "9b5291f0-0175-4321-8951-919a24920c49",
+      "ConcordiaCourseId": "046703"
+    },
+    {
+      "Id": "f67e01b2-4c51-4a6d-8c4d-1c9869222bcd",
+      "ConcordiaCourseId": "046704"
+    },
+    {
+      "Id": "565b24f4-f68f-4dd8-94ee-9869d57e1e52",
+      "ConcordiaCourseId": "046705"
+    },
+    {
+      "Id": "313afb3f-9405-43e4-a816-9fb18003bc7e",
+      "ConcordiaCourseId": "046706"
+    },
+    {
+      "Id": "fc0dbb29-f507-42c7-bf89-0177a28a9023",
+      "ConcordiaCourseId": "046707"
+    },
+    {
+      "Id": "797cd422-4006-4565-a6f8-82700eb3baa5",
+      "ConcordiaCourseId": "046708"
+    },
+    {
+      "Id": "5d205f0e-67ab-4ca4-9352-e39f1387fb2f",
+      "ConcordiaCourseId": "046709"
+    },
+    {
+      "Id": "781a3034-104b-49fb-a735-1dbc7bb18a4e",
+      "ConcordiaCourseId": "046710"
+    },
+    {
+      "Id": "c8bd2d06-0d55-49ad-8b8b-71cc7f1793e2",
+      "ConcordiaCourseId": "046711"
+    },
+    {
+      "Id": "0ccf4c4e-6725-482a-9348-9a75f2259185",
+      "ConcordiaCourseId": "046712"
+    },
+    {
+      "Id": "b26dc4a4-a436-46d1-987a-600292248717",
+      "ConcordiaCourseId": "046713"
+    },
+    {
+      "Id": "716939b7-b28f-4302-878d-99037b6d4428",
+      "ConcordiaCourseId": "046714"
+    },
+    {
+      "Id": "460dbe2d-ffc8-454f-8197-e3d3894898fc",
+      "ConcordiaCourseId": "046715"
+    },
+    {
+      "Id": "18dd0e9a-a14e-4308-9135-f7ccdf948991",
+      "ConcordiaCourseId": "046716"
+    },
+    {
+      "Id": "2a1b10eb-6a06-4ee6-a79c-5373e25bae0e",
+      "ConcordiaCourseId": "046717"
+    },
+    {
+      "Id": "79bf2154-75bf-4619-9780-8a330007bf7b",
+      "ConcordiaCourseId": "046718"
+    },
+    {
+      "Id": "73a891a7-ec12-4573-aaae-e2961394859c",
+      "ConcordiaCourseId": "046719"
+    },
+    {
+      "Id": "56a79827-5d6b-406a-9755-e5fa2251a3ba",
+      "ConcordiaCourseId": "046720"
+    },
+    {
+      "Id": "fed148b7-18e5-47f1-94d4-cbce0b36ad8a",
+      "ConcordiaCourseId": "046721"
+    },
+    {
+      "Id": "9fb6421d-4160-42a4-9b60-c981a139029f",
+      "ConcordiaCourseId": "046722"
+    },
+    {
+      "Id": "78a09849-3c06-46a1-a6e2-04941210ee10",
+      "ConcordiaCourseId": "046723"
+    },
+    {
+      "Id": "2c51de1d-751c-4157-9bf1-4202b5b8c569",
+      "ConcordiaCourseId": "046724"
+    },
+    {
+      "Id": "7d14268f-56af-48a0-b4a7-b4481d37a087",
+      "ConcordiaCourseId": "046725"
+    },
+    {
+      "Id": "5924513a-af51-49ab-96a2-80cb1415b2b4",
+      "ConcordiaCourseId": "046726"
+    },
+    {
+      "Id": "5a00514b-51b7-4312-b889-e4b011a93484",
+      "ConcordiaCourseId": "046727"
+    },
+    {
+      "Id": "cdbd3647-dfad-4c72-b47b-1d338ab2053f",
+      "ConcordiaCourseId": "046728"
+    },
+    {
+      "Id": "c5f22eac-c2af-4b14-9ec0-669afe807ffc",
+      "ConcordiaCourseId": "046729"
+    },
+    {
+      "Id": "f1e868a9-9762-4ee1-8acd-bd6a4d08c42d",
+      "ConcordiaCourseId": "046730"
+    },
+    {
+      "Id": "664395eb-2268-4a6a-a2f3-0e75fb5f2b1f",
+      "ConcordiaCourseId": "046731"
+    },
+    {
+      "Id": "5d8b0eb3-839a-4044-afad-34b498367fb0",
+      "ConcordiaCourseId": "046732"
+    },
+    {
+      "Id": "759070c8-9d9f-4b0f-8082-17173aae31f6",
+      "ConcordiaCourseId": "047453"
+    },
+    {
+      "Id": "11d0ee7f-2dca-4bbb-943e-2169a185cd5c",
+      "ConcordiaCourseId": "047454"
+    },
+    {
+      "Id": "7100549d-81a7-48f3-a637-89c854ac0af5",
+      "ConcordiaCourseId": "047455"
+    },
+    {
+      "Id": "45ab05c8-f73e-4691-8c42-293082b452a3",
+      "ConcordiaCourseId": "047456"
+    },
+    {
+      "Id": "ce29d9f0-2fe7-4aab-9976-f75e4adcae5e",
+      "ConcordiaCourseId": "047950"
+    },
+    {
+      "Id": "8cb26eae-e7fe-4f78-8bd7-2f95e9ad690a",
+      "ConcordiaCourseId": "048309"
+    },
+    {
+      "Id": "6961685d-0c29-4cce-9df6-65df7a2ccb60",
+      "ConcordiaCourseId": "048312"
+    },
+    {
+      "Id": "533fbfdb-e6ef-4e5c-8ba5-bf236cf4b4db",
+      "ConcordiaCourseId": "048313"
+    },
+    {
+      "Id": "bfc0f075-a2a1-4a2e-9b11-7bdaeb72fc87",
+      "ConcordiaCourseId": "048314"
+    },
+    {
+      "Id": "36765244-11fe-4dac-9d35-584bc5f8adc4",
+      "ConcordiaCourseId": "048315"
+    },
+    {
+      "Id": "c5f82c41-8954-4948-b847-99fcb304b8b5",
+      "ConcordiaCourseId": "048445"
+    },
+    {
+      "Id": "ed4c27da-2efc-4843-991e-02636e5105bc",
+      "ConcordiaCourseId": "049662"
+    },
+    {
+      "Id": "97dc0f2b-95c4-4075-b47f-266175a6d640",
+      "ConcordiaCourseId": "049663"
+    },
+    {
+      "Id": "050333f3-829f-4bdb-8d95-27a8bc54535c",
+      "ConcordiaCourseId": "049664"
+    },
+    {
+      "Id": "00f5e48f-03ea-446e-8fc7-9cb7bc66408b",
+      "ConcordiaCourseId": "049665"
+    },
+    {
+      "Id": "5e811476-6d2d-48a7-b38d-cd50402f83e8",
+      "ConcordiaCourseId": "049666"
+    },
+    {
+      "Id": "aba9906d-3954-4cc6-bd21-165870d8f3ea",
+      "ConcordiaCourseId": "049667"
+    },
+    {
+      "Id": "a6e008ff-8046-49d7-ad3e-5269983d24ae",
+      "ConcordiaCourseId": "049668"
+    },
+    {
+      "Id": "5d3a2399-2549-4409-904c-73b0b8671d73",
+      "ConcordiaCourseId": "049669"
+    },
+    {
+      "Id": "0a4b0f01-b572-467d-aacb-c04d79a851bd",
+      "ConcordiaCourseId": "049670"
+    },
+    {
+      "Id": "c7e159d3-f318-4f0f-8b74-d2c1daa3af28",
+      "ConcordiaCourseId": "050202"
+    },
+    {
+      "Id": "800a1014-ac37-490e-a4ab-c652a0e08de2",
+      "ConcordiaCourseId": "050203"
+    },
+    {
+      "Id": "d4e517f3-0745-4944-a0d7-febeeda68506",
+      "ConcordiaCourseId": "011795"
+    },
+    {
+      "Id": "a6864e8d-06a5-4cfb-8f5f-d3b81154827c",
+      "ConcordiaCourseId": "011796"
+    },
+    {
+      "Id": "40d81f7c-0289-41de-ae5a-b235e636bd5b",
+      "ConcordiaCourseId": "011797"
+    },
+    {
+      "Id": "a64ee171-84c9-4725-8374-26764e05abb2",
+      "ConcordiaCourseId": "011798"
+    },
+    {
+      "Id": "ac5d49ec-2878-4817-a131-940943d96416",
+      "ConcordiaCourseId": "011799"
+    },
+    {
+      "Id": "b4762199-51b6-4b92-989f-f293aa408ad8",
+      "ConcordiaCourseId": "011800"
+    },
+    {
+      "Id": "42c845c9-ab20-4b2a-86a7-e700e1a72ea7",
+      "ConcordiaCourseId": "011801"
+    },
+    {
+      "Id": "73599df9-be32-4100-b1d3-15d41ec523a3",
+      "ConcordiaCourseId": "011802"
+    },
+    {
+      "Id": "d43d0971-915f-4ede-ad1e-7c106b80ad54",
+      "ConcordiaCourseId": "011804"
+    },
+    {
+      "Id": "b16afa6a-ac68-4e0a-bde8-d642f157df69",
+      "ConcordiaCourseId": "011805"
+    },
+    {
+      "Id": "8f1a5f3d-425e-4482-ba2c-e151d9cd4641",
+      "ConcordiaCourseId": "011806"
+    },
+    {
+      "Id": "bd71d536-175c-4253-a82e-68acb9330afb",
+      "ConcordiaCourseId": "011807"
+    },
+    {
+      "Id": "c656b54a-86df-421c-a3e1-a890b3ee56d1",
+      "ConcordiaCourseId": "011808"
+    },
+    {
+      "Id": "ba158d01-8ac7-434d-9e5b-19d63fff8cb3",
+      "ConcordiaCourseId": "011809"
+    },
+    {
+      "Id": "9c4c80d8-315b-4f3e-bf2e-f0a07ea9be32",
+      "ConcordiaCourseId": "011810"
+    },
+    {
+      "Id": "c0904e33-dff2-4ba6-85e0-6a6d32b2194d",
+      "ConcordiaCourseId": "011812"
+    },
+    {
+      "Id": "9c66bc7c-dea9-4f76-bee4-ddb5ffa38996",
+      "ConcordiaCourseId": "011814"
+    },
+    {
+      "Id": "a3101a66-7d59-4560-9b49-779c29432f8b",
+      "ConcordiaCourseId": "011815"
+    },
+    {
+      "Id": "605a7f4b-51bb-4a87-bdf5-2b21d1afa777",
+      "ConcordiaCourseId": "011816"
+    },
+    {
+      "Id": "a853f33a-0f8d-4a7a-b54d-b182d8b247ee",
+      "ConcordiaCourseId": "011817"
+    },
+    {
+      "Id": "912c2c4c-e215-4d2d-8720-b7755a9e16c7",
+      "ConcordiaCourseId": "011821"
+    },
+    {
+      "Id": "7d01a4ed-41b9-4584-a056-a70828227c1b",
+      "ConcordiaCourseId": "011822"
+    },
+    {
+      "Id": "e31bc38c-a909-40f8-9af5-1cf9076f1d6e",
+      "ConcordiaCourseId": "011824"
+    },
+    {
+      "Id": "4a299780-67b9-4166-837c-831f9da4ce7f",
+      "ConcordiaCourseId": "011825"
+    },
+    {
+      "Id": "50844fcb-46d1-46ca-a3f6-2097cf1846dc",
+      "ConcordiaCourseId": "048389"
+    },
+    {
+      "Id": "84a10531-c9ff-41f7-9692-ab7b79bb08aa",
+      "ConcordiaCourseId": "011829"
+    },
+    {
+      "Id": "f3077a0b-d085-462b-927f-1ca7ee1d8768",
+      "ConcordiaCourseId": "011830"
+    },
+    {
+      "Id": "848823a0-ca42-4a1c-b665-19c39cb9d673",
+      "ConcordiaCourseId": "011831"
+    },
+    {
+      "Id": "9f72fa45-2f3e-4428-9bf7-d2b8be80416a",
+      "ConcordiaCourseId": "011832"
+    },
+    {
+      "Id": "86677c64-08c2-487b-8153-fec858d85a68",
+      "ConcordiaCourseId": "011833"
+    },
+    {
+      "Id": "43cad965-6be9-4591-8c92-485008b6f777",
+      "ConcordiaCourseId": "011835"
+    },
+    {
+      "Id": "03abbe04-acfd-4633-b583-86185436639e",
+      "ConcordiaCourseId": "011837"
+    },
+    {
+      "Id": "3d2d1336-ebac-4f4c-8241-494c8db969ee",
+      "ConcordiaCourseId": "011838"
+    },
+    {
+      "Id": "28d7783d-ec77-45bd-9af5-492777fd8fe7",
+      "ConcordiaCourseId": "011840"
+    },
+    {
+      "Id": "502af3da-1490-4213-b3f0-5872aad7da71",
+      "ConcordiaCourseId": "011841"
+    },
+    {
+      "Id": "d5767d96-eb54-4893-a895-cf1b0ab46695",
+      "ConcordiaCourseId": "011842"
+    },
+    {
+      "Id": "51e43319-7db9-40fb-a3ce-ed5b22c9f81f",
+      "ConcordiaCourseId": "011844"
+    },
+    {
+      "Id": "e0c109d2-e4db-46e3-9ee1-f45189ee8c7f",
+      "ConcordiaCourseId": "011847"
+    },
+    {
+      "Id": "96b6a4b2-a4b2-44b9-8b18-24862b63a1a7",
+      "ConcordiaCourseId": "011849"
+    },
+    {
+      "Id": "a8ec6ee9-9a4a-46ae-9423-ca6d0c6394cb",
+      "ConcordiaCourseId": "011856"
+    },
+    {
+      "Id": "405bc95a-6e5e-41d9-ad46-c52f10c41615",
+      "ConcordiaCourseId": "040825"
+    },
+    {
+      "Id": "47e2f597-059a-43ca-a5a9-0092f1cda5d8",
+      "ConcordiaCourseId": "040826"
+    },
+    {
+      "Id": "45062a3e-f38c-4931-9794-2588b312172e",
+      "ConcordiaCourseId": "040827"
+    },
+    {
+      "Id": "481f9d38-e016-4305-a33a-b1471096ab59",
+      "ConcordiaCourseId": "040828"
+    },
+    {
+      "Id": "10e59a4b-8cdb-4885-82e1-f4fc582b1619",
+      "ConcordiaCourseId": "040829"
+    },
+    {
+      "Id": "fbbc145a-a8db-4483-97c3-3cd41323522f",
+      "ConcordiaCourseId": "040832"
+    },
+    {
+      "Id": "30786dbf-e673-4cb3-95b0-77c3e8289078",
+      "ConcordiaCourseId": "047343"
+    },
+    {
+      "Id": "c0bd4e1c-2c0d-4700-a99d-326f4cba674c",
+      "ConcordiaCourseId": "048338"
+    },
+    {
+      "Id": "83cc6d93-3d1e-4fc4-8950-66ae26d951f0",
+      "ConcordiaCourseId": "048342"
+    },
+    {
+      "Id": "374c9ca9-a8b1-4700-940c-b269d973eb6b",
+      "ConcordiaCourseId": "048958"
+    },
+    {
+      "Id": "7ac373d4-7892-4e5a-890c-8507733f945a",
+      "ConcordiaCourseId": "048959"
+    },
+    {
+      "Id": "12d08154-629f-40aa-90a4-ba2a003f2cd6",
+      "ConcordiaCourseId": "048960"
+    },
+    {
+      "Id": "4c921513-da8d-41ed-838a-8443bb4706f2",
+      "ConcordiaCourseId": "048961"
+    },
+    {
+      "Id": "71d67c39-707d-4a9b-a985-7b89cdaf7ee8",
+      "ConcordiaCourseId": "049406"
+    },
+    {
+      "Id": "3efc400b-7474-48d9-a2fd-ed9f6d145c3f",
+      "ConcordiaCourseId": "049574"
+    },
+    {
+      "Id": "d7ce5ecf-e08b-43ab-b369-67e75d647921",
+      "ConcordiaCourseId": "049575"
+    },
+    {
+      "Id": "d65d4c32-4318-4cfe-b3f7-8278e3daaae0",
+      "ConcordiaCourseId": "011939"
+    },
+    {
+      "Id": "3ed67d75-d9e5-4e51-b268-fbb099dcbcbd",
+      "ConcordiaCourseId": "011940"
+    },
+    {
+      "Id": "af9d33da-f948-4d3a-8879-331a32566a06",
+      "ConcordiaCourseId": "011941"
+    },
+    {
+      "Id": "56f2c362-fd17-43f9-8d17-b8dfe1668f8d",
+      "ConcordiaCourseId": "011942"
+    },
+    {
+      "Id": "95a39a15-b4e2-4475-b86b-d67d2b3e5f67",
+      "ConcordiaCourseId": "011943"
+    },
+    {
+      "Id": "71167ab7-9eff-4759-836e-2f84b7f11541",
+      "ConcordiaCourseId": "011946"
+    },
+    {
+      "Id": "456d1698-d588-4472-b95d-61389da2d626",
+      "ConcordiaCourseId": "011947"
+    },
+    {
+      "Id": "dc0bd2d7-f6f3-4258-8cbf-30b84d92c0a1",
+      "ConcordiaCourseId": "011950"
+    },
+    {
+      "Id": "51fdc1eb-2c9a-4b71-96e0-135bd0b1a98f",
+      "ConcordiaCourseId": "011951"
+    },
+    {
+      "Id": "c3d79f16-cdeb-4596-b6f2-cbc341f7febb",
+      "ConcordiaCourseId": "011985"
+    },
+    {
+      "Id": "db9b871b-63f8-43ad-b21d-2286c8a7f499",
+      "ConcordiaCourseId": "011989"
+    },
+    {
+      "Id": "933eaee4-8814-448f-9619-ec655a7799b8",
+      "ConcordiaCourseId": "011995"
+    },
+    {
+      "Id": "baae4e3e-b94e-4046-b3af-4e3e1812442c",
+      "ConcordiaCourseId": "011998"
+    },
+    {
+      "Id": "544468ac-760a-41dd-b215-4d9f1de618a8",
+      "ConcordiaCourseId": "012005"
+    },
+    {
+      "Id": "f3c9cbb8-5541-4b91-870e-559e700899f0",
+      "ConcordiaCourseId": "012008"
+    },
+    {
+      "Id": "c8f7674a-868e-4914-aaf5-7114cc424a2e",
+      "ConcordiaCourseId": "012034"
+    },
+    {
+      "Id": "ccaa0225-9e4f-4a1a-8c8f-14801956c19f",
+      "ConcordiaCourseId": "012038"
+    },
+    {
+      "Id": "5c73b4a8-c923-4344-9843-c1f27e3aaefa",
+      "ConcordiaCourseId": "012040"
+    },
+    {
+      "Id": "6e99fe05-d3e0-40a1-803a-cace86a60e31",
+      "ConcordiaCourseId": "012042"
+    },
+    {
+      "Id": "6d862686-a5ac-4a62-8175-8ea6f6129b3d",
+      "ConcordiaCourseId": "012043"
+    },
+    {
+      "Id": "d367afe3-ef4d-4fcc-8ec2-7c7271bb01b4",
+      "ConcordiaCourseId": "012235"
+    },
+    {
+      "Id": "38e00109-ebc5-4dce-a48f-88137d1a09b4",
+      "ConcordiaCourseId": "012275"
+    },
+    {
+      "Id": "3e8e5ce6-22e9-48f8-bd4c-1133e7224e75",
+      "ConcordiaCourseId": "045424"
+    },
+    {
+      "Id": "d6440167-1a97-40b7-8f89-8744675bfbac",
+      "ConcordiaCourseId": "046733"
+    },
+    {
+      "Id": "1b93da73-73ae-424e-afcd-1d2f852c21b0",
+      "ConcordiaCourseId": "046734"
+    },
+    {
+      "Id": "2c0ea0cb-05c2-488f-9130-027a65cab2e8",
+      "ConcordiaCourseId": "046735"
+    },
+    {
+      "Id": "40598aa1-e67f-4ba0-ac2d-a7487df40c77",
+      "ConcordiaCourseId": "012664"
+    },
+    {
+      "Id": "cdcf3be7-00a5-4d24-97d2-5a79640dacb4",
+      "ConcordiaCourseId": "012665"
+    },
+    {
+      "Id": "76a60b58-727a-4e8d-8903-43469724a1b5",
+      "ConcordiaCourseId": "012666"
+    },
+    {
+      "Id": "3594ec1d-bb04-4e55-90ba-bbd4998f8e4a",
+      "ConcordiaCourseId": "012667"
+    },
+    {
+      "Id": "d83b7317-52b2-4c8a-b75d-ac4e796bee55",
+      "ConcordiaCourseId": "012668"
+    },
+    {
+      "Id": "cad0fc33-066b-464b-bcb3-77cb032ebd4f",
+      "ConcordiaCourseId": "012669"
+    },
+    {
+      "Id": "da1a55f8-9375-47f5-ae71-97e599d47ccb",
+      "ConcordiaCourseId": "012670"
+    },
+    {
+      "Id": "0791bdf0-f3ad-4972-ba22-a9e06d6455c0",
+      "ConcordiaCourseId": "012674"
+    },
+    {
+      "Id": "a7ce755d-d088-41f1-94e4-cbb71809da77",
+      "ConcordiaCourseId": "012675"
+    },
+    {
+      "Id": "05f1f068-d563-460d-a29b-655e6dae5c1b",
+      "ConcordiaCourseId": "012676"
+    },
+    {
+      "Id": "bd333716-a12e-4ae9-999c-314d55d89d55",
+      "ConcordiaCourseId": "012677"
+    },
+    {
+      "Id": "4363f3ec-1a64-4bf5-83c2-2e966838d83c",
+      "ConcordiaCourseId": "012678"
+    },
+    {
+      "Id": "47c6ef14-94d0-4787-a079-25f395502c50",
+      "ConcordiaCourseId": "012683"
+    },
+    {
+      "Id": "e61c50ca-3aba-490f-b8c8-aac13b4de303",
+      "ConcordiaCourseId": "012684"
+    },
+    {
+      "Id": "057b3c77-69fc-48d3-8ac2-cf1b23d3868c",
+      "ConcordiaCourseId": "012685"
+    },
+    {
+      "Id": "aa3db48c-ec21-4fa1-9a3b-45529bdcc9ff",
+      "ConcordiaCourseId": "012686"
+    },
+    {
+      "Id": "102db8ee-e3c9-4a25-a11e-72a35476e8b6",
+      "ConcordiaCourseId": "012687"
+    },
+    {
+      "Id": "18e6e541-c5c6-40d0-9866-76979b728cbe",
+      "ConcordiaCourseId": "012688"
+    },
+    {
+      "Id": "604f3a3e-8546-4550-9062-6fbf9b9cf5d7",
+      "ConcordiaCourseId": "012689"
+    },
+    {
+      "Id": "1d55cc6b-abdf-4cad-8637-66eca0304ffa",
+      "ConcordiaCourseId": "012690"
+    },
+    {
+      "Id": "a4dd4119-ebaf-4263-9918-4b2d97f4439f",
+      "ConcordiaCourseId": "012691"
+    },
+    {
+      "Id": "dcd8ce95-2463-4c96-a9dc-3ae8ffca4c4a",
+      "ConcordiaCourseId": "012692"
+    },
+    {
+      "Id": "7eb58cc8-fa29-41c6-91a8-e2a5ce1db34f",
+      "ConcordiaCourseId": "012693"
+    },
+    {
+      "Id": "fa0142d9-bb05-4a10-8de6-de8858ad1dc6",
+      "ConcordiaCourseId": "012695"
+    },
+    {
+      "Id": "acbb37d8-3fae-4b61-b8cd-b3043e62064e",
+      "ConcordiaCourseId": "012696"
+    },
+    {
+      "Id": "31f4aa3d-568f-4249-8bc2-95debc64941f",
+      "ConcordiaCourseId": "012697"
+    },
+    {
+      "Id": "13500bd2-6fba-4051-9181-ed08cc996af4",
+      "ConcordiaCourseId": "012698"
+    },
+    {
+      "Id": "3365a2bd-6d1b-4b94-9a63-351e2c46b3a9",
+      "ConcordiaCourseId": "012699"
+    },
+    {
+      "Id": "35205f24-b1f3-45fa-9be8-8ff6790cf5fb",
+      "ConcordiaCourseId": "012700"
+    },
+    {
+      "Id": "2764a7e7-2481-4c34-8521-6dcc62fe6282",
+      "ConcordiaCourseId": "012701"
+    },
+    {
+      "Id": "c48d77a1-da97-4a0e-9370-d42beda1f21e",
+      "ConcordiaCourseId": "012702"
+    },
+    {
+      "Id": "45abbf3e-eeec-4b24-b196-31e0c2916de2",
+      "ConcordiaCourseId": "012703"
+    },
+    {
+      "Id": "32cf3542-d056-47c3-9d4d-e67c27821b53",
+      "ConcordiaCourseId": "012708"
+    },
+    {
+      "Id": "f633a723-9027-4a2a-b301-dd78917f5593",
+      "ConcordiaCourseId": "012712"
+    },
+    {
+      "Id": "f0fdb30e-7399-426e-ac98-808828d31505",
+      "ConcordiaCourseId": "012713"
+    },
+    {
+      "Id": "914477fd-694e-4c69-bab6-5f094edae8f3",
+      "ConcordiaCourseId": "012714"
+    },
+    {
+      "Id": "495a5aee-f56e-47cb-889f-8d24e6afc807",
+      "ConcordiaCourseId": "012715"
+    },
+    {
+      "Id": "e754b24c-df65-4db6-ad26-aaa5ef4623f2",
+      "ConcordiaCourseId": "012716"
+    },
+    {
+      "Id": "804db2ba-a7d5-4937-af3e-f4b03b472a46",
+      "ConcordiaCourseId": "012717"
+    },
+    {
+      "Id": "007653d6-c565-4c13-b06a-58401436f1a3",
+      "ConcordiaCourseId": "012718"
+    },
+    {
+      "Id": "b3314a94-a244-49ae-86a5-2662a014eb97",
+      "ConcordiaCourseId": "012721"
+    },
+    {
+      "Id": "2927abaa-34b4-4896-9f07-c07e5e76e114",
+      "ConcordiaCourseId": "012722"
+    },
+    {
+      "Id": "4115cc68-ccc2-4fa4-90ac-9bbc47a72952",
+      "ConcordiaCourseId": "012723"
+    },
+    {
+      "Id": "7ba516bb-4545-4709-a4a0-c0d0817ffdb0",
+      "ConcordiaCourseId": "012724"
+    },
+    {
+      "Id": "36666d86-9470-407f-a475-6f7ccaab4504",
+      "ConcordiaCourseId": "012725"
+    },
+    {
+      "Id": "5c332b69-5660-4a92-885a-0cc65b1836e4",
+      "ConcordiaCourseId": "012727"
+    },
+    {
+      "Id": "5a37ec89-5064-4ad8-a427-0e6b3d664c3a",
+      "ConcordiaCourseId": "012728"
+    },
+    {
+      "Id": "1f2c57f9-ddf4-4cb5-a13c-9cce5a2a8793",
+      "ConcordiaCourseId": "012730"
+    },
+    {
+      "Id": "93eb05da-0a23-4409-9bc1-31cbde9eef79",
+      "ConcordiaCourseId": "012732"
+    },
+    {
+      "Id": "07ba0c4f-d5a0-49d5-98b3-0ea993cffb3b",
+      "ConcordiaCourseId": "012735"
+    },
+    {
+      "Id": "3a81a3c8-528b-4185-b073-cd7e04fbc83c",
+      "ConcordiaCourseId": "012736"
+    },
+    {
+      "Id": "5156b20c-106f-4a7f-a950-4ec243e7bef8",
+      "ConcordiaCourseId": "012737"
+    },
+    {
+      "Id": "9cd0cc9c-a022-424b-bb50-64f84a3db97f",
+      "ConcordiaCourseId": "012738"
+    },
+    {
+      "Id": "922b852b-01d4-4f33-b076-d6e82408b493",
+      "ConcordiaCourseId": "012739"
+    },
+    {
+      "Id": "3b72c70b-7df4-41c9-b5d5-4c75419bdc52",
+      "ConcordiaCourseId": "012740"
+    },
+    {
+      "Id": "dc336a95-e02a-4e32-8403-4b40943f1491",
+      "ConcordiaCourseId": "012741"
+    },
+    {
+      "Id": "ee684867-1d56-4c25-8180-31c3167b5b82",
+      "ConcordiaCourseId": "012742"
+    },
+    {
+      "Id": "1e961607-cc63-4590-9021-151b7828e179",
+      "ConcordiaCourseId": "012743"
+    },
+    {
+      "Id": "045e1fc7-17e4-482a-be1f-a2ae1dc94c37",
+      "ConcordiaCourseId": "012744"
+    },
+    {
+      "Id": "b9a241d1-bb1c-4e6c-bc6e-a01a3037bb3f",
+      "ConcordiaCourseId": "012746"
+    },
+    {
+      "Id": "6fde653b-24f7-4b18-927b-8edd6aff2180",
+      "ConcordiaCourseId": "012747"
+    },
+    {
+      "Id": "820a262f-70ba-48ca-8d9b-a44a0bace7e4",
+      "ConcordiaCourseId": "012748"
+    },
+    {
+      "Id": "b4bf5ce8-d003-4e34-8db3-7cce68f9e1ee",
+      "ConcordiaCourseId": "012749"
+    },
+    {
+      "Id": "11802fee-2fa7-402c-ad85-d77093403d4f",
+      "ConcordiaCourseId": "012750"
+    },
+    {
+      "Id": "c1d250e1-d98b-4c42-a1cc-dd4bf1fd85e9",
+      "ConcordiaCourseId": "012751"
+    },
+    {
+      "Id": "92aac765-a65e-47ef-95ff-440c013b5713",
+      "ConcordiaCourseId": "012752"
+    },
+    {
+      "Id": "18fab421-aa27-4552-b784-689ed977c978",
+      "ConcordiaCourseId": "012753"
+    },
+    {
+      "Id": "c64406b2-c141-479c-abf2-84e6b516dfe0",
+      "ConcordiaCourseId": "012757"
+    },
+    {
+      "Id": "9be62214-c0df-4043-9e9d-ba81e848181b",
+      "ConcordiaCourseId": "040848"
+    },
+    {
+      "Id": "52751282-ceda-458e-a63c-e6846c5c5be8",
+      "ConcordiaCourseId": "040849"
+    },
+    {
+      "Id": "9d8216ac-bee8-49eb-9492-dd5c48bacbd7",
+      "ConcordiaCourseId": "040850"
+    },
+    {
+      "Id": "c0a8834a-e8ff-4052-a972-42ae538b6068",
+      "ConcordiaCourseId": "040852"
+    },
+    {
+      "Id": "166eaf0f-7111-4d52-a7ed-87b113df5999",
+      "ConcordiaCourseId": "040855"
+    },
+    {
+      "Id": "65d76110-6ef2-43e0-80b8-f6170d088de7",
+      "ConcordiaCourseId": "040856"
+    },
+    {
+      "Id": "3baaa615-8d1f-4a17-ac2a-73aee0c7953b",
+      "ConcordiaCourseId": "040857"
+    },
+    {
+      "Id": "36a6259f-a11d-4da2-807f-e36dfa6e12c6",
+      "ConcordiaCourseId": "040858"
+    },
+    {
+      "Id": "c9cf1451-dc2a-419f-bee7-d20cc24bacd2",
+      "ConcordiaCourseId": "040860"
+    },
+    {
+      "Id": "138161ad-3338-4db7-a5af-9fa8a6fee7f7",
+      "ConcordiaCourseId": "040861"
+    },
+    {
+      "Id": "3d80fcdd-7434-4233-9204-9850123cabb5",
+      "ConcordiaCourseId": "040862"
+    },
+    {
+      "Id": "ee100701-4a10-4812-8cc2-7b54820e6484",
+      "ConcordiaCourseId": "040863"
+    },
+    {
+      "Id": "167df7ff-5cf5-4ffb-9455-0c3c10fa9318",
+      "ConcordiaCourseId": "040864"
+    },
+    {
+      "Id": "3e0fd46f-026d-4056-8c68-c4bc97f64d4e",
+      "ConcordiaCourseId": "040865"
+    },
+    {
+      "Id": "310eb5f2-e5f0-4475-b9c9-b7894ce38196",
+      "ConcordiaCourseId": "040867"
+    },
+    {
+      "Id": "87780c6b-fa91-430d-924f-44c0f427ead8",
+      "ConcordiaCourseId": "040868"
+    },
+    {
+      "Id": "6e136f3d-fd86-4b08-8184-e57546b0e057",
+      "ConcordiaCourseId": "040869"
+    },
+    {
+      "Id": "b70f5065-b4b7-470f-a96e-5bf1fed898ad",
+      "ConcordiaCourseId": "040870"
+    },
+    {
+      "Id": "671b27c4-9019-4d97-ad08-bef087d731d5",
+      "ConcordiaCourseId": "040871"
+    },
+    {
+      "Id": "94fe4570-ccc5-400e-ac2c-f63208bb4126",
+      "ConcordiaCourseId": "040872"
+    },
+    {
+      "Id": "6682c958-4196-4b2c-bd52-f1fb5643c986",
+      "ConcordiaCourseId": "040874"
+    },
+    {
+      "Id": "0596560f-5281-409c-a5fd-95de6b8ef25e",
+      "ConcordiaCourseId": "040878"
+    },
+    {
+      "Id": "cc2b09ac-42d1-4a86-b316-a6a343c0d877",
+      "ConcordiaCourseId": "040879"
+    },
+    {
+      "Id": "26aedc71-84a7-4019-96d4-b2badb8f41bf",
+      "ConcordiaCourseId": "040880"
+    },
+    {
+      "Id": "1f4b372e-7e7c-4161-94d0-19839f40fdd6",
+      "ConcordiaCourseId": "044030"
+    },
+    {
+      "Id": "c8bc372e-da37-44a3-9bf7-06b4046c64e7",
+      "ConcordiaCourseId": "044031"
+    },
+    {
+      "Id": "2796bee0-5deb-4b8f-ad56-ecb39e3a7513",
+      "ConcordiaCourseId": "044032"
+    },
+    {
+      "Id": "7b591836-8f68-451f-9e95-3c291d6befa3",
+      "ConcordiaCourseId": "044033"
+    },
+    {
+      "Id": "cbfcf775-147a-429e-a5bc-b7ae5503e5d3",
+      "ConcordiaCourseId": "044034"
+    },
+    {
+      "Id": "02332907-617e-4e8c-aec4-d2cbb39cb2bd",
+      "ConcordiaCourseId": "044035"
+    },
+    {
+      "Id": "7572d677-95c0-4778-a917-3bd1a1d4cb0f",
+      "ConcordiaCourseId": "044036"
+    },
+    {
+      "Id": "99e9d2ba-1788-4bb4-a999-a1d27afbb29f",
+      "ConcordiaCourseId": "044037"
+    },
+    {
+      "Id": "f98657e7-450a-4bc7-bbf9-53f23e92e843",
+      "ConcordiaCourseId": "044038"
+    },
+    {
+      "Id": "0e0989d7-448b-4bc3-bef9-d1ad2aaed6f9",
+      "ConcordiaCourseId": "044039"
+    },
+    {
+      "Id": "3992e402-9bfb-4600-9a7f-e5bd23856468",
+      "ConcordiaCourseId": "044040"
+    },
+    {
+      "Id": "8eefbcaf-192d-4fbc-838b-a391346b48d1",
+      "ConcordiaCourseId": "044041"
+    },
+    {
+      "Id": "2b7f590e-773d-40af-a8c1-49b34fd4931d",
+      "ConcordiaCourseId": "044042"
+    },
+    {
+      "Id": "1cd4e131-057a-4cd9-9e44-34a5aea6618f",
+      "ConcordiaCourseId": "044043"
+    },
+    {
+      "Id": "e752346d-e0b9-4e06-af96-98198f633037",
+      "ConcordiaCourseId": "044044"
+    },
+    {
+      "Id": "67bcb735-7733-4a9a-8928-414b89b903dc",
+      "ConcordiaCourseId": "044045"
+    },
+    {
+      "Id": "7083a463-844a-4918-8b7b-a960a45e11ae",
+      "ConcordiaCourseId": "045062"
+    },
+    {
+      "Id": "7b0f3fc3-0a58-4463-a478-d404e3b38c20",
+      "ConcordiaCourseId": "045067"
+    },
+    {
+      "Id": "650b5eaa-f34d-4c81-a4fd-a528c4463b76",
+      "ConcordiaCourseId": "045100"
+    },
+    {
+      "Id": "8fd8add4-b2c6-414b-9db2-4ea5e8fa678a",
+      "ConcordiaCourseId": "045101"
+    },
+    {
+      "Id": "705b09b3-9131-45fe-ab98-c8770707a612",
+      "ConcordiaCourseId": "045102"
+    },
+    {
+      "Id": "745c98e9-8657-4669-bfeb-50ef699c4f41",
+      "ConcordiaCourseId": "045103"
+    },
+    {
+      "Id": "b8b7836b-ecc2-4d45-a372-1e93aaccc081",
+      "ConcordiaCourseId": "045104"
+    },
+    {
+      "Id": "259a1980-528b-49d1-8499-773699d85bdd",
+      "ConcordiaCourseId": "045105"
+    },
+    {
+      "Id": "edbc8bd5-26ff-43c1-824d-58df044e5798",
+      "ConcordiaCourseId": "046736"
+    },
+    {
+      "Id": "52d0c92c-4a56-40fd-954a-ec3b9f609c51",
+      "ConcordiaCourseId": "046737"
+    },
+    {
+      "Id": "a1938fe6-b7e7-4a28-b450-b48c59260f01",
+      "ConcordiaCourseId": "046738"
+    },
+    {
+      "Id": "46bea162-d140-4104-9f95-0043a8dd1a0a",
+      "ConcordiaCourseId": "047168"
+    },
+    {
+      "Id": "4a7ae8f6-5f25-45c6-9c55-84b6a28858de",
+      "ConcordiaCourseId": "047874"
+    },
+    {
+      "Id": "4dd84251-7b7b-4ae8-a994-342507d4158d",
+      "ConcordiaCourseId": "047875"
+    },
+    {
+      "Id": "92a63e2f-2796-40d4-ae55-fd2f3c9bc1e2",
+      "ConcordiaCourseId": "047876"
+    },
+    {
+      "Id": "aa4bd1d3-9c9c-4c3d-80b6-27564efb6c22",
+      "ConcordiaCourseId": "049254"
+    },
+    {
+      "Id": "e194be1c-68a0-4b5b-a863-c5c162116d03",
+      "ConcordiaCourseId": "050360"
+    },
+    {
+      "Id": "4d096ed9-e3ba-41c1-a331-07f1e59921c8",
+      "ConcordiaCourseId": "048511"
+    },
+    {
+      "Id": "fd9a701d-8e4e-4e61-95a6-a503097ddabf",
+      "ConcordiaCourseId": "048512"
+    },
+    {
+      "Id": "459ff401-e607-44c1-9e53-ea2cc52a5f5a",
+      "ConcordiaCourseId": "048513"
+    },
+    {
+      "Id": "ca83d0d5-bd95-43cd-b88a-1f671d0f17ae",
+      "ConcordiaCourseId": "048514"
+    },
+    {
+      "Id": "c4d41da4-0735-49bb-b370-8a50f9f24f3d",
+      "ConcordiaCourseId": "048515"
+    },
+    {
+      "Id": "600a818d-52d1-4afb-8686-456cf8ce87dd",
+      "ConcordiaCourseId": "012779"
+    },
+    {
+      "Id": "bb097212-a3b3-483e-9303-5b82a6eea05f",
+      "ConcordiaCourseId": "012780"
+    },
+    {
+      "Id": "23c07f22-df0c-4405-a44b-28a6848edb54",
+      "ConcordiaCourseId": "012781"
+    },
+    {
+      "Id": "24a42f9a-f728-401f-b3f9-15fade64029d",
+      "ConcordiaCourseId": "012782"
+    },
+    {
+      "Id": "c12ad136-4c4d-4453-8aab-097a61a9b2fc",
+      "ConcordiaCourseId": "012783"
+    },
+    {
+      "Id": "7d842d72-922b-40ee-863f-6b3bbe85a444",
+      "ConcordiaCourseId": "012784"
+    },
+    {
+      "Id": "b90f2a9a-f72d-4190-be07-b475c3cbb4c4",
+      "ConcordiaCourseId": "012785"
+    },
+    {
+      "Id": "892691f8-8b41-4a97-b90b-ac7002da1ad3",
+      "ConcordiaCourseId": "012786"
+    },
+    {
+      "Id": "548f7013-d4ca-4766-a4dc-d81e0575d807",
+      "ConcordiaCourseId": "046739"
+    },
+    {
+      "Id": "ea3a1dba-9d57-4194-bb4f-def11f468c67",
+      "ConcordiaCourseId": "047182"
+    },
+    {
+      "Id": "9cee7e0f-dccb-4dad-a797-6bc3fef35cb6",
+      "ConcordiaCourseId": "047524"
+    },
+    {
+      "Id": "26386a78-b7b5-4970-b703-5cb4b15d50eb",
+      "ConcordiaCourseId": "047525"
+    },
+    {
+      "Id": "d4502765-b083-432f-9d99-ad55f35fa202",
+      "ConcordiaCourseId": "047526"
+    },
+    {
+      "Id": "d23f91fd-95b8-4ecd-b77c-a17a0838875c",
+      "ConcordiaCourseId": "047527"
+    },
+    {
+      "Id": "7a916149-30bb-455a-bd3e-3c47e5e4462a",
+      "ConcordiaCourseId": "047530"
+    },
+    {
+      "Id": "3fe04352-d959-45c6-a8d1-1eef8c011808",
+      "ConcordiaCourseId": "047531"
+    },
+    {
+      "Id": "fdaca6bf-513b-4e7d-99ab-9a29cc70154b",
+      "ConcordiaCourseId": "047532"
+    },
+    {
+      "Id": "f705f5f9-aad7-44c8-a743-53b8db2da113",
+      "ConcordiaCourseId": "047534"
+    },
+    {
+      "Id": "96de77ce-1583-4847-9311-3d4a02ce6f0c",
+      "ConcordiaCourseId": "047535"
+    },
+    {
+      "Id": "13915779-4782-43fc-91e8-1a41428eab85",
+      "ConcordiaCourseId": "048986"
+    },
+    {
+      "Id": "b1521614-cc68-4529-ad86-9e0feff0f355",
+      "ConcordiaCourseId": "048987"
+    },
+    {
+      "Id": "5494d3a5-49a4-49ac-99df-8c4436a60a4f",
+      "ConcordiaCourseId": "048988"
+    },
+    {
+      "Id": "77394dbe-0b9b-4f88-a310-98c06165e935",
+      "ConcordiaCourseId": "048989"
+    },
+    {
+      "Id": "1d800e83-559b-40b0-b007-b41b46c06933",
+      "ConcordiaCourseId": "048990"
+    },
+    {
+      "Id": "e0b823c4-a450-49c7-b539-5d62e2dc4520",
+      "ConcordiaCourseId": "048991"
+    },
+    {
+      "Id": "1a9af276-0487-42d3-b059-9538e93eabf5",
+      "ConcordiaCourseId": "048992"
+    },
+    {
+      "Id": "9862f8b7-2d12-4fee-a26b-1d0f0e1256cc",
+      "ConcordiaCourseId": "049546"
+    },
+    {
+      "Id": "12d81211-ba87-4fb9-97cb-39b3e90b2a8f",
+      "ConcordiaCourseId": "049846"
+    },
+    {
+      "Id": "5cd5f97c-0b16-492e-a507-666770925e07",
+      "ConcordiaCourseId": "046740"
+    },
+    {
+      "Id": "9dd48cbb-a24c-4246-86d6-9bead1df8662",
+      "ConcordiaCourseId": "046741"
+    },
+    {
+      "Id": "20e8f062-33ca-457d-94a8-7d69ea3d14d2",
+      "ConcordiaCourseId": "046742"
+    },
+    {
+      "Id": "29a2763c-79a1-4f64-aec2-091c411d0a2f",
+      "ConcordiaCourseId": "046743"
+    },
+    {
+      "Id": "ce8282ee-051a-40c0-b234-078bb5658ec1",
+      "ConcordiaCourseId": "012880"
+    },
+    {
+      "Id": "1390f7f4-e419-4c12-abfd-e21db42fb40f",
+      "ConcordiaCourseId": "012883"
+    },
+    {
+      "Id": "ba0f036b-a117-463c-8543-7ad6a553ab87",
+      "ConcordiaCourseId": "012884"
+    },
+    {
+      "Id": "32250d11-2828-4fa8-8fb5-b85bf79c6ac1",
+      "ConcordiaCourseId": "012886"
+    },
+    {
+      "Id": "a28004bb-e8f8-4a8d-98fe-6041ffcec3b0",
+      "ConcordiaCourseId": "012890"
+    },
+    {
+      "Id": "76da6812-a8fe-44c1-b6c6-d7dede0a39bd",
+      "ConcordiaCourseId": "012892"
+    },
+    {
+      "Id": "44ab7800-bd0d-445b-8e9e-77da5d1edb38",
+      "ConcordiaCourseId": "012899"
+    },
+    {
+      "Id": "88e73736-4d28-4a1e-9847-e11d681711d1",
+      "ConcordiaCourseId": "012905"
+    },
+    {
+      "Id": "36eda671-8ac5-4d18-8c46-2fd07df3ac68",
+      "ConcordiaCourseId": "012907"
+    },
+    {
+      "Id": "5897a219-dc85-4b6c-951e-5147a62a2b6f",
+      "ConcordiaCourseId": "012910"
+    },
+    {
+      "Id": "436d2acf-6345-4b84-8ac4-cae83f91c592",
+      "ConcordiaCourseId": "012918"
+    },
+    {
+      "Id": "c2a6bb22-f37b-441a-980a-94197e6197dd",
+      "ConcordiaCourseId": "012926"
+    },
+    {
+      "Id": "58bee17c-b5e4-47b4-b52d-6c47b7f9ecd5",
+      "ConcordiaCourseId": "012932"
+    },
+    {
+      "Id": "c5731324-98a7-43d2-b79e-4321a54894b6",
+      "ConcordiaCourseId": "012934"
+    },
+    {
+      "Id": "90f6d87a-0d91-4f2e-a900-6d8db3301cc6",
+      "ConcordiaCourseId": "012935"
+    },
+    {
+      "Id": "15a51e14-a945-41c4-b79c-a13c6d627460",
+      "ConcordiaCourseId": "012939"
+    },
+    {
+      "Id": "73026f07-6445-4b20-bc27-91982c6aaaec",
+      "ConcordiaCourseId": "012943"
+    },
+    {
+      "Id": "15a618b9-5dc9-46b7-be1c-9d1c56735810",
+      "ConcordiaCourseId": "012946"
+    },
+    {
+      "Id": "4a9d204f-aeda-4944-b2c5-0e31d3bc505f",
+      "ConcordiaCourseId": "012950"
+    },
+    {
+      "Id": "74162a5e-8928-4e22-9567-76bbfb7e9135",
+      "ConcordiaCourseId": "012955"
+    },
+    {
+      "Id": "ccf72f14-a870-4f1a-8183-098775176a00",
+      "ConcordiaCourseId": "012956"
+    },
+    {
+      "Id": "85cf9e29-eaf6-4608-bcc4-cb413989df93",
+      "ConcordiaCourseId": "012957"
+    },
+    {
+      "Id": "231d4bf7-ab4f-450c-8a01-edf0a646bc1d",
+      "ConcordiaCourseId": "012960"
+    },
+    {
+      "Id": "d9ba37be-fa9f-4056-8581-0ab954a12031",
+      "ConcordiaCourseId": "012961"
+    },
+    {
+      "Id": "61c0f6e9-d6d7-4787-a1dd-8eeb308751c2",
+      "ConcordiaCourseId": "012963"
+    },
+    {
+      "Id": "dfde64c9-f4d9-4aea-9f5c-01b89b843e4b",
+      "ConcordiaCourseId": "012964"
+    },
+    {
+      "Id": "b0b3641c-14c9-4d6d-aa41-e8f0f35c9ff9",
+      "ConcordiaCourseId": "012966"
+    },
+    {
+      "Id": "f0c66367-2728-47b5-9add-93f401ff255b",
+      "ConcordiaCourseId": "012967"
+    },
+    {
+      "Id": "59e1f463-80c5-4b63-9e8f-2a1f32b8069b",
+      "ConcordiaCourseId": "012971"
+    },
+    {
+      "Id": "395b3302-3766-4ffe-ab97-f869f8dc8869",
+      "ConcordiaCourseId": "012991"
+    },
+    {
+      "Id": "20e56ec8-69b1-4822-85f5-e56d6b247231",
+      "ConcordiaCourseId": "012997"
+    },
+    {
+      "Id": "416b158a-e0bf-4fbc-8d7a-546e8fe765ea",
+      "ConcordiaCourseId": "013002"
+    },
+    {
+      "Id": "0311de5b-f39a-453b-b51c-f9b3fa0fe0aa",
+      "ConcordiaCourseId": "013009"
+    },
+    {
+      "Id": "d5fa0a88-5cf7-47ba-a0ef-d322011768f1",
+      "ConcordiaCourseId": "013010"
+    },
+    {
+      "Id": "a3283f56-2f2a-4c56-908e-327ec76a000c",
+      "ConcordiaCourseId": "013015"
+    },
+    {
+      "Id": "0e2dd080-73dd-42d4-853c-247a655a26ca",
+      "ConcordiaCourseId": "013025"
+    },
+    {
+      "Id": "4ab6b648-5503-43f6-a470-05c968f181c3",
+      "ConcordiaCourseId": "013030"
+    },
+    {
+      "Id": "7623152a-11b5-460b-a64e-05d793d6e5d7",
+      "ConcordiaCourseId": "013031"
+    },
+    {
+      "Id": "e4ccdbd0-438d-449c-88e0-a3d72696f704",
+      "ConcordiaCourseId": "013032"
+    },
+    {
+      "Id": "1f4dd083-02d9-40b8-af38-a6463dd3d53d",
+      "ConcordiaCourseId": "013033"
+    },
+    {
+      "Id": "92247d58-3814-4f9f-b69c-af8e42b9086c",
+      "ConcordiaCourseId": "013036"
+    },
+    {
+      "Id": "5494d937-f050-46e5-aba8-2d30e32cb627",
+      "ConcordiaCourseId": "013038"
+    },
+    {
+      "Id": "929fb8be-7bdd-4cb2-a24d-f88ee9143ca2",
+      "ConcordiaCourseId": "013039"
+    },
+    {
+      "Id": "93e34561-2aa1-4687-af69-e6d2b2bc3d47",
+      "ConcordiaCourseId": "013040"
+    },
+    {
+      "Id": "87d2a25e-d3f8-45a7-baea-c4525fc4f461",
+      "ConcordiaCourseId": "013042"
+    },
+    {
+      "Id": "ae1bac22-7431-49c9-8016-5c6761e70dc7",
+      "ConcordiaCourseId": "013045"
+    },
+    {
+      "Id": "1327bc71-f298-475a-ba8b-9285ebc115a3",
+      "ConcordiaCourseId": "013046"
+    },
+    {
+      "Id": "bcf3c841-4363-4153-a4f2-535eb68a4cd5",
+      "ConcordiaCourseId": "013082"
+    },
+    {
+      "Id": "a0809745-0dbc-4c2b-8a2b-0f439e69e1cc",
+      "ConcordiaCourseId": "013083"
+    },
+    {
+      "Id": "578d02f8-fa5b-47e1-965b-2d331ded3583",
+      "ConcordiaCourseId": "013092"
+    },
+    {
+      "Id": "388996cd-9a65-4531-9c08-0d63c1953c81",
+      "ConcordiaCourseId": "034741"
+    },
+    {
+      "Id": "61ce4cfc-d2c1-47b0-878e-8d83f534a50d",
+      "ConcordiaCourseId": "040910"
+    },
+    {
+      "Id": "4a9225c5-1657-4fbc-ae3d-ab7eea8de2d7",
+      "ConcordiaCourseId": "040911"
+    },
+    {
+      "Id": "c86ef263-8a50-4268-9904-e7b281f10b3f",
+      "ConcordiaCourseId": "040914"
+    },
+    {
+      "Id": "3360bcd8-bb98-4883-9114-e6e7d9055eda",
+      "ConcordiaCourseId": "040931"
+    },
+    {
+      "Id": "1a1a3adf-ce79-4eb3-bb69-f3f015f30535",
+      "ConcordiaCourseId": "040932"
+    },
+    {
+      "Id": "c520ac75-3028-4a07-ac35-5e02f5c5762c",
+      "ConcordiaCourseId": "046744"
+    },
+    {
+      "Id": "a504ba2b-ed98-4f06-8301-a6c65ed51c0d",
+      "ConcordiaCourseId": "046745"
+    },
+    {
+      "Id": "857a0da3-382d-42a7-b222-ec2ab8e85dea",
+      "ConcordiaCourseId": "046746"
+    },
+    {
+      "Id": "0805841b-d2f7-4f99-9edc-1ca6c29130a4",
+      "ConcordiaCourseId": "046747"
+    },
+    {
+      "Id": "cda2a2ab-6cbc-4cd6-8ff7-ee6c38560a58",
+      "ConcordiaCourseId": "046748"
+    },
+    {
+      "Id": "17e5ee06-6902-4ff7-8823-4cb80e8848ab",
+      "ConcordiaCourseId": "046750"
+    },
+    {
+      "Id": "001b5716-686d-4977-b019-2650fcea4041",
+      "ConcordiaCourseId": "046751"
+    },
+    {
+      "Id": "5f9de9bd-ae1a-40fd-a24d-a2e34db2203a",
+      "ConcordiaCourseId": "046752"
+    },
+    {
+      "Id": "4bf441b4-c766-45c6-86e6-f88d2e784018",
+      "ConcordiaCourseId": "046753"
+    },
+    {
+      "Id": "3f3b6539-cdb6-48ae-93fb-39a4ea5bda6d",
+      "ConcordiaCourseId": "047893"
+    },
+    {
+      "Id": "f87c71ee-4228-4d23-9121-9fa00f8934d2",
+      "ConcordiaCourseId": "049256"
+    },
+    {
+      "Id": "2475df89-10cc-4fc6-98ee-dbb30b87fca4",
+      "ConcordiaCourseId": "049257"
+    },
+    {
+      "Id": "7b602002-a49e-4a0d-8350-793b0b7bcbe9",
+      "ConcordiaCourseId": "049294"
+    },
+    {
+      "Id": "63c9be7c-b453-439f-8b9a-44d9e62ff0ea",
+      "ConcordiaCourseId": "049661"
+    },
+    {
+      "Id": "0ea50b0d-99ab-4623-b8fe-5f7360ab2238",
+      "ConcordiaCourseId": "050074"
+    },
+    {
+      "Id": "5de4795e-0a28-4229-be07-b518ad1afbb0",
+      "ConcordiaCourseId": "050544"
+    },
+    {
+      "Id": "745a1c27-66ec-49ad-b870-e5e03112bfff",
+      "ConcordiaCourseId": "050672"
+    },
+    {
+      "Id": "d1e8c599-1bb4-49e8-8509-c18814983fbc",
+      "ConcordiaCourseId": "050804"
+    },
+    {
+      "Id": "fd80ecc8-55d6-40ca-85ed-36944b99d01a",
+      "ConcordiaCourseId": "013271"
+    },
+    {
+      "Id": "fdcca232-842b-4d6d-8d31-2b7bf3f63b4f",
+      "ConcordiaCourseId": "013273"
+    },
+    {
+      "Id": "79373d4a-0a8e-49b2-ab64-177c2514dbe8",
+      "ConcordiaCourseId": "013276"
+    },
+    {
+      "Id": "6dafe3eb-3254-4e3d-a1ae-e5638ca75613",
+      "ConcordiaCourseId": "013277"
+    },
+    {
+      "Id": "c65a1779-e2a8-419e-a22e-04e5caa6e71d",
+      "ConcordiaCourseId": "013359"
+    },
+    {
+      "Id": "e00d3867-57be-4e7e-8455-0ca90c11860e",
+      "ConcordiaCourseId": "046754"
+    },
+    {
+      "Id": "32873f63-7ce8-404c-9f35-0f67db5fb7dc",
+      "ConcordiaCourseId": "046755"
+    },
+    {
+      "Id": "9ef6d270-3e36-4c0b-8bfb-015e42b6f87d",
+      "ConcordiaCourseId": "046756"
+    },
+    {
+      "Id": "5b375d3b-da44-466c-98ec-ddb990d3a61e",
+      "ConcordiaCourseId": "046757"
+    },
+    {
+      "Id": "5ba0be53-f85c-4609-9b24-8b85f7142d0c",
+      "ConcordiaCourseId": "013461"
+    },
+    {
+      "Id": "74dbc67f-109b-41aa-b483-270abf713ddf",
+      "ConcordiaCourseId": "013463"
+    },
+    {
+      "Id": "1f13d45f-33b3-4b9b-b17a-510e7e5fece7",
+      "ConcordiaCourseId": "013464"
+    },
+    {
+      "Id": "79fab948-3bd8-4010-88b0-aa267bc64074",
+      "ConcordiaCourseId": "013471"
+    },
+    {
+      "Id": "ee2c1786-f28e-46b7-873c-1078489e366f",
+      "ConcordiaCourseId": "013472"
+    },
+    {
+      "Id": "269e577c-39d6-4f4c-a664-73d2d11a5cf9",
+      "ConcordiaCourseId": "013473"
+    },
+    {
+      "Id": "04d86f43-3dbf-43a4-b0a1-c2c98b3c2d5b",
+      "ConcordiaCourseId": "013474"
+    },
+    {
+      "Id": "d5a3eb7e-355e-45b3-8506-a57ae890759c",
+      "ConcordiaCourseId": "013475"
+    },
+    {
+      "Id": "4533ad67-5d68-4c5f-bbfd-5c51ba4e1506",
+      "ConcordiaCourseId": "013482"
+    },
+    {
+      "Id": "899f38e4-8ee8-466a-9dcf-d77009da0e89",
+      "ConcordiaCourseId": "013494"
+    },
+    {
+      "Id": "4d78eed4-2b2b-4ac8-8fcc-9c8f0b04597d",
+      "ConcordiaCourseId": "013495"
+    },
+    {
+      "Id": "6edbbb70-03c9-431f-9da7-a4bea9ac1dcd",
+      "ConcordiaCourseId": "013499"
+    },
+    {
+      "Id": "53a3f00a-bbe8-4905-8ae6-7fa94ee6dc60",
+      "ConcordiaCourseId": "013500"
+    },
+    {
+      "Id": "936ff950-8229-4c62-837c-b44de3d841c9",
+      "ConcordiaCourseId": "013505"
+    },
+    {
+      "Id": "5422262f-897a-4f1f-9039-9846bcff8335",
+      "ConcordiaCourseId": "013509"
+    },
+    {
+      "Id": "16c9fa97-3d34-4eaf-854f-5e11ff8a615e",
+      "ConcordiaCourseId": "013511"
+    },
+    {
+      "Id": "df638138-b7ee-47b6-93d2-a0b98a4b3ae6",
+      "ConcordiaCourseId": "013513"
+    },
+    {
+      "Id": "5a37f97b-3c57-4c7a-a143-273e1728faa2",
+      "ConcordiaCourseId": "013515"
+    },
+    {
+      "Id": "66143aaf-bbbc-4a1b-bb55-48fd655c5cf6",
+      "ConcordiaCourseId": "013533"
+    },
+    {
+      "Id": "d058718b-2e0a-43ec-9c93-a0ef0832e8a7",
+      "ConcordiaCourseId": "013539"
+    },
+    {
+      "Id": "9da2e7e3-f962-49b6-b2b6-118baa1ac26a",
+      "ConcordiaCourseId": "013552"
+    },
+    {
+      "Id": "726890a4-c114-4486-a075-246d7401674d",
+      "ConcordiaCourseId": "013553"
+    },
+    {
+      "Id": "4bc82f3f-ac33-43cc-b0bb-b5f33f7d4a46",
+      "ConcordiaCourseId": "013558"
+    },
+    {
+      "Id": "dc6e3c5c-20c4-46fa-afbe-af48c6e34079",
+      "ConcordiaCourseId": "013563"
+    },
+    {
+      "Id": "2bb38a70-b88d-4dcd-97aa-2a39cb23aad8",
+      "ConcordiaCourseId": "013564"
+    },
+    {
+      "Id": "a91f937c-bf69-408b-8e8e-7d30dd1471e4",
+      "ConcordiaCourseId": "013567"
+    },
+    {
+      "Id": "f1287868-83de-4fdf-bb92-b5c025252fe0",
+      "ConcordiaCourseId": "046758"
+    },
+    {
+      "Id": "866ed45b-35ab-4802-9715-41a817c627ea",
+      "ConcordiaCourseId": "046759"
+    },
+    {
+      "Id": "19277368-24e3-4dec-bcdb-23ebb30d68e8",
+      "ConcordiaCourseId": "046760"
+    },
+    {
+      "Id": "c7ae37ea-8686-4d95-8fcf-7411b1741b58",
+      "ConcordiaCourseId": "046761"
+    },
+    {
+      "Id": "9aca82ba-d445-4afa-ad54-e0e4f63976ad",
+      "ConcordiaCourseId": "046762"
+    },
+    {
+      "Id": "af97d10f-3078-48c4-a94a-a679e73d0139",
+      "ConcordiaCourseId": "047398"
+    },
+    {
+      "Id": "b0f60f1a-f9b8-45d7-a4dd-45cd825e79cd",
+      "ConcordiaCourseId": "047400"
+    },
+    {
+      "Id": "94aec84f-5363-445e-9c50-3cf46e74fe2c",
+      "ConcordiaCourseId": "013685"
+    },
+    {
+      "Id": "8a8f8fc4-b6de-43e8-a31c-6cfecf67fa3f",
+      "ConcordiaCourseId": "013686"
+    },
+    {
+      "Id": "168ca5c0-95c0-45cf-92a0-d168c114843c",
+      "ConcordiaCourseId": "013687"
+    },
+    {
+      "Id": "fafb0665-911a-4854-9283-481fbc002794",
+      "ConcordiaCourseId": "013688"
+    },
+    {
+      "Id": "d3b87b39-d808-4ba5-aacc-0300f290c17c",
+      "ConcordiaCourseId": "013689"
+    },
+    {
+      "Id": "4488f39c-115f-448b-99ff-c6b069c7b60b",
+      "ConcordiaCourseId": "013690"
+    },
+    {
+      "Id": "55dba84f-4182-4f4a-a0fd-556834c99be1",
+      "ConcordiaCourseId": "013691"
+    },
+    {
+      "Id": "7a57ab1c-9945-45cc-86ba-7bdd723fed6e",
+      "ConcordiaCourseId": "013692"
+    },
+    {
+      "Id": "453dbaef-1a9a-4604-a696-49bd46d2f3db",
+      "ConcordiaCourseId": "013693"
+    },
+    {
+      "Id": "5d4968a4-7375-427b-8302-d3954517f028",
+      "ConcordiaCourseId": "013694"
+    },
+    {
+      "Id": "96a778b6-e6af-429d-bcc5-f9ed31fc7042",
+      "ConcordiaCourseId": "013695"
+    },
+    {
+      "Id": "2f515190-60b2-4a44-8349-ecdfc378ea99",
+      "ConcordiaCourseId": "013696"
+    },
+    {
+      "Id": "547c62fd-44bd-4062-a1fb-72633d3c4317",
+      "ConcordiaCourseId": "013697"
+    },
+    {
+      "Id": "9b7be058-bfca-4986-a940-731833cf7ff6",
+      "ConcordiaCourseId": "013698"
+    },
+    {
+      "Id": "6f5b2573-a342-43ca-a7ac-5cc9c9ee0ac8",
+      "ConcordiaCourseId": "013700"
+    },
+    {
+      "Id": "0a321ef3-0c7e-43a3-8541-5b524d846583",
+      "ConcordiaCourseId": "013701"
+    },
+    {
+      "Id": "bf7c21be-dc84-40a3-991b-e1829672cd24",
+      "ConcordiaCourseId": "013702"
+    },
+    {
+      "Id": "6b8a02fe-f8cf-4c42-a2be-300ea22d5b19",
+      "ConcordiaCourseId": "013705"
+    },
+    {
+      "Id": "aa89387b-ea49-44a2-af6a-bf835cafafd6",
+      "ConcordiaCourseId": "013706"
+    },
+    {
+      "Id": "61b2f9bb-bda0-4496-913f-d172c5e0f754",
+      "ConcordiaCourseId": "013707"
+    },
+    {
+      "Id": "3d795f8e-23ea-4114-8b0c-85d50ca32af2",
+      "ConcordiaCourseId": "013708"
+    },
+    {
+      "Id": "74b6a786-6a42-45cb-b0ab-87a68fdfb6fc",
+      "ConcordiaCourseId": "013709"
+    },
+    {
+      "Id": "8863cdf9-d216-476f-aee9-e1601ad2a49a",
+      "ConcordiaCourseId": "046763"
+    },
+    {
+      "Id": "fba56564-a44f-4008-8146-3120c4468a47",
+      "ConcordiaCourseId": "047472"
+    },
+    {
+      "Id": "4ee2a3b6-00df-40a8-810f-76239b26448b",
+      "ConcordiaCourseId": "050047"
+    },
+    {
+      "Id": "802fe7d1-48bf-4d05-9a03-c976115526ca",
+      "ConcordiaCourseId": "050048"
+    },
+    {
+      "Id": "3948c570-2621-4cd8-961f-58127042ce44",
+      "ConcordiaCourseId": "050819"
+    },
+    {
+      "Id": "54033ec9-513a-4d9d-a4ef-5277cfae9094",
+      "ConcordiaCourseId": "037003"
+    },
+    {
+      "Id": "aef0996f-aa6a-4875-b32d-a35942d3970d",
+      "ConcordiaCourseId": "037004"
+    },
+    {
+      "Id": "344c2f01-5f59-45c1-8064-cf966caf01bf",
+      "ConcordiaCourseId": "037006"
+    },
+    {
+      "Id": "3c92d61a-1968-4f8c-99cb-980124b761ac",
+      "ConcordiaCourseId": "037007"
+    },
+    {
+      "Id": "594121c6-15a0-40a0-ba40-a845baaf0609",
+      "ConcordiaCourseId": "037008"
+    },
+    {
+      "Id": "50272001-1a65-4a6a-8162-a37aaab8680a",
+      "ConcordiaCourseId": "037009"
+    },
+    {
+      "Id": "339b8422-a00b-4da6-911a-b7813f773021",
+      "ConcordiaCourseId": "037010"
+    },
+    {
+      "Id": "8863bbfe-5079-4745-b857-310f19e82758",
+      "ConcordiaCourseId": "037012"
+    },
+    {
+      "Id": "ee3ccf4f-24b7-4838-a92a-9ac86e939f3e",
+      "ConcordiaCourseId": "037015"
+    },
+    {
+      "Id": "39be6814-3ccb-4fd7-9709-92fb831a8951",
+      "ConcordiaCourseId": "037016"
+    },
+    {
+      "Id": "7445da3b-478c-4c72-a9de-cecf2cc0c5d8",
+      "ConcordiaCourseId": "037019"
+    },
+    {
+      "Id": "63e5f1d6-f73f-434f-b491-8e51d3d6f925",
+      "ConcordiaCourseId": "037020"
+    },
+    {
+      "Id": "ae7bbd54-e4ea-47c1-8709-0d7a2818bf6e",
+      "ConcordiaCourseId": "037028"
+    },
+    {
+      "Id": "5e9c825c-c8b4-496b-a294-673ba7dce57b",
+      "ConcordiaCourseId": "037030"
+    },
+    {
+      "Id": "944ff52d-f9d2-4928-86e8-d7cbeb731804",
+      "ConcordiaCourseId": "037031"
+    },
+    {
+      "Id": "e9da76d8-d073-47d6-a3be-4b8555f3c4f0",
+      "ConcordiaCourseId": "037036"
+    },
+    {
+      "Id": "fcc09f8d-b295-48c5-bb88-b6b41d44c7a8",
+      "ConcordiaCourseId": "037037"
+    },
+    {
+      "Id": "c3e0c260-b17b-4e96-b7c3-f844f0fe152c",
+      "ConcordiaCourseId": "037039"
+    },
+    {
+      "Id": "a6369049-ba8a-4e90-bb0a-f86f365d5bbf",
+      "ConcordiaCourseId": "037040"
+    },
+    {
+      "Id": "e1e3c77b-e26b-4085-8047-f412aef21a0c",
+      "ConcordiaCourseId": "037041"
+    },
+    {
+      "Id": "f359d9b9-bbdd-4f08-b904-52fe69ebc542",
+      "ConcordiaCourseId": "037042"
+    },
+    {
+      "Id": "32ad292e-b043-4fe9-8b7b-c98974ac9741",
+      "ConcordiaCourseId": "037043"
+    },
+    {
+      "Id": "acb6ba18-498c-48ee-874c-93532182ba45",
+      "ConcordiaCourseId": "037047"
+    },
+    {
+      "Id": "603cf125-c970-43db-b997-e678e5a55df6",
+      "ConcordiaCourseId": "037170"
+    },
+    {
+      "Id": "6779f5c6-2771-4903-92bf-a722ab632275",
+      "ConcordiaCourseId": "037259"
+    },
+    {
+      "Id": "7686c8bc-f2b3-4f2a-bbc3-1f076e3aeadc",
+      "ConcordiaCourseId": "045031"
+    },
+    {
+      "Id": "7c1a074f-7c9b-4887-84df-f4d9e804319f",
+      "ConcordiaCourseId": "045053"
+    },
+    {
+      "Id": "f6050709-2cc9-46b4-b668-7c8149811469",
+      "ConcordiaCourseId": "047616"
+    },
+    {
+      "Id": "21a3837d-a7a4-4301-8b4b-8551b497fee8",
+      "ConcordiaCourseId": "047797"
+    },
+    {
+      "Id": "9c8a3e93-04ee-46e1-a4a1-fecbbbbf75b3",
+      "ConcordiaCourseId": "047907"
+    },
+    {
+      "Id": "ac425cfa-942c-40f3-b36f-ca3d920a6c95",
+      "ConcordiaCourseId": "048193"
+    },
+    {
+      "Id": "0f93a5bc-95c6-4bcf-add3-c64fe5660404",
+      "ConcordiaCourseId": "048352"
+    },
+    {
+      "Id": "ae7513fc-7a9d-4d71-a911-ef55f0e6b1b7",
+      "ConcordiaCourseId": "048484"
+    },
+    {
+      "Id": "6dbc6bea-4736-4f04-a310-dbb69d81dde9",
+      "ConcordiaCourseId": "049243"
+    },
+    {
+      "Id": "f376c751-3a91-4e9b-8d4d-a63e03386d8a",
+      "ConcordiaCourseId": "049324"
+    },
+    {
+      "Id": "8f822642-3c9c-403f-9afb-2caa7393337a",
+      "ConcordiaCourseId": "049457"
+    },
+    {
+      "Id": "f7a8cadb-97c9-412e-8bba-ea0b37c8c042",
+      "ConcordiaCourseId": "049886"
+    },
+    {
+      "Id": "0d9e1c20-c0eb-4017-bde2-f9bc2297530a",
+      "ConcordiaCourseId": "050031"
+    },
+    {
+      "Id": "ac9047ee-c6c2-4ac9-99d9-8cf5403f901e",
+      "ConcordiaCourseId": "048044"
+    },
+    {
+      "Id": "eba0df86-c12f-456e-b70c-50f52d8e957b",
+      "ConcordiaCourseId": "048624"
+    },
+    {
+      "Id": "31fef901-0591-441b-9a18-df1b9d622cf3",
+      "ConcordiaCourseId": "048637"
+    },
+    {
+      "Id": "70097023-5b9c-4989-9c6a-f81daff79433",
+      "ConcordiaCourseId": "049456"
+    },
+    {
+      "Id": "956077b4-4970-48d2-9267-8f94b8291960",
+      "ConcordiaCourseId": "049459"
+    },
+    {
+      "Id": "dcd7e547-a6a3-44bb-aa57-a27cedfd101b",
+      "ConcordiaCourseId": "049616"
+    },
+    {
+      "Id": "5ae926eb-7c35-4947-9913-30e395720e50",
+      "ConcordiaCourseId": "049617"
+    },
+    {
+      "Id": "d66b26f3-034c-4292-968f-053cc2952030",
+      "ConcordiaCourseId": "050021"
+    },
+    {
+      "Id": "10740636-17de-42a6-8b1d-6228913d880e",
+      "ConcordiaCourseId": "050225"
+    },
+    {
+      "Id": "6fafe56c-188f-450a-85ba-285c23406f5e",
+      "ConcordiaCourseId": "047572"
+    },
+    {
+      "Id": "23b83711-c2c6-4401-8e34-28536ce12e32",
+      "ConcordiaCourseId": "047974"
+    },
+    {
+      "Id": "8b3b95c6-4523-4ec6-bff2-c3960e554250",
+      "ConcordiaCourseId": "047975"
+    },
+    {
+      "Id": "9a881b36-9d56-4330-9398-6359994d71a5",
+      "ConcordiaCourseId": "048148"
+    },
+    {
+      "Id": "fd219c29-91da-431e-95ec-531db5be05f8",
+      "ConcordiaCourseId": "048367"
+    },
+    {
+      "Id": "638d91af-1eae-4361-8a72-930be5328aa5",
+      "ConcordiaCourseId": "049463"
+    },
+    {
+      "Id": "e2f10725-c171-477e-bace-7c7b85867401",
+      "ConcordiaCourseId": "049801"
+    },
+    {
+      "Id": "2e07c4a4-815a-40f7-aa84-b6dd1844b09b",
+      "ConcordiaCourseId": "050148"
+    },
+    {
+      "Id": "54a04573-e054-4069-9d21-1efcfcfe935c",
+      "ConcordiaCourseId": "037120"
+    },
+    {
+      "Id": "f9ff130a-61f0-4e25-9a1a-3aa496d61b5c",
+      "ConcordiaCourseId": "037123"
+    },
+    {
+      "Id": "3d7f89c1-5255-4484-a3f7-afc2c76b7659",
+      "ConcordiaCourseId": "037127"
+    },
+    {
+      "Id": "2ff10a55-6748-4d15-be39-08c03f3e8b84",
+      "ConcordiaCourseId": "037135"
+    },
+    {
+      "Id": "fea9343d-85e6-4333-a662-b3c4284e25f8",
+      "ConcordiaCourseId": "037136"
+    },
+    {
+      "Id": "133b19be-41a7-4f24-ab8d-cf5ad090c8cf",
+      "ConcordiaCourseId": "037139"
+    },
+    {
+      "Id": "1267c889-184e-4394-8cea-05cb0fe58078",
+      "ConcordiaCourseId": "037140"
+    },
+    {
+      "Id": "b67b1aa5-8872-44ee-9fe9-9623418f708e",
+      "ConcordiaCourseId": "037194"
+    },
+    {
+      "Id": "2fa637a9-dc6f-423f-be54-214432c7b5e8",
+      "ConcordiaCourseId": "037196"
+    },
+    {
+      "Id": "36e97a39-6d88-41cc-955d-489529b6c8e4",
+      "ConcordiaCourseId": "037198"
+    },
+    {
+      "Id": "477ced35-a607-412e-aa5b-175a42567ea0",
+      "ConcordiaCourseId": "037203"
+    },
+    {
+      "Id": "a8286e79-dd14-4d41-bd81-fa6b1b1dbba0",
+      "ConcordiaCourseId": "037206"
+    },
+    {
+      "Id": "b81d6ed7-2c97-4249-87d6-ff3c3b3adc3f",
+      "ConcordiaCourseId": "037289"
+    },
+    {
+      "Id": "32f8da42-8131-4d23-8f57-c6314df48bf3",
+      "ConcordiaCourseId": "046438"
+    },
+    {
+      "Id": "d3f468a5-cb96-42b2-86b5-8c163b853365",
+      "ConcordiaCourseId": "047611"
+    },
+    {
+      "Id": "517e79d2-bec7-4517-b996-a410b8e8d6a4",
+      "ConcordiaCourseId": "047690"
+    },
+    {
+      "Id": "fab1f681-83e3-450d-b35e-e271582a5123",
+      "ConcordiaCourseId": "047736"
+    },
+    {
+      "Id": "823690a0-0115-41d0-9412-1016ac02f79e",
+      "ConcordiaCourseId": "048143"
+    },
+    {
+      "Id": "b629fb39-e76b-4ee6-8261-edf01280ade2",
+      "ConcordiaCourseId": "048173"
+    },
+    {
+      "Id": "335fe100-5cd8-4a2f-a252-dfd49aefaed1",
+      "ConcordiaCourseId": "048181"
+    },
+    {
+      "Id": "bc027464-91c6-4fe0-822e-1697720a0a25",
+      "ConcordiaCourseId": "048182"
+    },
+    {
+      "Id": "116a7a52-e644-4e8c-a462-7928b04e352b",
+      "ConcordiaCourseId": "048543"
+    },
+    {
+      "Id": "eff4aec7-617d-4f74-9d02-5adc1a6c8554",
+      "ConcordiaCourseId": "048601"
+    },
+    {
+      "Id": "6026dd2f-2c6f-4d7d-9a7f-b8f4313296e6",
+      "ConcordiaCourseId": "048610"
+    },
+    {
+      "Id": "5ecc0d2d-0ac8-4c70-9312-c49d4b83a3b6",
+      "ConcordiaCourseId": "048612"
+    },
+    {
+      "Id": "6940010a-139a-4483-9463-62bd7cf098a1",
+      "ConcordiaCourseId": "048850"
+    },
+    {
+      "Id": "234aea5b-65a3-4616-b571-9e255e5d742b",
+      "ConcordiaCourseId": "049210"
+    },
+    {
+      "Id": "697f6c3f-cebe-4b90-9b75-ced985837b9b",
+      "ConcordiaCourseId": "049455"
+    },
+    {
+      "Id": "3570fa93-bcc7-4f3c-b661-9ca2b98f87a3",
+      "ConcordiaCourseId": "049458"
+    },
+    {
+      "Id": "ed28f17c-3025-4662-8440-b81625f72d87",
+      "ConcordiaCourseId": "049460"
+    },
+    {
+      "Id": "05df9415-aba5-410c-8250-f9b2e02f2468",
+      "ConcordiaCourseId": "049462"
+    },
+    {
+      "Id": "ba7c9988-07f3-4727-b672-85976437d859",
+      "ConcordiaCourseId": "049478"
+    },
+    {
+      "Id": "6a5e6f02-92bd-45f1-ad13-4fe526b4afdf",
+      "ConcordiaCourseId": "049734"
+    },
+    {
+      "Id": "d32dc5d1-be5a-43dc-8996-938330e6c8ab",
+      "ConcordiaCourseId": "049890"
+    },
+    {
+      "Id": "3c6b9273-179e-46e0-9d31-9df97970b5bc",
+      "ConcordiaCourseId": "049891"
+    },
+    {
+      "Id": "4ed22e03-f351-46db-8f1f-54d5d440a2e1",
+      "ConcordiaCourseId": "049892"
+    },
+    {
+      "Id": "c06852e6-4539-4444-89cc-d1c10682b266",
+      "ConcordiaCourseId": "049893"
+    },
+    {
+      "Id": "d0cdf877-d875-484d-acf3-e330c5d4c3f1",
+      "ConcordiaCourseId": "049896"
+    },
+    {
+      "Id": "667d68f2-bc70-400a-a86e-92949abfc4f8",
+      "ConcordiaCourseId": "049897"
+    },
+    {
+      "Id": "9583b0e4-d0c6-4e63-8914-cffa548d6744",
+      "ConcordiaCourseId": "049898"
+    },
+    {
+      "Id": "dac318c4-1701-4c47-8531-804d344e3885",
+      "ConcordiaCourseId": "049899"
+    },
+    {
+      "Id": "751c4b5f-0609-4a0d-b388-fa8542ffeaac",
+      "ConcordiaCourseId": "049900"
+    },
+    {
+      "Id": "09001a18-d873-4f86-8ee2-ce250047b1e1",
+      "ConcordiaCourseId": "049901"
+    },
+    {
+      "Id": "9fe2973b-db74-4e9f-ba82-d901e0c94c16",
+      "ConcordiaCourseId": "049902"
+    },
+    {
+      "Id": "a258787f-e0ac-4e70-8df6-8e3cdd429d61",
+      "ConcordiaCourseId": "049905"
+    },
+    {
+      "Id": "9b9058aa-84a6-4771-b8d5-4df8f3cfaf44",
+      "ConcordiaCourseId": "049906"
+    },
+    {
+      "Id": "6b17581b-9222-4f68-911d-439ed589c606",
+      "ConcordiaCourseId": "049926"
+    },
+    {
+      "Id": "93da0b5d-3e8a-42da-bd8e-a21abaf7fa9f",
+      "ConcordiaCourseId": "049927"
+    },
+    {
+      "Id": "434a7d55-94a0-4764-85f1-d7ce934405bb",
+      "ConcordiaCourseId": "049928"
+    },
+    {
+      "Id": "f12436f9-790b-438e-8fc6-bea8cf78e66d",
+      "ConcordiaCourseId": "050023"
+    },
+    {
+      "Id": "329a3f06-de06-4ccc-bf33-33ff88fbb169",
+      "ConcordiaCourseId": "050024"
+    },
+    {
+      "Id": "2385deac-3170-4bc7-87d8-808d7c3748b1",
+      "ConcordiaCourseId": "050025"
+    },
+    {
+      "Id": "446769d3-81b8-4f17-8ecb-bdf44878f7b5",
+      "ConcordiaCourseId": "050026"
+    },
+    {
+      "Id": "aefc3700-8b1b-4710-bdf9-cd846e8954f4",
+      "ConcordiaCourseId": "050049"
+    },
+    {
+      "Id": "54e78b5d-94ab-461d-b4dc-fc50e51bcf47",
+      "ConcordiaCourseId": "050063"
+    },
+    {
+      "Id": "81dad544-26dc-45db-8c72-a1169cdb9a16",
+      "ConcordiaCourseId": "050211"
+    },
+    {
+      "Id": "10505a22-3c24-45a3-8cf1-c183e6594cb9",
+      "ConcordiaCourseId": "050212"
+    },
+    {
+      "Id": "a74d1a9b-e439-4aa8-8113-02d3670eec1e",
+      "ConcordiaCourseId": "050220"
+    },
+    {
+      "Id": "7d450acc-9927-4fb4-bc81-c2821cc2d062",
+      "ConcordiaCourseId": "050221"
+    },
+    {
+      "Id": "93afa6a8-7c1c-4f2e-b87c-5a6ce1e5c06e",
+      "ConcordiaCourseId": "050222"
+    },
+    {
+      "Id": "bd74676f-a1dc-4d5a-ba78-2594702bba5d",
+      "ConcordiaCourseId": "050223"
+    },
+    {
+      "Id": "80879951-ee8d-425a-9713-a95b7672fba6",
+      "ConcordiaCourseId": "050224"
+    },
+    {
+      "Id": "1c4009ab-6ff2-430d-83b1-912c031e9d71",
+      "ConcordiaCourseId": "050234"
+    },
+    {
+      "Id": "da0ea19e-f3d7-4186-be5a-e855a4abcbd0",
+      "ConcordiaCourseId": "050235"
+    },
+    {
+      "Id": "77dd5cae-90e2-450c-9d57-018d55bc956a",
+      "ConcordiaCourseId": "050236"
+    },
+    {
+      "Id": "01a68060-dc73-4345-85cc-5c961feae83e",
+      "ConcordiaCourseId": "050320"
+    },
+    {
+      "Id": "21734f8e-12ca-403a-9892-a32768b822af",
+      "ConcordiaCourseId": "037159"
+    },
+    {
+      "Id": "1a81bb17-725d-46cf-95ff-3c85a45cb95f",
+      "ConcordiaCourseId": "037160"
+    },
+    {
+      "Id": "b4a65620-bf0b-477a-8253-4e3faca4241d",
+      "ConcordiaCourseId": "048421"
+    },
+    {
+      "Id": "a8a65325-153b-4ea3-b6b3-806069c1b52e",
+      "ConcordiaCourseId": "049954"
+    },
+    {
+      "Id": "503e61bf-c6ba-4423-bd74-8b0fe29d9829",
+      "ConcordiaCourseId": "049955"
+    },
+    {
+      "Id": "8189f97c-c74d-4d20-8f18-9f092251b240",
+      "ConcordiaCourseId": "049956"
+    },
+    {
+      "Id": "6dd9e501-7d07-49dd-b20c-efcb82406fa8",
+      "ConcordiaCourseId": "047487"
+    },
+    {
+      "Id": "7712be24-0d59-421c-9092-dedf4c4c7d5e",
+      "ConcordiaCourseId": "047475"
+    },
+    {
+      "Id": "cfa5529c-fe62-4442-a311-e6f72024b536",
+      "ConcordiaCourseId": "047686"
+    },
+    {
+      "Id": "66fc1025-d234-41dc-bc9b-49a3ae0becce",
+      "ConcordiaCourseId": "047892"
+    },
+    {
+      "Id": "cdcf54e9-32d0-416a-959e-5897359a909f",
+      "ConcordiaCourseId": "047908"
+    },
+    {
+      "Id": "3c217751-1149-48f0-b27e-2cbb3e12f719",
+      "ConcordiaCourseId": "047909"
+    },
+    {
+      "Id": "6a106bba-59de-4a4d-af6b-39c72498a1f0",
+      "ConcordiaCourseId": "037129"
+    },
+    {
+      "Id": "43d29b2a-2326-4f46-8217-213019c4ec37",
+      "ConcordiaCourseId": "037131"
+    },
+    {
+      "Id": "d0465a8d-b56c-46fd-8197-b6fcb23ec03d",
+      "ConcordiaCourseId": "037254"
+    },
+    {
+      "Id": "58379273-f7ea-41b3-813f-506ca6a6d623",
+      "ConcordiaCourseId": "037258"
+    },
+    {
+      "Id": "3cd50b01-b463-4c21-9d2e-9d066cda5758",
+      "ConcordiaCourseId": "046439"
+    },
+    {
+      "Id": "7ac10378-277a-4d04-b9b6-9dae372d2ebc",
+      "ConcordiaCourseId": "047729"
+    },
+    {
+      "Id": "0a74a563-5b2f-425d-8c84-8410b3022958",
+      "ConcordiaCourseId": "047730"
+    },
+    {
+      "Id": "dce0098c-2626-43b1-9c40-f215281f2aed",
+      "ConcordiaCourseId": "048353"
+    },
+    {
+      "Id": "26a7ee8e-56ee-45da-916f-0d2b3eff14da",
+      "ConcordiaCourseId": "049451"
+    },
+    {
+      "Id": "9d7d98b7-068c-46b3-9768-7d6425a6c116",
+      "ConcordiaCourseId": "049473"
+    },
+    {
+      "Id": "40d18364-8b91-4ef6-8f1d-e6f9067a4b6f",
+      "ConcordiaCourseId": "049475"
+    },
+    {
+      "Id": "2a3eddd6-9db2-457a-b3a1-f11cdda70781",
+      "ConcordiaCourseId": "037304"
+    },
+    {
+      "Id": "0110bb3b-1746-4561-91bf-2154a72027d6",
+      "ConcordiaCourseId": "037306"
+    },
+    {
+      "Id": "b416d673-a57b-410c-bbf0-c19b68a3e6e2",
+      "ConcordiaCourseId": "037307"
+    },
+    {
+      "Id": "b1579730-f306-4adf-8620-5a50b325a05a",
+      "ConcordiaCourseId": "037308"
+    },
+    {
+      "Id": "657e521e-8ff0-4537-a839-1cfe7fbb5ec0",
+      "ConcordiaCourseId": "037314"
+    },
+    {
+      "Id": "5c030858-cd29-4a17-b999-b3ede2961a2b",
+      "ConcordiaCourseId": "037317"
+    },
+    {
+      "Id": "24cc82db-6fd0-4597-a143-93292c099797",
+      "ConcordiaCourseId": "037324"
+    },
+    {
+      "Id": "aa5b47aa-5b6a-491d-ac7a-039217a34f9a",
+      "ConcordiaCourseId": "037351"
+    },
+    {
+      "Id": "82557b38-5326-459f-b272-86bcad538de3",
+      "ConcordiaCourseId": "037352"
+    },
+    {
+      "Id": "e597df24-f5a5-4fb1-938b-4f78224a2dad",
+      "ConcordiaCourseId": "037355"
+    },
+    {
+      "Id": "6cb80c86-8eee-4b76-ae42-3674a453d2c1",
+      "ConcordiaCourseId": "037356"
+    },
+    {
+      "Id": "be4be98c-f0b5-4dec-832c-6e7b9c170850",
+      "ConcordiaCourseId": "037357"
+    },
+    {
+      "Id": "dfac45a1-5a6e-4f6b-8e11-b747e674e169",
+      "ConcordiaCourseId": "037358"
+    },
+    {
+      "Id": "dddec6f0-4a4c-41ea-b3d4-e46ce93ff4a2",
+      "ConcordiaCourseId": "045054"
+    },
+    {
+      "Id": "f97be5bf-f85b-41bf-95d2-62717233b928",
+      "ConcordiaCourseId": "047569"
+    },
+    {
+      "Id": "4279bfd9-8a3f-4941-bff0-8dde6d058262",
+      "ConcordiaCourseId": "047570"
+    },
+    {
+      "Id": "007cb7c1-27b0-4932-a071-017537d503f2",
+      "ConcordiaCourseId": "047685"
+    },
+    {
+      "Id": "c06f77dc-76e3-4c59-a25e-9251aa49b05b",
+      "ConcordiaCourseId": "047882"
+    },
+    {
+      "Id": "b7231a26-7bb8-45a7-ad39-2b873dcffee7",
+      "ConcordiaCourseId": "048617"
+    },
+    {
+      "Id": "62a5579f-103f-4657-8896-95d488cdd26a",
+      "ConcordiaCourseId": "048854"
+    },
+    {
+      "Id": "d2c8566a-52de-4ff2-9044-3b7a53270120",
+      "ConcordiaCourseId": "048855"
+    },
+    {
+      "Id": "e7564ed0-2cc8-48ef-8c6a-c51c17e411be",
+      "ConcordiaCourseId": "048890"
+    },
+    {
+      "Id": "fd3b245f-5ba5-4a19-80be-1f58f4f54af3",
+      "ConcordiaCourseId": "049100"
+    },
+    {
+      "Id": "7ff23b4b-1b1b-4188-92f8-944e198de833",
+      "ConcordiaCourseId": "049183"
+    },
+    {
+      "Id": "d6fd37c1-dba1-48eb-9bc5-cc04ed5299a8",
+      "ConcordiaCourseId": "049449"
+    },
+    {
+      "Id": "50f226cb-3f37-4ece-9e72-093c2fe7e4b8",
+      "ConcordiaCourseId": "049487"
+    },
+    {
+      "Id": "2a933002-f455-4fd8-8f01-8b695ed76fd1",
+      "ConcordiaCourseId": "049488"
+    },
+    {
+      "Id": "8c9d6ab2-0ad0-4275-aab1-170a3761474c",
+      "ConcordiaCourseId": "049489"
+    },
+    {
+      "Id": "b633d48a-beb3-4379-b65b-53e81813d569",
+      "ConcordiaCourseId": "049490"
+    },
+    {
+      "Id": "0c624a59-ae1e-4948-ade3-e0f204c63656",
+      "ConcordiaCourseId": "049913"
+    },
+    {
+      "Id": "89ebdc9b-7677-4710-8fe6-311209a6fa14",
+      "ConcordiaCourseId": "050022"
+    },
+    {
+      "Id": "0fc422c5-d57b-4459-ac7f-517d98ab5279",
+      "ConcordiaCourseId": "050283"
+    },
+    {
+      "Id": "5f8f7c5d-0d98-4ce9-b3de-1a1276ea1d1e",
+      "ConcordiaCourseId": "037363"
+    },
+    {
+      "Id": "bd57f59e-3ede-4f25-b87a-120078a5fdb7",
+      "ConcordiaCourseId": "037364"
+    },
+    {
+      "Id": "71cd02de-465c-465f-99f3-caf9bde50b9c",
+      "ConcordiaCourseId": "037367"
+    },
+    {
+      "Id": "128e1cd8-1705-4dc8-a352-cee7345f1f5d",
+      "ConcordiaCourseId": "037369"
+    },
+    {
+      "Id": "2ef0d4e9-79b5-43e0-be66-3902ca013755",
+      "ConcordiaCourseId": "047755"
+    },
+    {
+      "Id": "cb3b0c34-3fe1-44c4-91bd-aa0961844c81",
+      "ConcordiaCourseId": "048040"
+    },
+    {
+      "Id": "81bc646c-6e16-4d87-830f-5deda0be3c7e",
+      "ConcordiaCourseId": "048041"
+    },
+    {
+      "Id": "68c909df-c000-42f1-8318-40d782038c88",
+      "ConcordiaCourseId": "048142"
+    },
+    {
+      "Id": "34b3e975-3410-4291-bdd2-dc3dffabd49a",
+      "ConcordiaCourseId": "048618"
+    },
+    {
+      "Id": "a668fc00-ad77-4ff6-8a26-ee856bdedad8",
+      "ConcordiaCourseId": "048625"
+    },
+    {
+      "Id": "a968e5b5-4d56-451c-835e-1617f19503ee",
+      "ConcordiaCourseId": "049102"
+    },
+    {
+      "Id": "616866a8-9f1d-40bf-aa82-6f7136699de4",
+      "ConcordiaCourseId": "049165"
+    },
+    {
+      "Id": "f23e7330-675b-4579-9b78-805e4677c0d6",
+      "ConcordiaCourseId": "049509"
+    },
+    {
+      "Id": "590f4b65-8d21-47b9-ad20-d5e22d94261d",
+      "ConcordiaCourseId": "049510"
+    },
+    {
+      "Id": "c820ee46-36a1-4f61-9172-75b4280f233e",
+      "ConcordiaCourseId": "049803"
+    },
+    {
+      "Id": "c755bb90-50e6-4bf8-8704-039b4c920e71",
+      "ConcordiaCourseId": "050076"
+    },
+    {
+      "Id": "fb28e789-f5dc-4520-b316-be988196aaf6",
+      "ConcordiaCourseId": "050237"
+    },
+    {
+      "Id": "f45f3454-1735-4f3c-b2dc-ab2b1ee801b2",
+      "ConcordiaCourseId": "050238"
+    },
+    {
+      "Id": "c765af0a-4512-44a0-9add-88c076aa5de8",
+      "ConcordiaCourseId": "050354"
+    },
+    {
+      "Id": "b9cc5336-a7c8-4da2-ab93-aac09378a967",
+      "ConcordiaCourseId": "050361"
+    },
+    {
+      "Id": "45aebeec-1f6d-4383-a572-e945f5afc3aa",
+      "ConcordiaCourseId": "050518"
+    },
+    {
+      "Id": "f500f151-6317-472e-a98d-ad809670298b",
+      "ConcordiaCourseId": "050638"
+    },
+    {
+      "Id": "d4fc32f8-9c96-4290-b468-8b26df50105c",
+      "ConcordiaCourseId": "050846"
+    },
+    {
+      "Id": "266cc791-197f-4d93-92ca-9c604bdea5ee",
+      "ConcordiaCourseId": "050847"
+    },
+    {
+      "Id": "24292b26-55f3-4941-b2c5-2fbd667dab40",
+      "ConcordiaCourseId": "046764"
+    },
+    {
+      "Id": "5895d6ad-1950-481b-8959-fbd5cfa50ad5",
+      "ConcordiaCourseId": "046765"
+    },
+    {
+      "Id": "f7f774d8-2b2d-4876-9001-dec79552354a",
+      "ConcordiaCourseId": "046766"
+    },
+    {
+      "Id": "72cad5bf-5a15-4481-8214-c324461812ce",
+      "ConcordiaCourseId": "046767"
+    },
+    {
+      "Id": "406a3d2c-5c50-4b01-add3-356b61598be5",
+      "ConcordiaCourseId": "013816"
+    },
+    {
+      "Id": "5d1b35f9-d686-4119-a19b-2b7d0ed423bb",
+      "ConcordiaCourseId": "013820"
+    },
+    {
+      "Id": "1b377c0e-52b6-4268-b19a-5774dc8d6ff0",
+      "ConcordiaCourseId": "013821"
+    },
+    {
+      "Id": "825470bd-e6de-4edd-8b51-ad9e0046f50d",
+      "ConcordiaCourseId": "046768"
+    },
+    {
+      "Id": "d38ff530-eec1-4096-9bf4-21071c7893a6",
+      "ConcordiaCourseId": "013844"
+    },
+    {
+      "Id": "d89abc46-62f1-4222-845b-b40c6df1f418",
+      "ConcordiaCourseId": "013845"
+    },
+    {
+      "Id": "c6807a87-7cf3-4b6d-b645-435750113286",
+      "ConcordiaCourseId": "013846"
+    },
+    {
+      "Id": "583d6ff9-fd56-44ef-9ca4-0151d86d170c",
+      "ConcordiaCourseId": "013847"
+    },
+    {
+      "Id": "05098573-bdee-4315-b2f1-8171eab2aee2",
+      "ConcordiaCourseId": "013849"
+    },
+    {
+      "Id": "8ea105da-c3b8-4d11-9918-43e9347d820a",
+      "ConcordiaCourseId": "013850"
+    },
+    {
+      "Id": "d912a9c3-5446-4277-a3d3-34ce9d43036f",
+      "ConcordiaCourseId": "013851"
+    },
+    {
+      "Id": "8eecce34-8243-4532-8286-7dc47de24eb9",
+      "ConcordiaCourseId": "013859"
+    },
+    {
+      "Id": "8218cb0b-dda8-4d5e-9f09-a35c3cd18a03",
+      "ConcordiaCourseId": "013860"
+    },
+    {
+      "Id": "e431d66e-d280-4728-bd49-0d2230c72bdc",
+      "ConcordiaCourseId": "013861"
+    },
+    {
+      "Id": "13715729-9010-4e7b-939c-d604cf83a834",
+      "ConcordiaCourseId": "013862"
+    },
+    {
+      "Id": "beedb1f1-fa6d-484b-ad6f-a5b474d7c827",
+      "ConcordiaCourseId": "046769"
+    },
+    {
+      "Id": "61b464f8-f78d-43ff-9703-0823bbc5bcd2",
+      "ConcordiaCourseId": "047282"
+    },
+    {
+      "Id": "1be8b70a-186b-4476-9d0f-cca723ccdffc",
+      "ConcordiaCourseId": "047639"
+    },
+    {
+      "Id": "f69a6b87-d1f3-4404-844a-fe88ca416254",
+      "ConcordiaCourseId": "047684"
+    },
+    {
+      "Id": "e1f28929-5edc-4ef8-9fad-60ef3ca32dfb",
+      "ConcordiaCourseId": "047894"
+    },
+    {
+      "Id": "b8219d25-a72b-4588-bd35-e9acc2d39aeb",
+      "ConcordiaCourseId": "048018"
+    },
+    {
+      "Id": "4d7aefee-5669-4963-adf6-41ad3ba6e938",
+      "ConcordiaCourseId": "048645"
+    },
+    {
+      "Id": "03499155-435e-448f-9d7f-25e919acd0d8",
+      "ConcordiaCourseId": "048741"
+    },
+    {
+      "Id": "2517eef7-0d8e-4cd6-85ab-a4cb524eca61",
+      "ConcordiaCourseId": "048742"
+    },
+    {
+      "Id": "0f0fc4b7-4fee-42c1-b1a5-6973ab4e4605",
+      "ConcordiaCourseId": "048763"
+    },
+    {
+      "Id": "5d8ffb7e-3a25-4859-9bb2-8cf65769ebdf",
+      "ConcordiaCourseId": "049329"
+    },
+    {
+      "Id": "67243666-70f0-44cf-9382-272ed839797b",
+      "ConcordiaCourseId": "049414"
+    },
+    {
+      "Id": "d1a0e48f-671b-4895-8349-6856d6dc8627",
+      "ConcordiaCourseId": "049606"
+    },
+    {
+      "Id": "8837e1bf-3422-49f4-93b4-b3198af90a64",
+      "ConcordiaCourseId": "049607"
+    },
+    {
+      "Id": "77d9821c-e05c-4df7-8c9c-3417e8f86629",
+      "ConcordiaCourseId": "050055"
+    },
+    {
+      "Id": "0a2dcc52-2f4b-4d70-b14b-eaee9319d290",
+      "ConcordiaCourseId": "050191"
+    },
+    {
+      "Id": "6ee7d98c-6709-4a96-9a05-ec66126f193d",
+      "ConcordiaCourseId": "050353"
+    },
+    {
+      "Id": "a11f8289-4140-4f10-af0e-0e5d735ad745",
+      "ConcordiaCourseId": "050800"
+    },
+    {
+      "Id": "62d2c972-f2fd-4b1e-aa01-cac069b8ff8d",
+      "ConcordiaCourseId": "013874"
+    },
+    {
+      "Id": "c55e90f9-ddda-4fbd-9359-e404cd525574",
+      "ConcordiaCourseId": "013917"
+    },
+    {
+      "Id": "cefb5dad-7904-4c16-8cca-6437f46fd301",
+      "ConcordiaCourseId": "013918"
+    },
+    {
+      "Id": "3f276f5b-b6ab-41a1-bae7-4183e8daafc5",
+      "ConcordiaCourseId": "013921"
+    },
+    {
+      "Id": "505a0f2e-81a4-415b-81dc-e9e92c790ab2",
+      "ConcordiaCourseId": "013923"
+    },
+    {
+      "Id": "782e9cd9-17d4-495f-9a3e-46a0fdd0fc67",
+      "ConcordiaCourseId": "013929"
+    },
+    {
+      "Id": "af8257d5-aec4-4969-936b-4f0c2515910a",
+      "ConcordiaCourseId": "013930"
+    },
+    {
+      "Id": "6a54ee42-e229-4a6a-b2a1-9262a94536d6",
+      "ConcordiaCourseId": "013931"
+    },
+    {
+      "Id": "fd06b4b3-d91d-4812-93c6-de4fb3e06c87",
+      "ConcordiaCourseId": "013934"
+    },
+    {
+      "Id": "62b64fbd-8483-4179-8b55-406ef3d942b5",
+      "ConcordiaCourseId": "013936"
+    },
+    {
+      "Id": "28c3bc0c-18ca-44b2-aa52-b5d9efe5c7af",
+      "ConcordiaCourseId": "013937"
+    },
+    {
+      "Id": "a30176c6-cae2-4bfc-918a-b97dda82f34a",
+      "ConcordiaCourseId": "013938"
+    },
+    {
+      "Id": "e419a7c0-cdee-4057-a04f-4e6ec0094797",
+      "ConcordiaCourseId": "013939"
+    },
+    {
+      "Id": "f073df42-a4cc-4ce4-9b0f-e8604ca66604",
+      "ConcordiaCourseId": "013954"
+    },
+    {
+      "Id": "5ac97859-34ee-4064-83c4-b61aa0f0be10",
+      "ConcordiaCourseId": "013958"
+    },
+    {
+      "Id": "b08fdfec-de45-49a4-a103-d3667282c803",
+      "ConcordiaCourseId": "013959"
+    },
+    {
+      "Id": "540f6dc2-694a-46fe-bfdd-a714aa52c4c4",
+      "ConcordiaCourseId": "013962"
+    },
+    {
+      "Id": "b57d1bed-2a32-4686-8919-d321fa0f1523",
+      "ConcordiaCourseId": "013967"
+    },
+    {
+      "Id": "1a73c3ee-9527-4c48-a3d6-6265cac07420",
+      "ConcordiaCourseId": "013968"
+    },
+    {
+      "Id": "07699dad-5af8-463a-b8dc-8ebb64534536",
+      "ConcordiaCourseId": "013969"
+    },
+    {
+      "Id": "0dfc7c38-131e-4b12-86d8-8be2f5f18c01",
+      "ConcordiaCourseId": "013970"
+    },
+    {
+      "Id": "c4659b2d-245b-44e4-bee5-d9505f64fde4",
+      "ConcordiaCourseId": "013979"
+    },
+    {
+      "Id": "139972fd-c77c-46e2-8781-2e522b8d3cd7",
+      "ConcordiaCourseId": "013980"
+    },
+    {
+      "Id": "001935e9-4474-475c-81a8-87881f4bd3fb",
+      "ConcordiaCourseId": "013983"
+    },
+    {
+      "Id": "5bb1996e-14b7-4a6f-8f88-8171bd229dfc",
+      "ConcordiaCourseId": "013984"
+    },
+    {
+      "Id": "fdb06cb8-665a-48cd-98be-170bac064ff7",
+      "ConcordiaCourseId": "014011"
+    },
+    {
+      "Id": "1299302b-0d50-4c2a-a711-ba9ae6c11294",
+      "ConcordiaCourseId": "014013"
+    },
+    {
+      "Id": "882d5c3c-c46d-4eb3-9845-a81ea2064a5c",
+      "ConcordiaCourseId": "014016"
+    },
+    {
+      "Id": "c6eec795-6842-461e-84b9-23f7b8863025",
+      "ConcordiaCourseId": "014021"
+    },
+    {
+      "Id": "e0d82b24-efe4-40f4-8dfa-a6e067ace5af",
+      "ConcordiaCourseId": "014024"
+    },
+    {
+      "Id": "339432d2-bd22-4c77-bc97-dbdfad865f26",
+      "ConcordiaCourseId": "014029"
+    },
+    {
+      "Id": "a87ed501-dba9-4915-848d-391d7a96c031",
+      "ConcordiaCourseId": "014036"
+    },
+    {
+      "Id": "b569054f-d272-46d3-b7ed-e141c0951b8b",
+      "ConcordiaCourseId": "014038"
+    },
+    {
+      "Id": "9de338d3-e103-485b-9497-6d75adbc085f",
+      "ConcordiaCourseId": "014040"
+    },
+    {
+      "Id": "9a836c3f-09ff-4e22-af29-ce0504ce5515",
+      "ConcordiaCourseId": "014044"
+    },
+    {
+      "Id": "7654fe76-d58e-41ad-83fb-76aec8855f3c",
+      "ConcordiaCourseId": "014049"
+    },
+    {
+      "Id": "de160028-21fe-4fd1-b76d-87a165f477c4",
+      "ConcordiaCourseId": "014053"
+    },
+    {
+      "Id": "8354ee41-1f93-480b-b495-03bc121f4404",
+      "ConcordiaCourseId": "014063"
+    },
+    {
+      "Id": "a188c0ac-577e-4ac5-a6ac-593862470725",
+      "ConcordiaCourseId": "014070"
+    },
+    {
+      "Id": "50f1ee02-d2e7-406d-92eb-c70c1903c472",
+      "ConcordiaCourseId": "014074"
+    },
+    {
+      "Id": "b397718a-dc8d-402f-8f1e-760080f441e3",
+      "ConcordiaCourseId": "014077"
+    },
+    {
+      "Id": "16f28b76-8b24-4030-b5d2-6cc6aec9c370",
+      "ConcordiaCourseId": "014081"
+    },
+    {
+      "Id": "34d20aa7-f84f-4f5b-a0ed-ff2a76dda32f",
+      "ConcordiaCourseId": "014082"
+    },
+    {
+      "Id": "c6c42305-2728-4dae-9345-a14806bc922f",
+      "ConcordiaCourseId": "014083"
+    },
+    {
+      "Id": "d5793a83-2c5e-41b0-8180-e0c37edd8362",
+      "ConcordiaCourseId": "014088"
+    },
+    {
+      "Id": "493e18bf-273c-43fe-9ec7-0213c2e703c5",
+      "ConcordiaCourseId": "014091"
+    },
+    {
+      "Id": "800c1975-cc99-494d-87ca-73707f88b231",
+      "ConcordiaCourseId": "014094"
+    },
+    {
+      "Id": "16cd0d0e-56a2-4e53-b504-a18f667db7e9",
+      "ConcordiaCourseId": "014095"
+    },
+    {
+      "Id": "16d32d21-8deb-42f0-8f43-d59f1da3e268",
+      "ConcordiaCourseId": "014096"
+    },
+    {
+      "Id": "ffb4d38d-c877-45c6-90ee-78da09dfa7a0",
+      "ConcordiaCourseId": "014098"
+    },
+    {
+      "Id": "22b13a3c-75b3-4e71-aea5-af702a2f0aec",
+      "ConcordiaCourseId": "014100"
+    },
+    {
+      "Id": "f97e754f-79b1-4c50-86fa-91a24a6bc0bc",
+      "ConcordiaCourseId": "014101"
+    },
+    {
+      "Id": "edf9e8f9-2042-4017-9829-afed4862cbea",
+      "ConcordiaCourseId": "014103"
+    },
+    {
+      "Id": "bc7faac4-4e8b-42ba-ba0f-937b91dc9861",
+      "ConcordiaCourseId": "014107"
+    },
+    {
+      "Id": "53d86e32-c968-4110-bd01-9d221cc3fb7c",
+      "ConcordiaCourseId": "014109"
+    },
+    {
+      "Id": "d647c4ac-e17d-45b3-b395-378fb6c92828",
+      "ConcordiaCourseId": "014111"
+    },
+    {
+      "Id": "f2a3a5d1-111e-4021-a853-ca12228b2035",
+      "ConcordiaCourseId": "014113"
+    },
+    {
+      "Id": "c48f570f-9ae4-4c04-8506-1f24f7f35adc",
+      "ConcordiaCourseId": "014115"
+    },
+    {
+      "Id": "60aa5af2-74a5-46c6-a588-d69c78f826a3",
+      "ConcordiaCourseId": "014120"
+    },
+    {
+      "Id": "a79678e5-ee31-4b8a-a294-76b7be08fafb",
+      "ConcordiaCourseId": "014121"
+    },
+    {
+      "Id": "ab9e1d1b-4feb-41f7-85d5-1bb56f4fd89c",
+      "ConcordiaCourseId": "014124"
+    },
+    {
+      "Id": "6b2b3ce9-c904-47e5-a804-047e901b3122",
+      "ConcordiaCourseId": "014125"
+    },
+    {
+      "Id": "5cfd149c-0988-4ff9-851f-7a37dcf7104a",
+      "ConcordiaCourseId": "014128"
+    },
+    {
+      "Id": "84bc3d85-5e3f-4a16-81bb-30dd3d1c7d67",
+      "ConcordiaCourseId": "014129"
+    },
+    {
+      "Id": "c45065dd-9473-4adf-bb84-8eb1c5e24710",
+      "ConcordiaCourseId": "014131"
+    },
+    {
+      "Id": "1b07829d-c701-4c73-b0d4-4bccceb82bee",
+      "ConcordiaCourseId": "014132"
+    },
+    {
+      "Id": "feaeced4-4042-4756-80a0-7170491ed401",
+      "ConcordiaCourseId": "014134"
+    },
+    {
+      "Id": "338404d3-54cf-452e-ba3a-85b51e8b9daa",
+      "ConcordiaCourseId": "014135"
+    },
+    {
+      "Id": "f057b5b8-b5d0-4eca-ac9e-415ad55dd2a1",
+      "ConcordiaCourseId": "014137"
+    },
+    {
+      "Id": "320d8fb4-eaa7-4813-9ea7-d90ac88594a9",
+      "ConcordiaCourseId": "014140"
+    },
+    {
+      "Id": "083c189c-34fa-493a-9191-0f5aa58908ac",
+      "ConcordiaCourseId": "014145"
+    },
+    {
+      "Id": "c8354187-c1e3-44da-9452-7f670f7c8625",
+      "ConcordiaCourseId": "014146"
+    },
+    {
+      "Id": "983d4398-288c-4c5e-b7ba-db2e2cfb1d5d",
+      "ConcordiaCourseId": "014148"
+    },
+    {
+      "Id": "eea60c59-556f-46fd-94ce-7f8bc86cce0d",
+      "ConcordiaCourseId": "014149"
+    },
+    {
+      "Id": "493ecdb1-46ec-42ab-80f7-99f05d5caace",
+      "ConcordiaCourseId": "014150"
+    },
+    {
+      "Id": "db0360bd-7770-42fd-b7d8-e17f9bf621f0",
+      "ConcordiaCourseId": "014152"
+    },
+    {
+      "Id": "d5c3438b-0967-48be-9cce-fc1ec223c48b",
+      "ConcordiaCourseId": "014153"
+    },
+    {
+      "Id": "534191eb-d619-489a-9f37-f267f17236e5",
+      "ConcordiaCourseId": "014156"
+    },
+    {
+      "Id": "759eeb1e-e9e4-417b-9e25-ad390bbed97e",
+      "ConcordiaCourseId": "014157"
+    },
+    {
+      "Id": "b135c36e-99cc-4879-9ccc-374c99942f72",
+      "ConcordiaCourseId": "014159"
+    },
+    {
+      "Id": "e387b7d0-cf8a-44d7-ac31-587467f072e7",
+      "ConcordiaCourseId": "014160"
+    },
+    {
+      "Id": "b356effb-cad5-4950-bd99-466e6d588bd2",
+      "ConcordiaCourseId": "014161"
+    },
+    {
+      "Id": "965488e3-e9fd-4309-96bb-59ef5208c493",
+      "ConcordiaCourseId": "014162"
+    },
+    {
+      "Id": "a27d874c-0b89-489c-8f52-f66ecd9b8e15",
+      "ConcordiaCourseId": "014164"
+    },
+    {
+      "Id": "1cbdcb29-1a25-4501-ab6b-f351fbd28bd5",
+      "ConcordiaCourseId": "014166"
+    },
+    {
+      "Id": "75b70cff-fe98-451b-9734-9690581abf3a",
+      "ConcordiaCourseId": "014167"
+    },
+    {
+      "Id": "be49b10b-e78d-41fe-a4c9-c1b3a6e0d1a7",
+      "ConcordiaCourseId": "014168"
+    },
+    {
+      "Id": "a84ce43a-1e9d-477b-9b39-82134512d02d",
+      "ConcordiaCourseId": "014169"
+    },
+    {
+      "Id": "2cdd08f7-d1f6-4048-96cc-13667d54b850",
+      "ConcordiaCourseId": "014181"
+    },
+    {
+      "Id": "78f0a6ad-00e7-47c1-8160-99d369dc78f9",
+      "ConcordiaCourseId": "014195"
+    },
+    {
+      "Id": "d76bcde8-4b2a-433a-975c-4d2717897da4",
+      "ConcordiaCourseId": "014201"
+    },
+    {
+      "Id": "309f2d8b-7cd6-4d8d-b086-2284c066847c",
+      "ConcordiaCourseId": "014204"
+    },
+    {
+      "Id": "1fa79064-67db-482a-9a37-b165a3a6a787",
+      "ConcordiaCourseId": "014216"
+    },
+    {
+      "Id": "da9007cc-32f0-473a-8ef5-98f26df1c058",
+      "ConcordiaCourseId": "014250"
+    },
+    {
+      "Id": "662b3549-d742-4b91-8b32-9957c5474d9b",
+      "ConcordiaCourseId": "014252"
+    },
+    {
+      "Id": "569df10d-7039-4de8-922b-fca6c92b1a57",
+      "ConcordiaCourseId": "014263"
+    },
+    {
+      "Id": "a48ffa15-5d6d-4921-97a4-6f0c759f3ea0",
+      "ConcordiaCourseId": "014265"
+    },
+    {
+      "Id": "558b8315-7dae-4bf4-94fe-d9d5f18825b6",
+      "ConcordiaCourseId": "014285"
+    },
+    {
+      "Id": "bee2ae94-6926-45ca-a7bd-a4845d6a66c4",
+      "ConcordiaCourseId": "014297"
+    },
+    {
+      "Id": "9f5f84ed-6c0c-45bc-bbbb-5af9c668bf13",
+      "ConcordiaCourseId": "014303"
+    },
+    {
+      "Id": "8c501d00-ee21-425e-9699-3286e5f6bbcc",
+      "ConcordiaCourseId": "014329"
+    },
+    {
+      "Id": "1c5a837d-c181-4631-a4d7-8f48570a7954",
+      "ConcordiaCourseId": "014336"
+    },
+    {
+      "Id": "a61b0a1d-043b-4b76-afd5-978a6def5c20",
+      "ConcordiaCourseId": "014340"
+    },
+    {
+      "Id": "df912176-3061-496d-8ca3-02624c70ab22",
+      "ConcordiaCourseId": "014354"
+    },
+    {
+      "Id": "2b4fdfc4-9db3-48fc-b7a1-ed9ef208c2db",
+      "ConcordiaCourseId": "014361"
+    },
+    {
+      "Id": "0e237275-a721-402f-87df-2d2bcc882a92",
+      "ConcordiaCourseId": "014363"
+    },
+    {
+      "Id": "dc73cdc3-c9b9-4374-a2d2-31cf141d3f10",
+      "ConcordiaCourseId": "014367"
+    },
+    {
+      "Id": "76c1992d-a6fe-4064-aab2-53e5d97ee44c",
+      "ConcordiaCourseId": "014370"
+    },
+    {
+      "Id": "6be159d5-a1d1-4a83-9155-a50eb3480e52",
+      "ConcordiaCourseId": "014377"
+    },
+    {
+      "Id": "d0d3bec6-425a-4194-802c-8c02eecdbb99",
+      "ConcordiaCourseId": "014382"
+    },
+    {
+      "Id": "0985125b-f5df-4265-9bcf-231c8a720c88",
+      "ConcordiaCourseId": "014384"
+    },
+    {
+      "Id": "c3731800-7cad-44be-9376-b34652393d33",
+      "ConcordiaCourseId": "014397"
+    },
+    {
+      "Id": "1758e645-4921-4057-bd46-78d054882dd8",
+      "ConcordiaCourseId": "014455"
+    },
+    {
+      "Id": "ec015be7-f48a-491c-b866-f6c800e499bf",
+      "ConcordiaCourseId": "014456"
+    },
+    {
+      "Id": "91dbcf46-d04e-4575-8ba2-a3e562bd2e8d",
+      "ConcordiaCourseId": "014457"
+    },
+    {
+      "Id": "8533277e-a86e-4d46-acf3-892b85db9a0f",
+      "ConcordiaCourseId": "014458"
+    },
+    {
+      "Id": "a9d3f3cf-1a2a-45b7-a4b6-de3c293e5bec",
+      "ConcordiaCourseId": "014470"
+    },
+    {
+      "Id": "e457badb-8d7e-45c9-9867-22d7932c4738",
+      "ConcordiaCourseId": "014492"
+    },
+    {
+      "Id": "4ba3ab0b-2e1e-4c62-ab4b-564170bba960",
+      "ConcordiaCourseId": "014493"
+    },
+    {
+      "Id": "47d0d807-9d5c-4245-8e07-544e23b983ba",
+      "ConcordiaCourseId": "014500"
+    },
+    {
+      "Id": "08027934-7d57-4177-a721-8671da5e1ed7",
+      "ConcordiaCourseId": "014503"
+    },
+    {
+      "Id": "f3ba71d0-9b3c-4163-8735-cd5bb9049aff",
+      "ConcordiaCourseId": "014511"
+    },
+    {
+      "Id": "9186d782-7c3d-49d5-8d39-6f62d38e7c81",
+      "ConcordiaCourseId": "014515"
+    },
+    {
+      "Id": "6ec58ec0-8ca1-4de9-8354-626757d42d04",
+      "ConcordiaCourseId": "014524"
+    },
+    {
+      "Id": "050bf542-aaf7-453a-83f3-0ff4c25c53c5",
+      "ConcordiaCourseId": "014543"
+    },
+    {
+      "Id": "97f91295-2662-45a0-80f8-88dcc1c364da",
+      "ConcordiaCourseId": "014556"
+    },
+    {
+      "Id": "b77689db-7c51-46c4-9059-c81a9a9a923e",
+      "ConcordiaCourseId": "014570"
+    },
+    {
+      "Id": "100dff71-3615-4aff-9277-664241502589",
+      "ConcordiaCourseId": "014580"
+    },
+    {
+      "Id": "a7734479-607e-44d4-b935-a5d4a759add4",
+      "ConcordiaCourseId": "014590"
+    },
+    {
+      "Id": "058006f6-ca4d-457f-ab99-45af6586ed19",
+      "ConcordiaCourseId": "014594"
+    },
+    {
+      "Id": "1d341605-f666-44b0-91dd-94f765116b3c",
+      "ConcordiaCourseId": "014598"
+    },
+    {
+      "Id": "67859c93-3059-4f98-84c2-4a1d2d328415",
+      "ConcordiaCourseId": "014602"
+    },
+    {
+      "Id": "32629807-3095-45ac-8e62-220f1f267ed5",
+      "ConcordiaCourseId": "014619"
+    },
+    {
+      "Id": "e8f7ce83-50db-4b17-87a6-d2c4ffdb070d",
+      "ConcordiaCourseId": "014620"
+    },
+    {
+      "Id": "bf1a9f2f-1ec2-4f04-b0a8-28c6c8a114e7",
+      "ConcordiaCourseId": "014621"
+    },
+    {
+      "Id": "43b865e3-d1e8-4b38-9ccf-4ba7fb9d2a3d",
+      "ConcordiaCourseId": "022620"
+    },
+    {
+      "Id": "8252a6a9-278d-4036-92c0-b94f959577ea",
+      "ConcordiaCourseId": "040979"
+    },
+    {
+      "Id": "ab3ed211-d14a-4fe6-9304-f0224d73d6ca",
+      "ConcordiaCourseId": "040980"
+    },
+    {
+      "Id": "51a43763-4ff2-44fe-bab2-eb6170acb9e3",
+      "ConcordiaCourseId": "040982"
+    },
+    {
+      "Id": "3e839a34-1a20-4635-a122-68c53c066120",
+      "ConcordiaCourseId": "040984"
+    },
+    {
+      "Id": "2023be48-6e4c-4de6-907c-74d9251a4cec",
+      "ConcordiaCourseId": "040985"
+    },
+    {
+      "Id": "cc8e8e97-f512-442d-9269-93c79a3a1996",
+      "ConcordiaCourseId": "040986"
+    },
+    {
+      "Id": "be5d4f2a-844e-4436-89fe-acba6d441e7d",
+      "ConcordiaCourseId": "040987"
+    },
+    {
+      "Id": "d8fa90a4-6630-4aa5-869d-f78655d6c097",
+      "ConcordiaCourseId": "040989"
+    },
+    {
+      "Id": "71827108-60da-4397-ae20-626c9c25d5b1",
+      "ConcordiaCourseId": "040990"
+    },
+    {
+      "Id": "660bda51-9b56-4dd7-8b29-03268d7f3234",
+      "ConcordiaCourseId": "040994"
+    },
+    {
+      "Id": "530da300-7c34-4cdb-838d-23e6e74d841e",
+      "ConcordiaCourseId": "041050"
+    },
+    {
+      "Id": "746a9538-e7fa-4cec-b7a6-19b229f8d1ae",
+      "ConcordiaCourseId": "041069"
+    },
+    {
+      "Id": "4474938e-c224-4fc5-bcaa-9a678f25d66d",
+      "ConcordiaCourseId": "044052"
+    },
+    {
+      "Id": "7b74e6c5-34eb-429f-bbc8-e5a0491f1a25",
+      "ConcordiaCourseId": "045106"
+    },
+    {
+      "Id": "f777cf02-b6f1-4433-a08c-f90aee129167",
+      "ConcordiaCourseId": "045466"
+    },
+    {
+      "Id": "3bca2032-40e8-4060-9114-ce0350afa168",
+      "ConcordiaCourseId": "046105"
+    },
+    {
+      "Id": "1749bec2-2616-435b-a6b8-34489e7c018d",
+      "ConcordiaCourseId": "046770"
+    },
+    {
+      "Id": "6bfd64a7-0955-42a7-b400-3a0c1b35a4a5",
+      "ConcordiaCourseId": "046771"
+    },
+    {
+      "Id": "0d787106-a813-4be6-9953-c65dfb1c468a",
+      "ConcordiaCourseId": "046772"
+    },
+    {
+      "Id": "6cfa3270-0f68-4577-b342-39cd1c10439c",
+      "ConcordiaCourseId": "046773"
+    },
+    {
+      "Id": "9a28e4f3-8de3-44c4-81b0-d561530dd18e",
+      "ConcordiaCourseId": "046774"
+    },
+    {
+      "Id": "4546a6f3-e215-404c-8e5c-0faf1e064425",
+      "ConcordiaCourseId": "046775"
+    },
+    {
+      "Id": "529b1245-4649-4347-8576-03b56b88afc4",
+      "ConcordiaCourseId": "046776"
+    },
+    {
+      "Id": "64d5be5e-1706-4075-a170-2eaec32f0bf2",
+      "ConcordiaCourseId": "046777"
+    },
+    {
+      "Id": "fa22a68c-b4cb-47fc-a9c8-d86b38a437cb",
+      "ConcordiaCourseId": "046778"
+    },
+    {
+      "Id": "cb289b0a-3599-438d-b88a-5eff26d91de7",
+      "ConcordiaCourseId": "046779"
+    },
+    {
+      "Id": "bd10c512-54a6-4db1-93ab-25cfedec6cb6",
+      "ConcordiaCourseId": "046780"
+    },
+    {
+      "Id": "dcc9c56c-5b97-4dfe-a7a7-e03aa5682613",
+      "ConcordiaCourseId": "046781"
+    },
+    {
+      "Id": "dfff61cd-4c22-45a6-8da9-88df3cc50705",
+      "ConcordiaCourseId": "046782"
+    },
+    {
+      "Id": "b9d3aa96-e9b7-45a2-b2f2-ab9c20b013b1",
+      "ConcordiaCourseId": "046783"
+    },
+    {
+      "Id": "8eb1a046-ec3a-490f-b083-2306d12780d9",
+      "ConcordiaCourseId": "046784"
+    },
+    {
+      "Id": "d6a49c2f-8395-46c9-9aa7-49f9307bb8d3",
+      "ConcordiaCourseId": "046785"
+    },
+    {
+      "Id": "2b0d8c65-b13d-4904-804a-567d5873ff31",
+      "ConcordiaCourseId": "046786"
+    },
+    {
+      "Id": "0285da29-cacb-4c8c-9196-8b1d2f8606ed",
+      "ConcordiaCourseId": "046787"
+    },
+    {
+      "Id": "e966f117-fdcf-45d3-bf33-f23e9489a466",
+      "ConcordiaCourseId": "046788"
+    },
+    {
+      "Id": "3d97a3ec-7a89-42a7-b490-62d468f0cf6b",
+      "ConcordiaCourseId": "046789"
+    },
+    {
+      "Id": "52019d9d-0610-4e1b-a50b-520e43d17606",
+      "ConcordiaCourseId": "046790"
+    },
+    {
+      "Id": "7b2955ba-c9e5-4d72-a08d-3353c5bcc598",
+      "ConcordiaCourseId": "046791"
+    },
+    {
+      "Id": "1730f7bb-2a2a-47b9-8086-e244d9275980",
+      "ConcordiaCourseId": "046792"
+    },
+    {
+      "Id": "306d67b1-a55f-4a65-a593-2ce302a445fa",
+      "ConcordiaCourseId": "047241"
+    },
+    {
+      "Id": "4cc85661-ead7-4049-8c4a-123f12b86c18",
+      "ConcordiaCourseId": "047302"
+    },
+    {
+      "Id": "2925102f-f383-43fd-8794-938f79c06518",
+      "ConcordiaCourseId": "047303"
+    },
+    {
+      "Id": "efa9f86e-769e-47df-b505-8f4d5f97e09b",
+      "ConcordiaCourseId": "047304"
+    },
+    {
+      "Id": "ee209808-170f-4461-b3a4-fc350bff0519",
+      "ConcordiaCourseId": "047306"
+    },
+    {
+      "Id": "5a36ff98-6bda-421e-841b-b493d5406997",
+      "ConcordiaCourseId": "047630"
+    },
+    {
+      "Id": "d90e16b4-d0ba-4796-ae49-75c0aa256111",
+      "ConcordiaCourseId": "049242"
+    },
+    {
+      "Id": "e1f9d2d2-d19b-496e-9d16-0db12adeed8f",
+      "ConcordiaCourseId": "047296"
+    },
+    {
+      "Id": "e0dd1aed-573b-4a84-b76b-0ad37abbeadd",
+      "ConcordiaCourseId": "047297"
+    },
+    {
+      "Id": "a39887e3-910e-4ed3-8f8f-d5fb8d37c4a8",
+      "ConcordiaCourseId": "047298"
+    },
+    {
+      "Id": "1147c95a-2e7a-41b6-9327-d92e0916aeab",
+      "ConcordiaCourseId": "047299"
+    },
+    {
+      "Id": "ffdc9f26-6221-4c4e-a431-2823a8ad7301",
+      "ConcordiaCourseId": "047300"
+    },
+    {
+      "Id": "eb815f3e-b045-4442-b695-6c5e89c2df6f",
+      "ConcordiaCourseId": "047301"
+    },
+    {
+      "Id": "1183ff62-fddf-4a36-88ed-63a23d127e5a",
+      "ConcordiaCourseId": "047877"
+    },
+    {
+      "Id": "1edcb9e0-154e-4cd4-b2dc-c52409f818bd",
+      "ConcordiaCourseId": "047878"
+    },
+    {
+      "Id": "710aeceb-564a-4569-8744-379a1c20be33",
+      "ConcordiaCourseId": "047879"
+    },
+    {
+      "Id": "f28f14d0-f5ec-4efc-b0ee-e4d9195f8fa5",
+      "ConcordiaCourseId": "048399"
+    },
+    {
+      "Id": "2a7a5a13-fae8-442e-9e45-df0f0d82ba29",
+      "ConcordiaCourseId": "048848"
+    },
+    {
+      "Id": "10dfb870-66f1-44bd-afc3-758648962357",
+      "ConcordiaCourseId": "049241"
+    },
+    {
+      "Id": "1ab2a739-bdb4-46f6-b308-e6036e3373b7",
+      "ConcordiaCourseId": "049659"
+    },
+    {
+      "Id": "a46ef53d-8cc2-4a48-be5c-ba72fd33e8be",
+      "ConcordiaCourseId": "046793"
+    },
+    {
+      "Id": "c0c22bd2-a6bc-4cd4-b238-1b92ebea81fb",
+      "ConcordiaCourseId": "014929"
+    },
+    {
+      "Id": "19af6dcf-117f-4058-87ca-0885f99ec48a",
+      "ConcordiaCourseId": "014931"
+    },
+    {
+      "Id": "f0830dee-99e8-4621-8c6e-83c32cd4202b",
+      "ConcordiaCourseId": "014933"
+    },
+    {
+      "Id": "5089234b-5de9-4709-a3c0-142aa301f3e0",
+      "ConcordiaCourseId": "014935"
+    },
+    {
+      "Id": "ed511bab-c0e8-409f-8126-6a8429401355",
+      "ConcordiaCourseId": "014937"
+    },
+    {
+      "Id": "c01e5bd8-8430-4dbe-8d73-68d1944bc34a",
+      "ConcordiaCourseId": "014939"
+    },
+    {
+      "Id": "c5c1ad45-1c46-48ba-a587-19f9f8ec150f",
+      "ConcordiaCourseId": "014941"
+    },
+    {
+      "Id": "7f1ae6c4-d43a-4557-8fa3-525b2a6c4e0a",
+      "ConcordiaCourseId": "014943"
+    },
+    {
+      "Id": "8619afe7-42a8-459c-8063-068fc89de9b8",
+      "ConcordiaCourseId": "014945"
+    },
+    {
+      "Id": "be3f066f-babd-4119-b3b6-2ab1a1d2cde0",
+      "ConcordiaCourseId": "014948"
+    },
+    {
+      "Id": "58c201b2-2b03-48f9-a8f0-6dd31287cc66",
+      "ConcordiaCourseId": "014950"
+    },
+    {
+      "Id": "ab755f86-5d4a-430a-b099-2f8a2d2ace08",
+      "ConcordiaCourseId": "014952"
+    },
+    {
+      "Id": "bb7e0e81-643b-4cda-9427-8c3c96131fc2",
+      "ConcordiaCourseId": "014954"
+    },
+    {
+      "Id": "d3af6e71-1b1a-412d-91f1-775755104c98",
+      "ConcordiaCourseId": "014956"
+    },
+    {
+      "Id": "567070c7-45fa-458b-8dc3-9b6f7fc6a63c",
+      "ConcordiaCourseId": "014968"
+    },
+    {
+      "Id": "cf66415f-0a25-464b-85c0-89ba684bbf04",
+      "ConcordiaCourseId": "014970"
+    },
+    {
+      "Id": "bb3bbb69-d57a-485a-a285-bfe68901ebd6",
+      "ConcordiaCourseId": "014982"
+    },
+    {
+      "Id": "f7422cab-d122-4482-9d6a-33017b316175",
+      "ConcordiaCourseId": "014985"
+    },
+    {
+      "Id": "cdd6d252-9547-4de6-ac9c-3acea31e5892",
+      "ConcordiaCourseId": "014988"
+    },
+    {
+      "Id": "aa52a483-cd8b-4d70-ae77-f2af2801ab01",
+      "ConcordiaCourseId": "014991"
+    },
+    {
+      "Id": "e3ffe3ff-7868-407a-87a2-7141a74718d1",
+      "ConcordiaCourseId": "014993"
+    },
+    {
+      "Id": "c091daeb-11cb-42c4-90fe-930f20206275",
+      "ConcordiaCourseId": "014995"
+    },
+    {
+      "Id": "92204135-c702-43de-a419-20aa9683af9f",
+      "ConcordiaCourseId": "015010"
+    },
+    {
+      "Id": "e341a3b0-1fa6-469d-a9f2-2a6ffa31abd7",
+      "ConcordiaCourseId": "015025"
+    },
+    {
+      "Id": "66c38969-7c09-4e48-863c-e9bb7f606cda",
+      "ConcordiaCourseId": "015040"
+    },
+    {
+      "Id": "c67c1d46-8ddd-41da-badc-2d286975a0b4",
+      "ConcordiaCourseId": "015055"
+    },
+    {
+      "Id": "bd079f85-cf6a-41e5-ab37-14859294cf84",
+      "ConcordiaCourseId": "015070"
+    },
+    {
+      "Id": "ab2779db-654c-4a74-bc39-368c4e4ac6b0",
+      "ConcordiaCourseId": "015085"
+    },
+    {
+      "Id": "eac23d1d-b86d-449e-bf63-1b0bcc5662f6",
+      "ConcordiaCourseId": "015100"
+    },
+    {
+      "Id": "0098f8fc-059f-458e-8aba-2c1fd5787bd1",
+      "ConcordiaCourseId": "015115"
+    },
+    {
+      "Id": "f5f71ff4-5657-4057-890d-334e5795a97e",
+      "ConcordiaCourseId": "015130"
+    },
+    {
+      "Id": "cfdd9075-6de7-45a1-8ee5-70cac89a21c1",
+      "ConcordiaCourseId": "015145"
+    },
+    {
+      "Id": "6d6f60cc-f123-48fd-9c2e-116f7cdeaffc",
+      "ConcordiaCourseId": "015159"
+    },
+    {
+      "Id": "529eb5fc-2796-4751-a7d4-5d8f26001441",
+      "ConcordiaCourseId": "015174"
+    },
+    {
+      "Id": "650076c2-61a1-4ed7-8c28-3daf9e67f585",
+      "ConcordiaCourseId": "015189"
+    },
+    {
+      "Id": "d6f7793f-cc1c-43d4-a35f-45b9cdea2b40",
+      "ConcordiaCourseId": "015204"
+    },
+    {
+      "Id": "6a57bdb9-7565-41d6-91f7-7a1da31dc999",
+      "ConcordiaCourseId": "015219"
+    },
+    {
+      "Id": "eb8e4755-748b-4dd0-90d8-057a721ae483",
+      "ConcordiaCourseId": "015234"
+    },
+    {
+      "Id": "99e92dc9-a8b9-432f-a320-1c12ac791b42",
+      "ConcordiaCourseId": "015249"
+    },
+    {
+      "Id": "6141e9d3-8c98-4cbf-be01-52fda0f28507",
+      "ConcordiaCourseId": "015263"
+    },
+    {
+      "Id": "f781a93d-f146-41ed-949a-8144ea087922",
+      "ConcordiaCourseId": "015278"
+    },
+    {
+      "Id": "970db776-11e9-4c62-9422-353f9d7af829",
+      "ConcordiaCourseId": "015293"
+    },
+    {
+      "Id": "bfb4f560-0c3a-4f8c-b5e3-0551fab2e42b",
+      "ConcordiaCourseId": "015307"
+    },
+    {
+      "Id": "7af11d69-1aee-4964-a76d-38adfd9bcd15",
+      "ConcordiaCourseId": "015322"
+    },
+    {
+      "Id": "3625b15f-b992-4b96-8824-08ef012ad0c9",
+      "ConcordiaCourseId": "015336"
+    },
+    {
+      "Id": "8d272e50-ae93-41ff-b017-a3a560cc5111",
+      "ConcordiaCourseId": "015350"
+    },
+    {
+      "Id": "48e27ab2-6aeb-4b6b-a242-6395ecf5f53f",
+      "ConcordiaCourseId": "015365"
+    },
+    {
+      "Id": "dddcfd5b-60ac-40f6-8ebc-d867ed3cee6b",
+      "ConcordiaCourseId": "015380"
+    },
+    {
+      "Id": "e2121c4f-e541-4266-aae0-43ada7cb8bfd",
+      "ConcordiaCourseId": "015395"
+    },
+    {
+      "Id": "34ad9b85-bd49-4996-b2c7-040eba48986e",
+      "ConcordiaCourseId": "015410"
+    },
+    {
+      "Id": "62d554fd-34d0-451a-a75a-1d6bfb77c687",
+      "ConcordiaCourseId": "015424"
+    },
+    {
+      "Id": "bd832cbe-17f2-4ea5-96ce-df5f30d1c24c",
+      "ConcordiaCourseId": "015437"
+    },
+    {
+      "Id": "c08f5322-33ba-4672-b8ee-d5b85685b341",
+      "ConcordiaCourseId": "015450"
+    },
+    {
+      "Id": "119f3d00-1686-4b7b-8d82-6bcbca10fa8b",
+      "ConcordiaCourseId": "015463"
+    },
+    {
+      "Id": "a42c96b9-e007-4b36-a1e9-316dd76bdcd6",
+      "ConcordiaCourseId": "015475"
+    },
+    {
+      "Id": "79e16ce0-a3d9-45d7-b63b-dc8c9d254a7e",
+      "ConcordiaCourseId": "015488"
+    },
+    {
+      "Id": "02ebd641-9c65-4b6d-afec-b538e8a117a2",
+      "ConcordiaCourseId": "015501"
+    },
+    {
+      "Id": "457ade7e-3c23-4692-864c-dbf1360c03c7",
+      "ConcordiaCourseId": "015515"
+    },
+    {
+      "Id": "8124b67d-a6f8-440e-a42f-42032ea81c8c",
+      "ConcordiaCourseId": "015528"
+    },
+    {
+      "Id": "7a441048-8b63-40ee-a2fd-b7f76ac6eef3",
+      "ConcordiaCourseId": "015542"
+    },
+    {
+      "Id": "479d1421-12bc-421c-aa4a-72d56dcd0c1c",
+      "ConcordiaCourseId": "015555"
+    },
+    {
+      "Id": "bc37602a-01b0-4604-a934-244c87bd4463",
+      "ConcordiaCourseId": "015569"
+    },
+    {
+      "Id": "493ea24a-d86b-48e6-a7ff-5b6a6c6cdd0a",
+      "ConcordiaCourseId": "015581"
+    },
+    {
+      "Id": "56f260e4-3645-4928-85cc-6f7d7d345a4f",
+      "ConcordiaCourseId": "015595"
+    },
+    {
+      "Id": "44a2492b-86a5-46ae-9365-cb4a4e5c7512",
+      "ConcordiaCourseId": "015609"
+    },
+    {
+      "Id": "3b9de7e6-a3e3-408f-9b4d-ac426aa38ea1",
+      "ConcordiaCourseId": "015622"
+    },
+    {
+      "Id": "181c8351-5b35-4af0-a125-7e86d080b55f",
+      "ConcordiaCourseId": "015634"
+    },
+    {
+      "Id": "fac087ff-2702-4d61-8f12-cae2f12e0bb3",
+      "ConcordiaCourseId": "015646"
+    },
+    {
+      "Id": "99cc669d-7a77-4151-b2c2-74c771dc2498",
+      "ConcordiaCourseId": "015658"
+    },
+    {
+      "Id": "7836cfab-34c4-40d0-82fb-082961d9f14f",
+      "ConcordiaCourseId": "015670"
+    },
+    {
+      "Id": "11561f5f-448e-46a3-9240-a430bc6d05a1",
+      "ConcordiaCourseId": "015682"
+    },
+    {
+      "Id": "f8202329-e95d-4be1-a53b-ee77bc468138",
+      "ConcordiaCourseId": "015694"
+    },
+    {
+      "Id": "8946e74f-2e33-4645-85f1-6c36ba2cab05",
+      "ConcordiaCourseId": "015706"
+    },
+    {
+      "Id": "88e3f658-3d8d-4604-9f01-4540df6f31f2",
+      "ConcordiaCourseId": "015718"
+    },
+    {
+      "Id": "270ee6ac-9559-4d68-b5ff-fc66bff14b6f",
+      "ConcordiaCourseId": "015729"
+    },
+    {
+      "Id": "f5fa6797-2a61-43a1-8dba-a9d8739c4b4b",
+      "ConcordiaCourseId": "015740"
+    },
+    {
+      "Id": "4a8c22d6-e718-4b1c-a700-9fa1129058f8",
+      "ConcordiaCourseId": "015752"
+    },
+    {
+      "Id": "ae7b68a9-b209-4891-a11f-21cd7f3e305c",
+      "ConcordiaCourseId": "015756"
+    },
+    {
+      "Id": "3a302e37-6146-4854-bcc8-59247e778690",
+      "ConcordiaCourseId": "015758"
+    },
+    {
+      "Id": "3333f4a6-1f2e-4116-8569-837e4ff707c7",
+      "ConcordiaCourseId": "015760"
+    },
+    {
+      "Id": "0a73a50b-e92f-4c64-b12d-252622684923",
+      "ConcordiaCourseId": "015762"
+    },
+    {
+      "Id": "d9dc0b6b-0b8d-492b-acea-0dd5a3f34f29",
+      "ConcordiaCourseId": "015764"
+    },
+    {
+      "Id": "ea176f7f-de9c-4546-83c3-319e2d3f0e73",
+      "ConcordiaCourseId": "015765"
+    },
+    {
+      "Id": "e627d664-4375-43d8-ab23-2aff5ce64ed6",
+      "ConcordiaCourseId": "046794"
+    },
+    {
+      "Id": "a23ef1cd-162c-4ad5-b6fb-60f780e1840b",
+      "ConcordiaCourseId": "047246"
+    },
+    {
+      "Id": "2452b0d5-799b-41ea-b588-7acaee0d9287",
+      "ConcordiaCourseId": "047278"
+    },
+    {
+      "Id": "1a0cefa8-b2af-40c4-82ae-b6ec1ea693b0",
+      "ConcordiaCourseId": "047414"
+    },
+    {
+      "Id": "e18fedce-eff4-41cf-b335-007624a53741",
+      "ConcordiaCourseId": "047435"
+    },
+    {
+      "Id": "f8b084c7-5d75-46b1-b15d-6fc700620ade",
+      "ConcordiaCourseId": "047436"
+    },
+    {
+      "Id": "d8e4141b-7aeb-40a9-b696-c60a6809ccc1",
+      "ConcordiaCourseId": "047437"
+    },
+    {
+      "Id": "e2bc7e09-3706-4578-838f-c91cfcb2eb6a",
+      "ConcordiaCourseId": "047442"
+    },
+    {
+      "Id": "c47f299f-4e8c-435e-a02e-23febb88b178",
+      "ConcordiaCourseId": "048694"
+    },
+    {
+      "Id": "f126e961-1673-465e-ba52-076931e5325d",
+      "ConcordiaCourseId": "048695"
+    },
+    {
+      "Id": "f79c8e67-937b-41b9-904a-34600350c986",
+      "ConcordiaCourseId": "048696"
+    },
+    {
+      "Id": "be58f285-fa75-4948-8669-b390c583361b",
+      "ConcordiaCourseId": "048697"
+    },
+    {
+      "Id": "bbf9475f-5256-420f-b50d-20bdb516c75e",
+      "ConcordiaCourseId": "015792"
+    },
+    {
+      "Id": "acc37d7f-884c-4e34-9546-82dcef34f9d5",
+      "ConcordiaCourseId": "015793"
+    },
+    {
+      "Id": "bf39d4e2-8d53-4faa-b45b-6c24d574e09a",
+      "ConcordiaCourseId": "023803"
+    },
+    {
+      "Id": "4028ca2e-259b-44a8-bbd9-0262f0024607",
+      "ConcordiaCourseId": "023817"
+    },
+    {
+      "Id": "cfac2033-cd75-4a5e-b8c2-25666dd5345e",
+      "ConcordiaCourseId": "024050"
+    },
+    {
+      "Id": "3f668392-b8ab-49e8-8b10-3e1ba1e5249d",
+      "ConcordiaCourseId": "041326"
+    },
+    {
+      "Id": "bc229266-00e0-4f42-9952-8bf2cbd776eb",
+      "ConcordiaCourseId": "041327"
+    },
+    {
+      "Id": "bef7730c-251c-4acb-aae1-e98ee2a78577",
+      "ConcordiaCourseId": "046795"
+    },
+    {
+      "Id": "fb53c83e-3763-49b3-9fe1-27fa7d3b664c",
+      "ConcordiaCourseId": "046796"
+    },
+    {
+      "Id": "37ff230f-735f-4393-be60-c5bad8379fbb",
+      "ConcordiaCourseId": "046797"
+    },
+    {
+      "Id": "311b162a-eecd-4037-a27e-c8b36bc8a2fe",
+      "ConcordiaCourseId": "050806"
+    },
+    {
+      "Id": "f1875122-2fc5-4978-bd8f-536082ff122d",
+      "ConcordiaCourseId": "050807"
+    },
+    {
+      "Id": "cc431d4b-d2dd-493a-af4c-1911234e0b12",
+      "ConcordiaCourseId": "050808"
+    },
+    {
+      "Id": "e75833c3-29eb-4df6-b91a-ccad9cccca18",
+      "ConcordiaCourseId": "046798"
+    },
+    {
+      "Id": "ac8a6671-ab80-4a0e-92f8-a68aa62dd9ca",
+      "ConcordiaCourseId": "015839"
+    },
+    {
+      "Id": "de2b354f-3fdc-4f4f-a801-ed3caeac2b06",
+      "ConcordiaCourseId": "015840"
+    },
+    {
+      "Id": "ea802bf1-2ed0-4704-a1e0-4c45d3c04670",
+      "ConcordiaCourseId": "015841"
+    },
+    {
+      "Id": "ab69d22e-82cd-47a7-b104-04a159c86028",
+      "ConcordiaCourseId": "015842"
+    },
+    {
+      "Id": "58f63936-39fa-4048-bef6-11ef551a130d",
+      "ConcordiaCourseId": "015843"
+    },
+    {
+      "Id": "d14f2a9e-7800-4b14-a765-d76f79b6e808",
+      "ConcordiaCourseId": "015844"
+    },
+    {
+      "Id": "3863d08f-db3a-4d68-87d4-22091a1b2f4c",
+      "ConcordiaCourseId": "015846"
+    },
+    {
+      "Id": "5d688011-53a9-4ed9-b4d9-d1c6cf8aa241",
+      "ConcordiaCourseId": "015853"
+    },
+    {
+      "Id": "e1d37dca-53d3-4e4d-b33f-35887bcc651e",
+      "ConcordiaCourseId": "015854"
+    },
+    {
+      "Id": "abdd50a0-bd41-47d0-ac9a-3820f20ef158",
+      "ConcordiaCourseId": "015855"
+    },
+    {
+      "Id": "ec48fb09-263b-4680-82cb-e97b87356a16",
+      "ConcordiaCourseId": "015856"
+    },
+    {
+      "Id": "2f298071-c786-429b-adf4-42d184f2944e",
+      "ConcordiaCourseId": "015857"
+    },
+    {
+      "Id": "7c8f1379-c4eb-4845-9bda-37540b08f920",
+      "ConcordiaCourseId": "015858"
+    },
+    {
+      "Id": "a934eebf-807d-408e-9cb5-c88c21fb2c0f",
+      "ConcordiaCourseId": "046799"
+    },
+    {
+      "Id": "f543f62b-dbc7-4e71-a4ce-ca3dab4b70db",
+      "ConcordiaCourseId": "046800"
+    },
+    {
+      "Id": "90165b8e-1ca7-4b12-9f0a-5b63a92e5521",
+      "ConcordiaCourseId": "046801"
+    },
+    {
+      "Id": "4c4ce0a7-5522-4dd2-abe6-a2916194467b",
+      "ConcordiaCourseId": "047384"
+    },
+    {
+      "Id": "ddba5daf-9d0e-42a8-a370-c895719e760c",
+      "ConcordiaCourseId": "047385"
+    },
+    {
+      "Id": "bb2c1b3d-06b2-451c-b330-7c6b8b9f8044",
+      "ConcordiaCourseId": "047386"
+    },
+    {
+      "Id": "d5129868-4349-46d2-a271-2849e2ecc77f",
+      "ConcordiaCourseId": "047387"
+    },
+    {
+      "Id": "5a5a164e-423e-4b1f-a13e-3fac598efe86",
+      "ConcordiaCourseId": "047388"
+    },
+    {
+      "Id": "90388916-affb-466b-896e-b6bf2209ee4d",
+      "ConcordiaCourseId": "047955"
+    },
+    {
+      "Id": "5aad2a66-d734-4f02-85ec-71e1b0863897",
+      "ConcordiaCourseId": "047956"
+    },
+    {
+      "Id": "c5e34df4-8d04-4b0b-8432-b400648fafe9",
+      "ConcordiaCourseId": "047957"
+    },
+    {
+      "Id": "fcda8af9-ab47-4590-b214-20db619aa711",
+      "ConcordiaCourseId": "047958"
+    },
+    {
+      "Id": "0c77d863-04cc-4857-90b0-d836b4f3adce",
+      "ConcordiaCourseId": "050065"
+    },
+    {
+      "Id": "dbf9c15f-a4c5-45bd-9992-723e774a90e6",
+      "ConcordiaCourseId": "015899"
+    },
+    {
+      "Id": "0a1e274f-dbb8-4588-b302-7f447fb40d92",
+      "ConcordiaCourseId": "015907"
+    },
+    {
+      "Id": "5fb33891-f89c-4134-a7fe-ae9fc9fa0668",
+      "ConcordiaCourseId": "015917"
+    },
+    {
+      "Id": "41bb8a73-99a0-49f2-958c-36b5bb9c1450",
+      "ConcordiaCourseId": "015921"
+    },
+    {
+      "Id": "72b04ee5-4d51-4dd2-81d8-d0e7ddd920cc",
+      "ConcordiaCourseId": "015922"
+    },
+    {
+      "Id": "00fdca3c-f188-4cf9-9d63-d3b46deb8554",
+      "ConcordiaCourseId": "015925"
+    },
+    {
+      "Id": "2453280c-96cf-4072-b11b-382ee099e6d9",
+      "ConcordiaCourseId": "015929"
+    },
+    {
+      "Id": "02c944af-e18b-4c6c-92c0-0b4022c91e6e",
+      "ConcordiaCourseId": "015931"
+    },
+    {
+      "Id": "4b76a6ae-f063-4f1b-936c-e8b60e2fedef",
+      "ConcordiaCourseId": "015938"
+    },
+    {
+      "Id": "a33c5404-4130-4db1-9886-343b1e5a5d10",
+      "ConcordiaCourseId": "015940"
+    },
+    {
+      "Id": "e4479fe6-f3b5-4459-83db-d6263c5e18c3",
+      "ConcordiaCourseId": "015950"
+    },
+    {
+      "Id": "b0827496-e109-4199-a784-a6bf3b7493fc",
+      "ConcordiaCourseId": "015963"
+    },
+    {
+      "Id": "0afdfc2c-c248-41cf-ae0f-d084d6c1752c",
+      "ConcordiaCourseId": "015986"
+    },
+    {
+      "Id": "5c000a26-fe01-487a-bb04-baef451c15be",
+      "ConcordiaCourseId": "015991"
+    },
+    {
+      "Id": "bc88c572-2a3d-44d0-ac68-01cb7feba21c",
+      "ConcordiaCourseId": "016011"
+    },
+    {
+      "Id": "b0505394-ba7d-452b-a29e-6200b09a858d",
+      "ConcordiaCourseId": "016040"
+    },
+    {
+      "Id": "7e85f894-9962-4a8f-9d5a-8df6c5ecce48",
+      "ConcordiaCourseId": "041344"
+    },
+    {
+      "Id": "234f38db-9e6a-414f-be1d-0b2b4de8ed73",
+      "ConcordiaCourseId": "041346"
+    },
+    {
+      "Id": "0b892f4b-2a98-4174-85c3-61f8bf51d6a3",
+      "ConcordiaCourseId": "041349"
+    },
+    {
+      "Id": "d80f8656-b136-41a5-a5bf-432aa8cf30bd",
+      "ConcordiaCourseId": "041354"
+    },
+    {
+      "Id": "fd9afb15-ac46-4c49-bf88-71a4d9efe277",
+      "ConcordiaCourseId": "041361"
+    },
+    {
+      "Id": "0f91bf89-401d-4507-b617-1923528e4796",
+      "ConcordiaCourseId": "041370"
+    },
+    {
+      "Id": "57a12ddc-d244-45cd-a097-60f350c7294a",
+      "ConcordiaCourseId": "041375"
+    },
+    {
+      "Id": "40f71b60-5063-4d50-af26-e0a03d3fcd28",
+      "ConcordiaCourseId": "041380"
+    },
+    {
+      "Id": "4e0a735a-6f3e-4dad-927d-43c93ab5458e",
+      "ConcordiaCourseId": "041383"
+    },
+    {
+      "Id": "6d1373f0-2839-429b-b1ad-888e515ec0db",
+      "ConcordiaCourseId": "041386"
+    },
+    {
+      "Id": "00fbb665-557b-448b-ad6d-254e6e76c82e",
+      "ConcordiaCourseId": "041393"
+    },
+    {
+      "Id": "f55a9a1e-f403-42e1-bf49-b38b01753d3d",
+      "ConcordiaCourseId": "041397"
+    },
+    {
+      "Id": "5a9ba308-374d-483e-99b0-24a93928a27d",
+      "ConcordiaCourseId": "041398"
+    },
+    {
+      "Id": "07f8432d-d43b-493b-809d-d2d943208f2e",
+      "ConcordiaCourseId": "041399"
+    },
+    {
+      "Id": "fefff8e6-94a3-4ae4-af84-088b4b0c612e",
+      "ConcordiaCourseId": "041400"
+    },
+    {
+      "Id": "27b8d15e-f7d0-4fe0-bda4-26ad7abdba69",
+      "ConcordiaCourseId": "041401"
+    },
+    {
+      "Id": "b137b73b-d26c-4a26-9220-36bb4a52aa20",
+      "ConcordiaCourseId": "041402"
+    },
+    {
+      "Id": "09781cc0-de46-4f27-be92-4aa31a8d565a",
+      "ConcordiaCourseId": "041403"
+    },
+    {
+      "Id": "1c4a076e-2051-45bc-bc72-d45666eba423",
+      "ConcordiaCourseId": "041407"
+    },
+    {
+      "Id": "8a562326-f814-4103-b781-fe2b8d79e479",
+      "ConcordiaCourseId": "041411"
+    },
+    {
+      "Id": "814535f4-151f-48ca-8a13-4565537ff6eb",
+      "ConcordiaCourseId": "041415"
+    },
+    {
+      "Id": "b2c59a10-8bb6-4ac4-b92e-1b49af797279",
+      "ConcordiaCourseId": "041419"
+    },
+    {
+      "Id": "fbbef1e5-f659-447f-ab43-dbd2b8da4c1b",
+      "ConcordiaCourseId": "041422"
+    },
+    {
+      "Id": "7fc72632-01bb-4970-91f8-a3a30ae82636",
+      "ConcordiaCourseId": "041431"
+    },
+    {
+      "Id": "2ebb9b4c-0b19-4727-9f6a-fad32bb993a5",
+      "ConcordiaCourseId": "041435"
+    },
+    {
+      "Id": "a25f70f3-8299-431c-be94-19396f0b10c8",
+      "ConcordiaCourseId": "041439"
+    },
+    {
+      "Id": "a3ce879c-56b3-4227-bd49-f4f2baa8e2be",
+      "ConcordiaCourseId": "041447"
+    },
+    {
+      "Id": "85179c36-6c14-445a-8f89-0319da920815",
+      "ConcordiaCourseId": "041451"
+    },
+    {
+      "Id": "b7c7969c-78ad-4c76-916c-4e3ddb2beac6",
+      "ConcordiaCourseId": "041454"
+    },
+    {
+      "Id": "eb9bdb0d-3608-4c72-8413-00a567afbbb4",
+      "ConcordiaCourseId": "041456"
+    },
+    {
+      "Id": "3cbbcdf3-1cbd-47cd-a801-c9b9f8add314",
+      "ConcordiaCourseId": "041459"
+    },
+    {
+      "Id": "85f8fe97-015b-40b2-8d5d-14436ad58678",
+      "ConcordiaCourseId": "041461"
+    },
+    {
+      "Id": "e722a94e-6c70-4aa8-b884-5adcde3a934a",
+      "ConcordiaCourseId": "041464"
+    },
+    {
+      "Id": "1aca6ae5-7c84-4a59-be21-19ec3df3704c",
+      "ConcordiaCourseId": "041471"
+    },
+    {
+      "Id": "271cccf7-cf39-4faf-8398-019d6954c309",
+      "ConcordiaCourseId": "041472"
+    },
+    {
+      "Id": "9072a906-28b5-49be-bcb1-f037e0a0c886",
+      "ConcordiaCourseId": "041473"
+    },
+    {
+      "Id": "847bcada-d8b2-45a3-94d2-67e5323ceca1",
+      "ConcordiaCourseId": "041474"
+    },
+    {
+      "Id": "f23d4a64-0454-4a1e-891d-04bb3fa1bd86",
+      "ConcordiaCourseId": "041475"
+    },
+    {
+      "Id": "741257b7-ae9e-43fc-a83a-42742a74baa3",
+      "ConcordiaCourseId": "041476"
+    },
+    {
+      "Id": "debef8e6-9a45-4152-958e-622f22e147e3",
+      "ConcordiaCourseId": "041477"
+    },
+    {
+      "Id": "28f0a192-02a8-4da4-91ea-e503341e311b",
+      "ConcordiaCourseId": "044079"
+    },
+    {
+      "Id": "ccb76651-7e46-4a44-a083-93846241a43d",
+      "ConcordiaCourseId": "044080"
+    },
+    {
+      "Id": "103d1e49-36d1-4d98-961b-a3c699514b6d",
+      "ConcordiaCourseId": "044087"
+    },
+    {
+      "Id": "344814dd-9b9d-4530-9e86-adce5d0f97ab",
+      "ConcordiaCourseId": "046153"
+    },
+    {
+      "Id": "5ba8a4ac-8322-4911-b01e-25302c2bb810",
+      "ConcordiaCourseId": "046154"
+    },
+    {
+      "Id": "b5cc5642-9746-40b8-927f-a8c0da87ef3e",
+      "ConcordiaCourseId": "046802"
+    },
+    {
+      "Id": "68a23c94-7629-4680-a1f5-1e3f3ac8f175",
+      "ConcordiaCourseId": "046803"
+    },
+    {
+      "Id": "a886fe04-dead-4d94-a9d6-2841467a9407",
+      "ConcordiaCourseId": "046804"
+    },
+    {
+      "Id": "af296dbb-9d3e-481a-8262-8c1d311fc443",
+      "ConcordiaCourseId": "046805"
+    },
+    {
+      "Id": "425982ad-6252-4573-b79b-d1aef0749fab",
+      "ConcordiaCourseId": "047228"
+    },
+    {
+      "Id": "197fde39-9003-49f2-9b27-1b98ea6167e7",
+      "ConcordiaCourseId": "047258"
+    },
+    {
+      "Id": "f3c58bee-656d-47c2-9366-c11eaecd2a13",
+      "ConcordiaCourseId": "047262"
+    },
+    {
+      "Id": "fef3016a-5c89-4b73-b3ff-f2df0c1d654d",
+      "ConcordiaCourseId": "047305"
+    },
+    {
+      "Id": "17c10b3f-fac7-4262-b67a-4dd87f56fce8",
+      "ConcordiaCourseId": "047307"
+    },
+    {
+      "Id": "efcae3e0-d095-424d-a25c-6f7ba865c9ed",
+      "ConcordiaCourseId": "047308"
+    },
+    {
+      "Id": "e62a1614-3858-44aa-a79c-6569777d737b",
+      "ConcordiaCourseId": "047309"
+    },
+    {
+      "Id": "166c4977-6b63-46e8-926a-0f845a3eff49",
+      "ConcordiaCourseId": "047310"
+    },
+    {
+      "Id": "8a4ebaf8-49c4-43b3-a2fc-55e964d9988e",
+      "ConcordiaCourseId": "047312"
+    },
+    {
+      "Id": "3345aa67-732b-4723-a953-92108ac9f4fc",
+      "ConcordiaCourseId": "047313"
+    },
+    {
+      "Id": "5aff935f-9553-4b4b-984b-14a8ed39ac40",
+      "ConcordiaCourseId": "047351"
+    },
+    {
+      "Id": "70c58325-129a-4253-832a-16c14ab705c4",
+      "ConcordiaCourseId": "047352"
+    },
+    {
+      "Id": "c1aba488-b42a-45ea-bfdd-26a5eac0d474",
+      "ConcordiaCourseId": "047356"
+    },
+    {
+      "Id": "50cf99e9-13ce-48fc-bfc0-694488a3b46b",
+      "ConcordiaCourseId": "047357"
+    },
+    {
+      "Id": "d7ac89b4-9b3c-45c7-a08c-0bf0fa0504d7",
+      "ConcordiaCourseId": "047358"
+    },
+    {
+      "Id": "98248520-9de5-4546-8097-230801050a0b",
+      "ConcordiaCourseId": "047359"
+    },
+    {
+      "Id": "47515ad0-57f0-43ad-bfa5-fb06c139f292",
+      "ConcordiaCourseId": "047362"
+    },
+    {
+      "Id": "0bb139e7-008f-4733-a6be-e0cba89c21eb",
+      "ConcordiaCourseId": "047365"
+    },
+    {
+      "Id": "e3617aa6-24aa-4c99-9580-298ed5940049",
+      "ConcordiaCourseId": "047366"
+    },
+    {
+      "Id": "f1aa51f5-78a1-438a-a70f-fba733938a88",
+      "ConcordiaCourseId": "047421"
+    },
+    {
+      "Id": "6e0f2a3d-c290-4518-9476-5a95e0cb6be6",
+      "ConcordiaCourseId": "047424"
+    },
+    {
+      "Id": "30fe14f6-0755-4dd3-8218-ae09233d69a2",
+      "ConcordiaCourseId": "047438"
+    },
+    {
+      "Id": "043f294b-c436-4e97-9c79-d6a701410d16",
+      "ConcordiaCourseId": "047439"
+    },
+    {
+      "Id": "205b1f43-2e2e-4528-acd2-5cbd63f33dae",
+      "ConcordiaCourseId": "047440"
+    },
+    {
+      "Id": "0cbda2c1-7bed-4ae7-ac40-0b75aa1a8483",
+      "ConcordiaCourseId": "047447"
+    },
+    {
+      "Id": "53d5dd8b-4620-40d4-a8c7-441e1b1f5f4c",
+      "ConcordiaCourseId": "047449"
+    },
+    {
+      "Id": "19bbed3d-085f-41cf-8bbf-cba77b82de53",
+      "ConcordiaCourseId": "048671"
+    },
+    {
+      "Id": "e3c9e814-b3a8-4042-8eef-fdc80b15a697",
+      "ConcordiaCourseId": "016054"
+    },
+    {
+      "Id": "20fc312d-ef4a-4500-bb0a-751524cb369c",
+      "ConcordiaCourseId": "016055"
+    },
+    {
+      "Id": "2cbb9ea7-939d-433c-9545-27983b0257ba",
+      "ConcordiaCourseId": "016056"
+    },
+    {
+      "Id": "0c00de90-f6b1-466c-9fd5-753878f8a438",
+      "ConcordiaCourseId": "016057"
+    },
+    {
+      "Id": "fddc4ce6-a8a0-4881-8c3a-c27492f14510",
+      "ConcordiaCourseId": "016059"
+    },
+    {
+      "Id": "08dcf7cc-d743-4741-8ae6-03ac66320328",
+      "ConcordiaCourseId": "016061"
+    },
+    {
+      "Id": "b43eb496-4974-4fe6-a15f-568a6c898331",
+      "ConcordiaCourseId": "016062"
+    },
+    {
+      "Id": "b33c1fa4-720a-460f-a861-53312cce036d",
+      "ConcordiaCourseId": "016063"
+    },
+    {
+      "Id": "3a147000-f30c-4a94-9e2d-141a829ce17b",
+      "ConcordiaCourseId": "016064"
+    },
+    {
+      "Id": "2c1b264d-01ba-4800-93ea-6cfdcc3294fb",
+      "ConcordiaCourseId": "016065"
+    },
+    {
+      "Id": "c97a4ff8-d7f0-4d2e-a838-24420801c3f3",
+      "ConcordiaCourseId": "016066"
+    },
+    {
+      "Id": "99c2692b-9daa-43da-91a0-95680460a6d7",
+      "ConcordiaCourseId": "016067"
+    },
+    {
+      "Id": "f6369301-7817-4959-9bb6-30a6a1c4d6df",
+      "ConcordiaCourseId": "016068"
+    },
+    {
+      "Id": "353c94c5-1b5b-4ec3-b54f-24fa7ee0efd6",
+      "ConcordiaCourseId": "016069"
+    },
+    {
+      "Id": "c9703f8b-aa9c-46b5-84d3-9dbc42a0a6f4",
+      "ConcordiaCourseId": "016070"
+    },
+    {
+      "Id": "7ad07c3e-1606-4875-9fcc-599a5baa985b",
+      "ConcordiaCourseId": "016072"
+    },
+    {
+      "Id": "a7b35992-3942-452f-bc17-87dc361f5688",
+      "ConcordiaCourseId": "016073"
+    },
+    {
+      "Id": "5076c310-f604-4d8b-9265-ee9aeac7ed08",
+      "ConcordiaCourseId": "016075"
+    },
+    {
+      "Id": "d70eb659-13f6-41ca-b1cc-d582ebc6e4f7",
+      "ConcordiaCourseId": "016076"
+    },
+    {
+      "Id": "6d9ca0de-3701-439c-8524-78ce8ac60df0",
+      "ConcordiaCourseId": "016077"
+    },
+    {
+      "Id": "656ab16e-33b7-487f-b74d-a91cae9f6cca",
+      "ConcordiaCourseId": "016079"
+    },
+    {
+      "Id": "c6538538-fe45-44c3-910d-8d81ddda5645",
+      "ConcordiaCourseId": "016081"
+    },
+    {
+      "Id": "00532040-52ef-4cd6-b7fa-eedd7817c619",
+      "ConcordiaCourseId": "016084"
+    },
+    {
+      "Id": "8d06065e-671a-4e1d-8e4a-65318528fd92",
+      "ConcordiaCourseId": "016088"
+    },
+    {
+      "Id": "19b1a00d-565b-4b09-8e29-61a75690e2f6",
+      "ConcordiaCourseId": "016090"
+    },
+    {
+      "Id": "ae42ee77-9986-4f5c-874f-6a6699da113c",
+      "ConcordiaCourseId": "016091"
+    },
+    {
+      "Id": "6628b9cf-c9c9-4690-a42a-0c1f3ba6c931",
+      "ConcordiaCourseId": "016092"
+    },
+    {
+      "Id": "d1524a4d-1552-43a1-971f-6bcd4c9a4109",
+      "ConcordiaCourseId": "016093"
+    },
+    {
+      "Id": "11b69cd7-8ff9-4dcc-a46b-ff1013a08f20",
+      "ConcordiaCourseId": "016094"
+    },
+    {
+      "Id": "6bb31623-42f1-43ab-9fb1-5d02167a4c7d",
+      "ConcordiaCourseId": "016095"
+    },
+    {
+      "Id": "5828d711-b23a-4be5-bb26-0ddbf43e30a2",
+      "ConcordiaCourseId": "016096"
+    },
+    {
+      "Id": "fa41a81b-2f2e-49fa-8964-ff1cb653cd2b",
+      "ConcordiaCourseId": "016097"
+    },
+    {
+      "Id": "740467ba-740b-4804-9a67-6ec8d88961d2",
+      "ConcordiaCourseId": "016098"
+    },
+    {
+      "Id": "afc0c62f-7d9f-4090-8af9-19763defbecf",
+      "ConcordiaCourseId": "016099"
+    },
+    {
+      "Id": "723dc993-c50b-482a-b3e5-1f2e79fd3608",
+      "ConcordiaCourseId": "016100"
+    },
+    {
+      "Id": "6b1cb5db-433b-4e25-b617-b029e99ca175",
+      "ConcordiaCourseId": "041478"
+    },
+    {
+      "Id": "b244a23f-aeff-4dbc-8ce8-675196f681da",
+      "ConcordiaCourseId": "041479"
+    },
+    {
+      "Id": "66d89869-3d1f-4fb7-a225-f11267bc151b",
+      "ConcordiaCourseId": "041480"
+    },
+    {
+      "Id": "8579a97c-36db-477d-ba7a-e6f5ed67d9e6",
+      "ConcordiaCourseId": "046806"
+    },
+    {
+      "Id": "10f78adf-d6c5-4300-b85e-d007fa0e7c8a",
+      "ConcordiaCourseId": "046807"
+    },
+    {
+      "Id": "b62aa677-4918-4b9e-9e7c-9c3d0923c0a7",
+      "ConcordiaCourseId": "047986"
+    },
+    {
+      "Id": "8a12ddab-ac41-4065-8d47-994b5be2d32e",
+      "ConcordiaCourseId": "047987"
+    },
+    {
+      "Id": "41f45c23-e5de-4701-803f-3171ea00cd20",
+      "ConcordiaCourseId": "048949"
+    },
+    {
+      "Id": "78e2bb89-a925-4d44-a5fd-1632d25c1c59",
+      "ConcordiaCourseId": "049311"
+    },
+    {
+      "Id": "1c3cf233-ee65-45f3-91bc-17238d0b2c56",
+      "ConcordiaCourseId": "049312"
+    },
+    {
+      "Id": "a1879b35-8c8b-4940-baf5-7970b5c6afd1",
+      "ConcordiaCourseId": "049332"
+    },
+    {
+      "Id": "3278aa3b-f1d8-4b69-b032-4a61f08e68a8",
+      "ConcordiaCourseId": "049362"
+    },
+    {
+      "Id": "7ccd5fb4-b2b5-4164-9695-e94a0889fc6e",
+      "ConcordiaCourseId": "049421"
+    },
+    {
+      "Id": "7df3cd5a-23ae-45fd-b3d3-99b039b31364",
+      "ConcordiaCourseId": "049703"
+    },
+    {
+      "Id": "f2dcf25c-5ced-4df0-a9e5-ac345bb6138c",
+      "ConcordiaCourseId": "049704"
+    },
+    {
+      "Id": "cf967568-cc71-4ed3-8c8b-2d2457db8f12",
+      "ConcordiaCourseId": "049706"
+    },
+    {
+      "Id": "9b1de2ee-80b3-468e-b17d-a19f56103543",
+      "ConcordiaCourseId": "049707"
+    },
+    {
+      "Id": "024ca34f-ef7a-4d7b-82a5-5813a9da1bbe",
+      "ConcordiaCourseId": "049710"
+    },
+    {
+      "Id": "dea04ba3-5af8-429a-9782-f8a2aa4d5f96",
+      "ConcordiaCourseId": "050278"
+    },
+    {
+      "Id": "69bca439-860b-4582-a6e9-f65111a3c42d",
+      "ConcordiaCourseId": "050557"
+    },
+    {
+      "Id": "a0b187f1-f00c-4123-9ed6-e597d8dd6432",
+      "ConcordiaCourseId": "050558"
+    },
+    {
+      "Id": "570cd2db-dbd8-468f-943e-8ae45624a9b2",
+      "ConcordiaCourseId": "050795"
+    },
+    {
+      "Id": "397e16f6-9aff-4697-abc7-a036c6f7886b",
+      "ConcordiaCourseId": "016142"
+    },
+    {
+      "Id": "42f61290-0887-4b8c-883c-d1ccf487bff3",
+      "ConcordiaCourseId": "041482"
+    },
+    {
+      "Id": "7c279b82-d56c-4de5-ad65-4ff4f0190ea4",
+      "ConcordiaCourseId": "046808"
+    },
+    {
+      "Id": "af19bd13-174e-40e5-90e0-5d3a1542ab42",
+      "ConcordiaCourseId": "046809"
+    },
+    {
+      "Id": "abaf2414-f41a-4862-9069-017f7ff889be",
+      "ConcordiaCourseId": "046810"
+    },
+    {
+      "Id": "449e0d91-d380-4595-aabb-0d8dec6a507f",
+      "ConcordiaCourseId": "046811"
+    },
+    {
+      "Id": "39367f83-4466-40f5-91b8-58b0a293eb42",
+      "ConcordiaCourseId": "016181"
+    },
+    {
+      "Id": "8c1f04b7-04fd-4832-a0e3-6b3b8c1a89c3",
+      "ConcordiaCourseId": "016182"
+    },
+    {
+      "Id": "230abdca-5d83-417d-897d-78d47194e091",
+      "ConcordiaCourseId": "016183"
+    },
+    {
+      "Id": "85fdeb42-d000-47f7-bbbf-f0ae35d25c61",
+      "ConcordiaCourseId": "016184"
+    },
+    {
+      "Id": "990f896e-bebc-4f99-9db7-565e25069620",
+      "ConcordiaCourseId": "016185"
+    },
+    {
+      "Id": "e866d4e7-3cce-4ba6-9315-060db7d2346c",
+      "ConcordiaCourseId": "016186"
+    },
+    {
+      "Id": "358a0678-1e2a-41bb-a66b-850acae53a31",
+      "ConcordiaCourseId": "016187"
+    },
+    {
+      "Id": "72e70a53-fb75-4cb7-a66a-55bc8f6ed1b2",
+      "ConcordiaCourseId": "016188"
+    },
+    {
+      "Id": "2b438286-fa39-412d-99e7-92a2f304043a",
+      "ConcordiaCourseId": "016189"
+    },
+    {
+      "Id": "507bd4df-2168-4f55-9c5e-d7c3f817838e",
+      "ConcordiaCourseId": "016190"
+    },
+    {
+      "Id": "1e2a5b57-b6f6-469c-b211-d5a4351a7a67",
+      "ConcordiaCourseId": "016191"
+    },
+    {
+      "Id": "bff79165-df94-488d-9c57-28438c474aed",
+      "ConcordiaCourseId": "016192"
+    },
+    {
+      "Id": "c449cb39-595d-4de3-a5bb-f922afc8c19a",
+      "ConcordiaCourseId": "016193"
+    },
+    {
+      "Id": "01795e71-c70f-4247-beb2-7a28fd0065f7",
+      "ConcordiaCourseId": "016194"
+    },
+    {
+      "Id": "ee52a9ea-e58c-41fb-b854-2517108abb0c",
+      "ConcordiaCourseId": "016195"
+    },
+    {
+      "Id": "2f55f2ea-0b5d-4050-a148-cf66cc24fb7f",
+      "ConcordiaCourseId": "016196"
+    },
+    {
+      "Id": "5736bab7-ad0e-4ce4-bde7-93f8e67461df",
+      "ConcordiaCourseId": "016197"
+    },
+    {
+      "Id": "8b4f3509-b9f2-40e3-92cb-741fa7e87a52",
+      "ConcordiaCourseId": "016198"
+    },
+    {
+      "Id": "845c7505-2386-42d0-baa4-678e648dae24",
+      "ConcordiaCourseId": "016199"
+    },
+    {
+      "Id": "f0d54808-1eb6-4db4-bef9-6a5abe5e5c27",
+      "ConcordiaCourseId": "016200"
+    },
+    {
+      "Id": "d31a1cdb-7b17-47fa-983a-9cc0ad637c49",
+      "ConcordiaCourseId": "016201"
+    },
+    {
+      "Id": "5340b77c-0165-405d-89b6-9a1a55fb25cb",
+      "ConcordiaCourseId": "016202"
+    },
+    {
+      "Id": "db1f8ee3-c895-4245-a4d4-531ef10e401c",
+      "ConcordiaCourseId": "016203"
+    },
+    {
+      "Id": "4f422176-e8da-40ad-8f94-dc290cad3728",
+      "ConcordiaCourseId": "016204"
+    },
+    {
+      "Id": "52315d97-2eda-48a1-b1be-c96727b2f1a8",
+      "ConcordiaCourseId": "016205"
+    },
+    {
+      "Id": "23b0c616-84b7-4157-9397-9876915d4f5d",
+      "ConcordiaCourseId": "016206"
+    },
+    {
+      "Id": "bfaec2a4-af7f-4b62-939f-aa6283d6387e",
+      "ConcordiaCourseId": "016209"
+    },
+    {
+      "Id": "81b1091e-5e0f-40f1-bca8-467a58fc632f",
+      "ConcordiaCourseId": "016210"
+    },
+    {
+      "Id": "8f101a8f-1e1a-4067-a45c-d0ccbf2513b5",
+      "ConcordiaCourseId": "016211"
+    },
+    {
+      "Id": "b51e301e-ab04-46e2-a3d8-341eb1e0b9d6",
+      "ConcordiaCourseId": "016212"
+    },
+    {
+      "Id": "f0506687-010a-4ef7-acfa-8848575505cc",
+      "ConcordiaCourseId": "016219"
+    },
+    {
+      "Id": "b3b2f548-fd7d-45ff-8514-dcade0143194",
+      "ConcordiaCourseId": "016221"
+    },
+    {
+      "Id": "5647b826-03df-4f35-83e8-144e8c52b77b",
+      "ConcordiaCourseId": "016222"
+    },
+    {
+      "Id": "959ff75d-b06a-45c9-9203-a4d52cde10a1",
+      "ConcordiaCourseId": "041487"
+    },
+    {
+      "Id": "bdb3e795-feb0-47ee-adaf-48fee2746839",
+      "ConcordiaCourseId": "046812"
+    },
+    {
+      "Id": "a37a5702-a7da-45ce-af97-a2ab1cae40bb",
+      "ConcordiaCourseId": "047355"
+    },
+    {
+      "Id": "12ffa9cd-61c2-4310-9cea-a5ef0b44d035",
+      "ConcordiaCourseId": "048620"
+    },
+    {
+      "Id": "9228a446-de0c-4c46-9cdf-dbf9e93e202b",
+      "ConcordiaCourseId": "049532"
+    },
+    {
+      "Id": "d284db36-698d-4632-8702-4bb0bb00e9cf",
+      "ConcordiaCourseId": "049856"
+    },
+    {
+      "Id": "e8ccdf16-985d-4e1e-8496-aeecfdaa175e",
+      "ConcordiaCourseId": "050321"
+    },
+    {
+      "Id": "9fb5d2ee-2c31-405e-8fd7-735029e317cc",
+      "ConcordiaCourseId": "050428"
+    },
+    {
+      "Id": "05df0161-ce3b-45c5-baac-e55a151c58bd",
+      "ConcordiaCourseId": "016226"
+    },
+    {
+      "Id": "ef434e64-5547-494c-adbc-50ffbbbdc763",
+      "ConcordiaCourseId": "016236"
+    },
+    {
+      "Id": "524d410f-ac3f-4444-b93b-eb276f8287da",
+      "ConcordiaCourseId": "016239"
+    },
+    {
+      "Id": "973dea52-e602-458b-ac37-637f65d60b55",
+      "ConcordiaCourseId": "016240"
+    },
+    {
+      "Id": "1df8f7c8-50d1-4602-ad94-add7052421b4",
+      "ConcordiaCourseId": "041503"
+    },
+    {
+      "Id": "81dd3d65-360f-4a32-80fd-b21ec4e9925b",
+      "ConcordiaCourseId": "041504"
+    },
+    {
+      "Id": "2eb573d2-8f20-4ee9-b4bc-459ec37d7b81",
+      "ConcordiaCourseId": "041507"
+    },
+    {
+      "Id": "e60a162e-d242-45f0-918a-2723fb1121eb",
+      "ConcordiaCourseId": "041508"
+    },
+    {
+      "Id": "c4466f1d-1fa6-4a59-b539-6450926ce0d7",
+      "ConcordiaCourseId": "041509"
+    },
+    {
+      "Id": "80a66f28-2e81-42ec-aa31-9c42ff98dc70",
+      "ConcordiaCourseId": "041522"
+    },
+    {
+      "Id": "3b52fb1f-8ba8-48ad-a98f-48f909361345",
+      "ConcordiaCourseId": "041525"
+    },
+    {
+      "Id": "3b88733d-13ad-4573-9cfc-1b2916045dc9",
+      "ConcordiaCourseId": "041526"
+    },
+    {
+      "Id": "b09d3865-4aa9-450c-b5c7-a251f6d60b1b",
+      "ConcordiaCourseId": "046813"
+    },
+    {
+      "Id": "1aaae1d8-d90c-4fab-9c09-e96c4a84614d",
+      "ConcordiaCourseId": "046814"
+    },
+    {
+      "Id": "31002baf-bd61-4563-9eab-fa88984cc77a",
+      "ConcordiaCourseId": "046815"
+    },
+    {
+      "Id": "a99f38a8-b8c0-4411-a4d6-be830f67dba7",
+      "ConcordiaCourseId": "046816"
+    },
+    {
+      "Id": "c998d530-ec55-44b3-9c0e-0afd78e2485a",
+      "ConcordiaCourseId": "046817"
+    },
+    {
+      "Id": "ba0c4c57-f9ff-458e-a0a8-d4d7c9a08cc7",
+      "ConcordiaCourseId": "046818"
+    },
+    {
+      "Id": "b0c5029e-aa3d-4597-8716-bcf318c9fa25",
+      "ConcordiaCourseId": "046819"
+    },
+    {
+      "Id": "114a4016-403e-4126-b360-6294c36b32ae",
+      "ConcordiaCourseId": "046820"
+    },
+    {
+      "Id": "3ed7c7bc-42b6-4b8e-9c8f-61d991660aee",
+      "ConcordiaCourseId": "046821"
+    },
+    {
+      "Id": "f1714916-aa19-463d-b4b7-d4d624267749",
+      "ConcordiaCourseId": "046822"
+    },
+    {
+      "Id": "0f5001c5-9410-4d5a-bbbf-bd6a170fecfb",
+      "ConcordiaCourseId": "046823"
+    },
+    {
+      "Id": "6364afba-c9a7-402f-a97a-8666df2775c0",
+      "ConcordiaCourseId": "046824"
+    },
+    {
+      "Id": "5814816c-f35c-4a5f-8e8b-4aae1acae484",
+      "ConcordiaCourseId": "046825"
+    },
+    {
+      "Id": "666fd79b-610a-42db-8c3a-8117193c1d3c",
+      "ConcordiaCourseId": "046826"
+    },
+    {
+      "Id": "4f08ae49-76ba-438f-932b-c03c7b20f3cb",
+      "ConcordiaCourseId": "046827"
+    },
+    {
+      "Id": "8e80f877-9aa8-4b7f-a62e-5f517f3b4bb5",
+      "ConcordiaCourseId": "046828"
+    },
+    {
+      "Id": "4110d619-8028-4672-9ef7-d8adf8b585d0",
+      "ConcordiaCourseId": "016386"
+    },
+    {
+      "Id": "478c1541-0aef-4c4c-aca4-f4b8afa1e8de",
+      "ConcordiaCourseId": "016387"
+    },
+    {
+      "Id": "6bf187de-8dcc-4f8d-b0bf-22262cc340e8",
+      "ConcordiaCourseId": "016388"
+    },
+    {
+      "Id": "97087439-6194-44d1-a4cc-b7b0095a3de4",
+      "ConcordiaCourseId": "022617"
+    },
+    {
+      "Id": "d67a597b-e3f6-4f28-b066-df0b3cc5d9db",
+      "ConcordiaCourseId": "022618"
+    },
+    {
+      "Id": "377d90ae-ba47-4071-b897-7720e36ebe06",
+      "ConcordiaCourseId": "022619"
+    },
+    {
+      "Id": "961951fa-5050-4367-918d-c8ef94f5003e",
+      "ConcordiaCourseId": "022621"
+    },
+    {
+      "Id": "32ad2fa3-2e24-4a61-9c2b-04bb0a206e1d",
+      "ConcordiaCourseId": "022622"
+    },
+    {
+      "Id": "0aede537-d6b4-4482-8d9e-062e7a924e06",
+      "ConcordiaCourseId": "022623"
+    },
+    {
+      "Id": "f8f4aa0c-9b2b-4219-b7a4-dd3acaf35878",
+      "ConcordiaCourseId": "022631"
+    },
+    {
+      "Id": "9893800b-8bed-43fa-aef5-1e574ee86454",
+      "ConcordiaCourseId": "022632"
+    },
+    {
+      "Id": "4b662a9d-94cb-4d9d-863d-9d6a25742941",
+      "ConcordiaCourseId": "022633"
+    },
+    {
+      "Id": "9c59f702-71c8-4428-8015-f98bfc7d6837",
+      "ConcordiaCourseId": "022634"
+    },
+    {
+      "Id": "a8257d7f-5653-45fc-82f0-576ea2b8c9ec",
+      "ConcordiaCourseId": "022635"
+    },
+    {
+      "Id": "db141e68-832f-4b54-bb05-3e88a5d6f86d",
+      "ConcordiaCourseId": "022636"
+    },
+    {
+      "Id": "84b4a384-3ef9-4319-b484-59d4ccb341b0",
+      "ConcordiaCourseId": "022637"
+    },
+    {
+      "Id": "74e91a30-98ca-4964-ae3b-35172987e571",
+      "ConcordiaCourseId": "022638"
+    },
+    {
+      "Id": "29d67893-85bc-4903-a069-c3fe803b264a",
+      "ConcordiaCourseId": "022639"
+    },
+    {
+      "Id": "9386b1ff-53b4-4f5f-b067-82472134253e",
+      "ConcordiaCourseId": "022656"
+    },
+    {
+      "Id": "92ce97d0-bac6-4a5a-a7db-49a90def34bb",
+      "ConcordiaCourseId": "022665"
+    },
+    {
+      "Id": "82419896-7eae-4d10-8b13-d247c1b0e066",
+      "ConcordiaCourseId": "033898"
+    },
+    {
+      "Id": "1fef53f5-2ad4-4010-b0da-79ce89e4ff6e",
+      "ConcordiaCourseId": "046829"
+    },
+    {
+      "Id": "c1822dc0-1067-449b-adb4-3e0af2559129",
+      "ConcordiaCourseId": "046830"
+    },
+    {
+      "Id": "43994638-c162-4c35-9454-d59a50d5d1c4",
+      "ConcordiaCourseId": "046831"
+    },
+    {
+      "Id": "e21d8511-56b2-469e-ae44-3d2db0a993af",
+      "ConcordiaCourseId": "046832"
+    },
+    {
+      "Id": "697d73af-6e2f-42b9-8836-8afe7d9fd40f",
+      "ConcordiaCourseId": "046833"
+    },
+    {
+      "Id": "e7570305-2af2-49e0-9115-b6e698654355",
+      "ConcordiaCourseId": "047201"
+    },
+    {
+      "Id": "40ee791d-f429-4b85-98f1-aaee638c7598",
+      "ConcordiaCourseId": "047230"
+    },
+    {
+      "Id": "679c7f75-d078-4d48-b05c-3036000dc7c3",
+      "ConcordiaCourseId": "047236"
+    },
+    {
+      "Id": "01c37aca-b4da-4a15-9e3b-af8119741ec9",
+      "ConcordiaCourseId": "047492"
+    },
+    {
+      "Id": "abaab5fb-803c-452c-b68a-947bc4ad05aa",
+      "ConcordiaCourseId": "047493"
+    },
+    {
+      "Id": "8121b3c6-926b-4fcd-a826-a241026a9591",
+      "ConcordiaCourseId": "048398"
+    },
+    {
+      "Id": "ea1f4c88-8b67-4019-95ce-9235ee01663b",
+      "ConcordiaCourseId": "048404"
+    },
+    {
+      "Id": "3751cad6-55b7-4ef7-bb06-8eb68f981ed5",
+      "ConcordiaCourseId": "048405"
+    },
+    {
+      "Id": "0f17d066-af43-420e-bcbf-702ac5e69922",
+      "ConcordiaCourseId": "048406"
+    },
+    {
+      "Id": "1af15eae-c268-4295-8e9f-95b55a3495de",
+      "ConcordiaCourseId": "048407"
+    },
+    {
+      "Id": "687199c2-609e-402a-8084-14c2782adfb2",
+      "ConcordiaCourseId": "048857"
+    },
+    {
+      "Id": "84d42eee-82b2-4c86-abac-0067845f8e7d",
+      "ConcordiaCourseId": "049109"
+    },
+    {
+      "Id": "1b3d2e67-6252-4d69-b8ac-49a894836edc",
+      "ConcordiaCourseId": "049110"
+    },
+    {
+      "Id": "32617ef4-0982-4c5d-8183-d571429b0aa9",
+      "ConcordiaCourseId": "022681"
+    },
+    {
+      "Id": "ed52ad58-8a9c-42a6-927a-fadda0d5e467",
+      "ConcordiaCourseId": "022683"
+    },
+    {
+      "Id": "d6300c4b-9c1e-4aac-8cce-d2c3e8c8ef46",
+      "ConcordiaCourseId": "022684"
+    },
+    {
+      "Id": "0bd641dd-7cec-45bc-969f-e8bdc1eef59a",
+      "ConcordiaCourseId": "022685"
+    },
+    {
+      "Id": "40bcc112-648a-4519-a424-e307efff03eb",
+      "ConcordiaCourseId": "022686"
+    },
+    {
+      "Id": "df67f92b-370a-43cc-8910-033f3793d133",
+      "ConcordiaCourseId": "022689"
+    },
+    {
+      "Id": "c26c5ee9-bb9a-42a0-bb47-e02baa135033",
+      "ConcordiaCourseId": "022690"
+    },
+    {
+      "Id": "365cfbdc-30c8-4278-b2e0-dfb0541a6709",
+      "ConcordiaCourseId": "022691"
+    },
+    {
+      "Id": "a2f7d449-6e6d-42fe-8502-35bdf47c69f2",
+      "ConcordiaCourseId": "022712"
+    },
+    {
+      "Id": "450871c7-ea74-413e-baa4-936634f52c04",
+      "ConcordiaCourseId": "022713"
+    },
+    {
+      "Id": "8925a2be-7975-433c-bf7f-afa8810b1a3a",
+      "ConcordiaCourseId": "022716"
+    },
+    {
+      "Id": "69ad8d19-f474-4ebe-a3d4-0f91112296f0",
+      "ConcordiaCourseId": "022717"
+    },
+    {
+      "Id": "be0ea99a-44c3-4641-b8f0-7d00baa259f7",
+      "ConcordiaCourseId": "022721"
+    },
+    {
+      "Id": "289127a0-703f-420d-a91c-d7ff9a484981",
+      "ConcordiaCourseId": "022722"
+    },
+    {
+      "Id": "d4e09945-b2fd-4ebd-89ea-949d6c6e7a13",
+      "ConcordiaCourseId": "022725"
+    },
+    {
+      "Id": "3f9ca2f3-0baa-430a-a55d-00b49b191a9d",
+      "ConcordiaCourseId": "022726"
+    },
+    {
+      "Id": "86c5eb77-9f7a-407a-82f8-78b5ff4212e5",
+      "ConcordiaCourseId": "022733"
+    },
+    {
+      "Id": "e98eac78-4928-4329-865f-a499130f6536",
+      "ConcordiaCourseId": "022734"
+    },
+    {
+      "Id": "9077a265-1c65-492d-98ea-51188e25a85f",
+      "ConcordiaCourseId": "022735"
+    },
+    {
+      "Id": "c5c353b2-347e-4c05-b6bc-69543e9205aa",
+      "ConcordiaCourseId": "022754"
+    },
+    {
+      "Id": "00cbf769-e015-43ba-a492-69aff450a129",
+      "ConcordiaCourseId": "022755"
+    },
+    {
+      "Id": "f9a20b0e-842a-4fad-af18-5df796275594",
+      "ConcordiaCourseId": "022761"
+    },
+    {
+      "Id": "231f8d0e-5a2f-4752-b0fd-b8712f989855",
+      "ConcordiaCourseId": "022764"
+    },
+    {
+      "Id": "e68d1fff-679d-4899-a60c-011b9f776d84",
+      "ConcordiaCourseId": "022769"
+    },
+    {
+      "Id": "c67b47c6-e5b1-4c69-8814-74b6a324d622",
+      "ConcordiaCourseId": "022771"
+    },
+    {
+      "Id": "3a1919e2-ccab-4386-a807-cdbede9d882b",
+      "ConcordiaCourseId": "022773"
+    },
+    {
+      "Id": "8fb6559f-69a7-4450-8bb0-1f56103f1fd7",
+      "ConcordiaCourseId": "022781"
+    },
+    {
+      "Id": "c33205e8-e3fe-4988-9096-ad2af403ebe1",
+      "ConcordiaCourseId": "022782"
+    },
+    {
+      "Id": "917af40d-3eca-4acc-aa01-b1143002f28e",
+      "ConcordiaCourseId": "022783"
+    },
+    {
+      "Id": "d405de52-546f-4135-8cde-737a9d40f484",
+      "ConcordiaCourseId": "022785"
+    },
+    {
+      "Id": "5d89ac21-7c42-455e-b8ae-cd23ac603dd4",
+      "ConcordiaCourseId": "022786"
+    },
+    {
+      "Id": "5cb7952e-2c87-4835-84d5-86545f4d372a",
+      "ConcordiaCourseId": "022789"
+    },
+    {
+      "Id": "92d9bcb6-d310-4499-8223-6cc25a594c8d",
+      "ConcordiaCourseId": "022800"
+    },
+    {
+      "Id": "24e37506-9f56-4c7b-8187-82af47a918b4",
+      "ConcordiaCourseId": "022804"
+    },
+    {
+      "Id": "cc580056-11ab-4e5c-ae59-26533bc686dc",
+      "ConcordiaCourseId": "022808"
+    },
+    {
+      "Id": "a6d5034d-9a14-4743-8f20-a94aa7eded9f",
+      "ConcordiaCourseId": "022810"
+    },
+    {
+      "Id": "685419b6-6475-49f9-af97-61c37b60a0e2",
+      "ConcordiaCourseId": "046834"
+    },
+    {
+      "Id": "89715aee-2f4d-4ad7-8851-5f207f462174",
+      "ConcordiaCourseId": "046835"
+    },
+    {
+      "Id": "c2d08fd2-dc1e-42a1-aa75-73acff700448",
+      "ConcordiaCourseId": "046836"
+    },
+    {
+      "Id": "0fafd20d-6627-4489-b3eb-9a54313d4ea7",
+      "ConcordiaCourseId": "046837"
+    },
+    {
+      "Id": "ddcfc304-272b-45c7-bf27-276f4eca314f",
+      "ConcordiaCourseId": "046838"
+    },
+    {
+      "Id": "392f01e6-e80b-47c4-b485-99c1637885e7",
+      "ConcordiaCourseId": "046839"
+    },
+    {
+      "Id": "8f9e5114-f13b-461c-976b-2d2b58660e30",
+      "ConcordiaCourseId": "047401"
+    },
+    {
+      "Id": "50e2a6b4-d978-4534-862c-6e0e4848ac71",
+      "ConcordiaCourseId": "047820"
+    },
+    {
+      "Id": "e875e75f-f7a4-497d-bead-fdf1a61aaf84",
+      "ConcordiaCourseId": "049361"
+    },
+    {
+      "Id": "1f020bbf-e339-40c8-bd9c-e984372374cc",
+      "ConcordiaCourseId": "049620"
+    },
+    {
+      "Id": "5d5f3647-45e8-4ac7-ab54-240541882384",
+      "ConcordiaCourseId": "049621"
+    },
+    {
+      "Id": "6fce6706-3fe4-43ad-870b-be35b8d88889",
+      "ConcordiaCourseId": "049713"
+    },
+    {
+      "Id": "9745fa71-0526-4075-bd48-2bb3f0838d6c",
+      "ConcordiaCourseId": "022899"
+    },
+    {
+      "Id": "9bf0a230-7a1d-4051-aed3-6150692002ec",
+      "ConcordiaCourseId": "022900"
+    },
+    {
+      "Id": "83df02a5-4690-4630-bb9f-0bd3a9bf3b3d",
+      "ConcordiaCourseId": "022901"
+    },
+    {
+      "Id": "2e38994f-3a0d-4fdf-bb69-c1e199063c9e",
+      "ConcordiaCourseId": "022902"
+    },
+    {
+      "Id": "b5cb6314-e844-4cc4-aa1f-54b263a8f41d",
+      "ConcordiaCourseId": "022903"
+    },
+    {
+      "Id": "ec852555-809d-40c2-9c46-7466163f9d34",
+      "ConcordiaCourseId": "022906"
+    },
+    {
+      "Id": "3a3eaaab-653b-4d20-abc7-0c4b8ee690d3",
+      "ConcordiaCourseId": "022907"
+    },
+    {
+      "Id": "57bb0713-8586-4355-826d-bf38c869b44e",
+      "ConcordiaCourseId": "022908"
+    },
+    {
+      "Id": "c1c8d898-ca63-4b71-bac4-8110e35ec2ad",
+      "ConcordiaCourseId": "022909"
+    },
+    {
+      "Id": "fa026344-3719-4e43-93c6-75e44c6b68bb",
+      "ConcordiaCourseId": "022910"
+    },
+    {
+      "Id": "5d49f34d-2605-4137-9c20-ca43b646dace",
+      "ConcordiaCourseId": "022911"
+    },
+    {
+      "Id": "56ae122d-d0b9-4520-97eb-8da577c834e2",
+      "ConcordiaCourseId": "022917"
+    },
+    {
+      "Id": "e944e96f-cab3-4b57-9812-0314f2e513bb",
+      "ConcordiaCourseId": "022918"
+    },
+    {
+      "Id": "6d6ea836-d2e8-4ebe-bcf2-705e7dee0e08",
+      "ConcordiaCourseId": "046840"
+    },
+    {
+      "Id": "03f7d5d7-574e-47e0-adb2-7048e271d9e5",
+      "ConcordiaCourseId": "046841"
+    },
+    {
+      "Id": "fae6b945-f0f0-4a7b-85d9-b9ce8ad3af72",
+      "ConcordiaCourseId": "047622"
+    },
+    {
+      "Id": "fa3f7c17-5df8-4900-9845-f9e9a7e97456",
+      "ConcordiaCourseId": "048933"
+    },
+    {
+      "Id": "980f7a52-8b46-4168-b599-a93aa4188b2f",
+      "ConcordiaCourseId": "048934"
+    },
+    {
+      "Id": "1b3817ae-6be0-448b-bfe0-3c6bf43de346",
+      "ConcordiaCourseId": "022920"
+    },
+    {
+      "Id": "b27242da-8886-4f21-8f94-f632899e0840",
+      "ConcordiaCourseId": "046842"
+    },
+    {
+      "Id": "9b875e0f-fc99-4d66-afc2-8e3d9fc020dd",
+      "ConcordiaCourseId": "048783"
+    },
+    {
+      "Id": "d65ff104-4bda-44ba-b573-b02fff9aad3e",
+      "ConcordiaCourseId": "049166"
+    },
+    {
+      "Id": "93d89f38-ade1-4de2-9c62-eb4a028573a6",
+      "ConcordiaCourseId": "049238"
+    },
+    {
+      "Id": "2ec38151-8817-4c1c-880c-54024294632b",
+      "ConcordiaCourseId": "049440"
+    },
+    {
+      "Id": "0bdd754f-4b7e-4f10-bce5-6d6d130aea40",
+      "ConcordiaCourseId": "049540"
+    },
+    {
+      "Id": "cff80aee-be1c-4a26-9d20-e9f92e69037d",
+      "ConcordiaCourseId": "049622"
+    },
+    {
+      "Id": "8f497c04-b57c-434f-ac7d-d7030529bead",
+      "ConcordiaCourseId": "050276"
+    },
+    {
+      "Id": "f8caedae-28bd-4521-a423-d71a716baf40",
+      "ConcordiaCourseId": "050281"
+    },
+    {
+      "Id": "cedf25b9-82c5-47bf-b19c-97d4a8e25368",
+      "ConcordiaCourseId": "050345"
+    },
+    {
+      "Id": "b4f4ea8f-6ab3-48af-9dc4-d226c1461e23",
+      "ConcordiaCourseId": "050346"
+    },
+    {
+      "Id": "0d7d91b7-7048-4510-bacd-6993a3001b73",
+      "ConcordiaCourseId": "050347"
+    },
+    {
+      "Id": "5a3dd923-8629-414a-a335-1b84d2f54a97",
+      "ConcordiaCourseId": "050348"
+    },
+    {
+      "Id": "f4e05d64-2082-45c2-9e15-f665246f5783",
+      "ConcordiaCourseId": "050349"
+    },
+    {
+      "Id": "619d7369-d34f-4b1a-943f-06a922e86fa5",
+      "ConcordiaCourseId": "050350"
+    },
+    {
+      "Id": "c61327b4-b0a0-4b97-9538-400196102ada",
+      "ConcordiaCourseId": "050371"
+    },
+    {
+      "Id": "d1963656-c594-4ce5-a3cd-4cbd285ab67b",
+      "ConcordiaCourseId": "022924"
+    },
+    {
+      "Id": "b33b1dd5-af94-479a-a361-ee523a16fba3",
+      "ConcordiaCourseId": "022925"
+    },
+    {
+      "Id": "fde39ef2-3c21-49be-9697-9108ecfe000f",
+      "ConcordiaCourseId": "022927"
+    },
+    {
+      "Id": "2ac52e6e-c55e-4f68-b7f9-d97a34909382",
+      "ConcordiaCourseId": "022928"
+    },
+    {
+      "Id": "522dabdd-dba6-4c5c-977e-1b79d0ac6e4d",
+      "ConcordiaCourseId": "022930"
+    },
+    {
+      "Id": "e9b59ef4-39c1-45ae-b0b3-29b111c03340",
+      "ConcordiaCourseId": "022931"
+    },
+    {
+      "Id": "cc8dbde4-09da-4026-b0f9-502a9ac2cdf7",
+      "ConcordiaCourseId": "022936"
+    },
+    {
+      "Id": "43b160be-b4f6-44ab-81b0-684abf04582a",
+      "ConcordiaCourseId": "022937"
+    },
+    {
+      "Id": "4a79ed9b-a9c1-430e-bf51-113d88de9100",
+      "ConcordiaCourseId": "022939"
+    },
+    {
+      "Id": "fb35fc86-17b8-4c64-90f2-8bffacf5a7f4",
+      "ConcordiaCourseId": "022940"
+    },
+    {
+      "Id": "f340af9e-9c8d-40d4-9d5c-acd4d902aab2",
+      "ConcordiaCourseId": "022942"
+    },
+    {
+      "Id": "f8cfbf34-9218-4eb7-8cd3-4a71dd395b3b",
+      "ConcordiaCourseId": "022947"
+    },
+    {
+      "Id": "7848ee6d-b0d1-4912-a91b-765579c56e9f",
+      "ConcordiaCourseId": "022948"
+    },
+    {
+      "Id": "7b77bef8-ad2e-4940-9aa9-f5c90235f4fa",
+      "ConcordiaCourseId": "022953"
+    },
+    {
+      "Id": "0079db4e-f290-462f-b932-1cf10eaa4ac6",
+      "ConcordiaCourseId": "022962"
+    },
+    {
+      "Id": "790a39d1-78fd-4ed2-8f12-d184a3b02049",
+      "ConcordiaCourseId": "022963"
+    },
+    {
+      "Id": "ce988600-7121-41cd-bd30-335cf30fdb02",
+      "ConcordiaCourseId": "022969"
+    },
+    {
+      "Id": "26c71831-5cc1-42a6-b3e2-7437d6ba56c7",
+      "ConcordiaCourseId": "022970"
+    },
+    {
+      "Id": "a16e9bdf-fb53-45a9-8c66-2bee08f56728",
+      "ConcordiaCourseId": "022972"
+    },
+    {
+      "Id": "15464cfc-41b8-4d77-b394-469b49830b30",
+      "ConcordiaCourseId": "022973"
+    },
+    {
+      "Id": "e7931bd1-76f2-48a3-93ba-0179200cb8b2",
+      "ConcordiaCourseId": "022974"
+    },
+    {
+      "Id": "b5d0d34d-afb6-4910-b743-c60865c82a6f",
+      "ConcordiaCourseId": "022975"
+    },
+    {
+      "Id": "dc784a15-bbd8-406c-83b2-acf96739aae5",
+      "ConcordiaCourseId": "022977"
+    },
+    {
+      "Id": "df0835d1-8a2a-465e-b159-07fb67928893",
+      "ConcordiaCourseId": "022978"
+    },
+    {
+      "Id": "ea861fa0-052a-4930-a486-2063d0a81458",
+      "ConcordiaCourseId": "022980"
+    },
+    {
+      "Id": "7d07ed91-2143-43e3-b156-7e243cd1ecb6",
+      "ConcordiaCourseId": "022981"
+    },
+    {
+      "Id": "4ea5752f-f8e3-4448-8587-c8f4843ff412",
+      "ConcordiaCourseId": "022983"
+    },
+    {
+      "Id": "b9b50807-139f-494b-9141-a2ce0e087557",
+      "ConcordiaCourseId": "022995"
+    },
+    {
+      "Id": "5bb8e927-4937-420f-93f4-7dbc25097093",
+      "ConcordiaCourseId": "022997"
+    },
+    {
+      "Id": "8daf8e47-3e4c-4e3b-a872-9b8c7ef8497d",
+      "ConcordiaCourseId": "022998"
+    },
+    {
+      "Id": "cb3b2c9e-4260-448a-abd6-a325c92f6fdb",
+      "ConcordiaCourseId": "022999"
+    },
+    {
+      "Id": "d9633f84-9095-4e67-99a3-e16d25305504",
+      "ConcordiaCourseId": "023000"
+    },
+    {
+      "Id": "099681f9-40c9-4830-80fa-ad1096b04dcd",
+      "ConcordiaCourseId": "023002"
+    },
+    {
+      "Id": "859f5ba5-135c-4ebf-bda0-6072f8d0c23a",
+      "ConcordiaCourseId": "023003"
+    },
+    {
+      "Id": "6b512d6b-6516-4e49-b2fc-1b414c117bd0",
+      "ConcordiaCourseId": "023004"
+    },
+    {
+      "Id": "bae22be1-939d-4d40-ba95-d61c7da2fde2",
+      "ConcordiaCourseId": "023006"
+    },
+    {
+      "Id": "27b2f64d-d8e1-45b9-b777-a46f83e936fa",
+      "ConcordiaCourseId": "023008"
+    },
+    {
+      "Id": "f1e091f9-bc3e-406c-9472-dd02914a97a0",
+      "ConcordiaCourseId": "023012"
+    },
+    {
+      "Id": "a31ecf97-3a92-4259-90e6-e92250ce028c",
+      "ConcordiaCourseId": "023013"
+    },
+    {
+      "Id": "79af2a33-f62b-424d-93d4-353335b3dbc6",
+      "ConcordiaCourseId": "023021"
+    },
+    {
+      "Id": "61226d0a-cea6-4e8f-aa8d-cf9bdf880446",
+      "ConcordiaCourseId": "023022"
+    },
+    {
+      "Id": "6208e6b1-3632-4737-a664-1edcf242cfea",
+      "ConcordiaCourseId": "023023"
+    },
+    {
+      "Id": "0bce47f8-8c1c-45de-8f7b-2f240aaa1768",
+      "ConcordiaCourseId": "023024"
+    },
+    {
+      "Id": "7039641e-bbd6-4031-bc32-565635a74472",
+      "ConcordiaCourseId": "023025"
+    },
+    {
+      "Id": "6e6ed93b-b601-4175-9de6-0b1e9d73ec9d",
+      "ConcordiaCourseId": "023026"
+    },
+    {
+      "Id": "6a706c61-87df-4d4d-af0d-69e59846e579",
+      "ConcordiaCourseId": "023027"
+    },
+    {
+      "Id": "8d3128b9-ba46-4cf0-9b33-5e589e19f3d9",
+      "ConcordiaCourseId": "023028"
+    },
+    {
+      "Id": "e2bee2ec-5167-417c-acd6-fed6e3147d09",
+      "ConcordiaCourseId": "023029"
+    },
+    {
+      "Id": "f2252f34-5645-4970-a2b7-872816965fc4",
+      "ConcordiaCourseId": "023030"
+    },
+    {
+      "Id": "b02fc77e-55c3-4410-8930-2ad67082acc3",
+      "ConcordiaCourseId": "023031"
+    },
+    {
+      "Id": "92a1b841-fe2f-4aa8-9fa2-d328d371f686",
+      "ConcordiaCourseId": "023032"
+    },
+    {
+      "Id": "9bfc1a1e-2e00-4f7d-bdb3-16ad535ea625",
+      "ConcordiaCourseId": "023033"
+    },
+    {
+      "Id": "86a9b552-01e1-4ff0-a243-908c65206697",
+      "ConcordiaCourseId": "023034"
+    },
+    {
+      "Id": "473ce460-0cfe-4da0-b89d-46fb49345af7",
+      "ConcordiaCourseId": "041563"
+    },
+    {
+      "Id": "1f2bc909-3cad-4e30-99da-8a8bf4b0017d",
+      "ConcordiaCourseId": "041565"
+    },
+    {
+      "Id": "74468d56-8a70-47a8-b691-af8c5c53324f",
+      "ConcordiaCourseId": "046240"
+    },
+    {
+      "Id": "64eb46f5-ed77-4224-aadf-d736273c212c",
+      "ConcordiaCourseId": "046843"
+    },
+    {
+      "Id": "634572fc-541b-481a-92bc-43a784da392b",
+      "ConcordiaCourseId": "046844"
+    },
+    {
+      "Id": "ed2514f3-0232-4ace-b931-1e64adf61ad6",
+      "ConcordiaCourseId": "046845"
+    },
+    {
+      "Id": "1f4047f2-4c51-429a-a150-ae41ffe1f618",
+      "ConcordiaCourseId": "046846"
+    },
+    {
+      "Id": "50d4beb5-e129-4f9d-a2b5-2cbb46a61bff",
+      "ConcordiaCourseId": "046847"
+    },
+    {
+      "Id": "c5cfcc7a-77cd-4cdf-b28c-db8f5a7f27ee",
+      "ConcordiaCourseId": "046848"
+    },
+    {
+      "Id": "7e5c6c3c-6f68-4ef5-aa21-a253b9e67abc",
+      "ConcordiaCourseId": "046849"
+    },
+    {
+      "Id": "dcf9de9a-f3ab-44ad-9ae3-1890436c7e77",
+      "ConcordiaCourseId": "047315"
+    },
+    {
+      "Id": "6eeef16f-ebe1-4fc8-80eb-239a781a890e",
+      "ConcordiaCourseId": "047316"
+    },
+    {
+      "Id": "1d1c19cc-1696-4707-b84e-ad0b757de332",
+      "ConcordiaCourseId": "047317"
+    },
+    {
+      "Id": "67f61f7f-eece-4b30-81f7-c01454fb1e18",
+      "ConcordiaCourseId": "047318"
+    },
+    {
+      "Id": "f7d126f1-77f4-457d-972c-f0a2aebc4ebc",
+      "ConcordiaCourseId": "047319"
+    },
+    {
+      "Id": "0580211e-845f-4178-8411-0d9773d50888",
+      "ConcordiaCourseId": "047320"
+    },
+    {
+      "Id": "10123818-759b-49bd-8f9b-e2f3e70f8af0",
+      "ConcordiaCourseId": "047441"
+    },
+    {
+      "Id": "6f683aa3-3f6d-4963-bed5-2c9d02f4a764",
+      "ConcordiaCourseId": "047802"
+    },
+    {
+      "Id": "a117a648-b182-4889-a1ef-34d19ab1060f",
+      "ConcordiaCourseId": "047803"
+    },
+    {
+      "Id": "a7e5f549-5105-4173-bd8b-05e5cd65ae11",
+      "ConcordiaCourseId": "047804"
+    },
+    {
+      "Id": "f63be306-1983-4695-aad9-63db2ed94537",
+      "ConcordiaCourseId": "047805"
+    },
+    {
+      "Id": "7e5f7666-e31e-4478-8374-07fd0ab47c6d",
+      "ConcordiaCourseId": "047806"
+    },
+    {
+      "Id": "153273c7-1a82-4020-801d-1a43810ac2c0",
+      "ConcordiaCourseId": "047807"
+    },
+    {
+      "Id": "680f7514-faeb-42b6-be3e-bd32a1d27ccc",
+      "ConcordiaCourseId": "047808"
+    },
+    {
+      "Id": "82a6f907-85f5-40fd-958a-1b2d23ae8e93",
+      "ConcordiaCourseId": "047809"
+    },
+    {
+      "Id": "f79a5a35-0452-4632-b2d3-069c9588421d",
+      "ConcordiaCourseId": "047810"
+    },
+    {
+      "Id": "4f289018-d358-4938-bd0e-413e54d53dc9",
+      "ConcordiaCourseId": "047811"
+    },
+    {
+      "Id": "d32fc045-a2c4-4809-a2a1-07932b7b9366",
+      "ConcordiaCourseId": "047812"
+    },
+    {
+      "Id": "7f69a33e-8171-4e21-a4b9-4a49824107fc",
+      "ConcordiaCourseId": "048363"
+    },
+    {
+      "Id": "d496e8f2-ca6c-4a5b-9a56-3cb291edd004",
+      "ConcordiaCourseId": "048364"
+    },
+    {
+      "Id": "7f44400b-ee2e-4af6-98a2-5ecfae6b33ce",
+      "ConcordiaCourseId": "048365"
+    },
+    {
+      "Id": "2c67fed8-35c3-46d0-8a68-283cc469c380",
+      "ConcordiaCourseId": "048366"
+    },
+    {
+      "Id": "01eeb391-dfef-4065-8120-6a6ac039a981",
+      "ConcordiaCourseId": "048646"
+    },
+    {
+      "Id": "161ed664-c601-4550-9f82-b8f92ed7ca2e",
+      "ConcordiaCourseId": "048647"
+    },
+    {
+      "Id": "ae2d8a17-afec-4955-ae9d-8bf2dcf3cb51",
+      "ConcordiaCourseId": "048648"
+    },
+    {
+      "Id": "356702fd-9240-4f90-882c-6f3f2616ebcc",
+      "ConcordiaCourseId": "048649"
+    },
+    {
+      "Id": "fe1a43f0-0d56-4c9c-ab45-4589e7dd7193",
+      "ConcordiaCourseId": "049113"
+    },
+    {
+      "Id": "eefb9938-65d9-4141-aea2-bf90ac7f6f4c",
+      "ConcordiaCourseId": "050056"
+    },
+    {
+      "Id": "b9e9e82a-2389-49db-b556-05c73e91ee94",
+      "ConcordiaCourseId": "050868"
+    },
+    {
+      "Id": "1000f333-61fc-47e6-b18a-6c19685cece6",
+      "ConcordiaCourseId": "050869"
+    },
+    {
+      "Id": "331c51d7-5e92-41c8-9922-5d868df3be04",
+      "ConcordiaCourseId": "023071"
+    },
+    {
+      "Id": "9f6ba01c-2004-4550-a5ac-3bf3944c01c9",
+      "ConcordiaCourseId": "023073"
+    },
+    {
+      "Id": "8eac0b9f-cca9-458e-a25c-c687833daaf3",
+      "ConcordiaCourseId": "023074"
+    },
+    {
+      "Id": "79d10aea-a8a0-4d0f-8ce6-65bce6de830c",
+      "ConcordiaCourseId": "023086"
+    },
+    {
+      "Id": "30f30799-9034-4d94-9230-21f8344ae88d",
+      "ConcordiaCourseId": "023098"
+    },
+    {
+      "Id": "3696e5f0-39f4-438b-a3e6-583553bdd121",
+      "ConcordiaCourseId": "023099"
+    },
+    {
+      "Id": "6b70f777-b952-448d-aa1e-83c0647f7c36",
+      "ConcordiaCourseId": "023100"
+    },
+    {
+      "Id": "f163594a-2330-405f-9756-2ca8b69e497d",
+      "ConcordiaCourseId": "023102"
+    },
+    {
+      "Id": "e3f0ca7a-a227-46ce-86fa-a1de830d2b86",
+      "ConcordiaCourseId": "023103"
+    },
+    {
+      "Id": "81eab1fd-4d85-4cdb-aff0-e56b8ca0ac50",
+      "ConcordiaCourseId": "023104"
+    },
+    {
+      "Id": "cfabb18a-f53a-4e72-b3b1-4bc00a9a8be9",
+      "ConcordiaCourseId": "023105"
+    },
+    {
+      "Id": "ee4086c0-c065-4634-8172-4d401f44b599",
+      "ConcordiaCourseId": "023106"
+    },
+    {
+      "Id": "9dbadaab-fdac-4e14-9c0f-2231566ea825",
+      "ConcordiaCourseId": "041566"
+    },
+    {
+      "Id": "667eb34e-d3cc-4530-8dd3-99778eb07bd2",
+      "ConcordiaCourseId": "041578"
+    },
+    {
+      "Id": "e6820cd5-6b97-4788-a100-99699190ef0d",
+      "ConcordiaCourseId": "041590"
+    },
+    {
+      "Id": "e54ecafc-2ee9-4c5b-bf49-6bff8152dca5",
+      "ConcordiaCourseId": "041591"
+    },
+    {
+      "Id": "a7e18506-d595-4cdd-ade4-3f083bda6cbc",
+      "ConcordiaCourseId": "041603"
+    },
+    {
+      "Id": "b4f58631-c3e1-4d33-93ca-c7deceeb085c",
+      "ConcordiaCourseId": "046850"
+    },
+    {
+      "Id": "2cd92b44-bb00-4e3c-a6fb-d2c6f66553b0",
+      "ConcordiaCourseId": "046851"
+    },
+    {
+      "Id": "aa2236b3-6f1c-4283-a173-9e8fe1027851",
+      "ConcordiaCourseId": "046852"
+    },
+    {
+      "Id": "0df5c9c4-4974-4c25-b1ad-caa50d05d7c1",
+      "ConcordiaCourseId": "048935"
+    },
+    {
+      "Id": "750a226b-bc72-4694-aec1-a8111d4d4a3a",
+      "ConcordiaCourseId": "048936"
+    },
+    {
+      "Id": "2b4c0fc1-a12d-401f-9d8c-c5873d3c445d",
+      "ConcordiaCourseId": "048937"
+    },
+    {
+      "Id": "eeb1bbe4-fd86-437a-ba29-0b9602565245",
+      "ConcordiaCourseId": "048938"
+    },
+    {
+      "Id": "8d7c9f67-4163-4667-bd6d-5d60c7f23200",
+      "ConcordiaCourseId": "048939"
+    },
+    {
+      "Id": "39e77fcc-f881-48a8-b488-84ac748a1dde",
+      "ConcordiaCourseId": "048940"
+    },
+    {
+      "Id": "16fe0677-ac16-463b-a249-530755bc26ef",
+      "ConcordiaCourseId": "048941"
+    },
+    {
+      "Id": "733b916e-a58b-4126-a1a0-6b075ce2f88d",
+      "ConcordiaCourseId": "048942"
+    },
+    {
+      "Id": "9df1e8e8-1a92-4c5a-b955-6a55ca6f161a",
+      "ConcordiaCourseId": "048943"
+    },
+    {
+      "Id": "eb4866f7-d7cb-4e3d-ba6b-64e6dff17f2d",
+      "ConcordiaCourseId": "048762"
+    },
+    {
+      "Id": "9e6260fa-d639-4682-8ceb-12791c303e1e",
+      "ConcordiaCourseId": "049169"
+    },
+    {
+      "Id": "7f504b5f-edd7-4e43-84cb-fc0bdfef8630",
+      "ConcordiaCourseId": "049170"
+    },
+    {
+      "Id": "a45dfc88-7a2b-49ae-993e-ea50045b5396",
+      "ConcordiaCourseId": "049171"
+    },
+    {
+      "Id": "59298d63-004a-4404-a201-188efe70b60f",
+      "ConcordiaCourseId": "049172"
+    },
+    {
+      "Id": "c275d681-2aac-4a0b-a912-b7d95d4b92f9",
+      "ConcordiaCourseId": "049328"
+    },
+    {
+      "Id": "7a1f3773-b658-417d-b0c7-e25a815b9acd",
+      "ConcordiaCourseId": "049564"
+    },
+    {
+      "Id": "eb933e03-8735-475d-910c-04586d8e11ab",
+      "ConcordiaCourseId": "050325"
+    },
+    {
+      "Id": "9eb10a4a-a5c1-4665-bfad-2d605786530a",
+      "ConcordiaCourseId": "050326"
+    },
+    {
+      "Id": "c3838d0c-a171-48fc-a928-258beaacdc0f",
+      "ConcordiaCourseId": "050772"
+    },
+    {
+      "Id": "81c8e3ca-7546-4f1e-8dcb-eb4c13db7363",
+      "ConcordiaCourseId": "050773"
+    },
+    {
+      "Id": "7ecdeb5f-43ab-40c6-a4fb-287f23da3b35",
+      "ConcordiaCourseId": "023126"
+    },
+    {
+      "Id": "390d3979-83bf-45ca-ac3f-0f285e8ed59a",
+      "ConcordiaCourseId": "023127"
+    },
+    {
+      "Id": "dc5b2363-779e-44ed-9156-9dc14e5c8deb",
+      "ConcordiaCourseId": "023128"
+    },
+    {
+      "Id": "cd0b6b2c-1095-4e86-a8fe-8aedcab1de8e",
+      "ConcordiaCourseId": "023131"
+    },
+    {
+      "Id": "f202a80c-72c7-45ae-85ca-7aeef5e6b376",
+      "ConcordiaCourseId": "023140"
+    },
+    {
+      "Id": "8e2ec0a4-4a2f-493e-997d-921d2497e597",
+      "ConcordiaCourseId": "023141"
+    },
+    {
+      "Id": "2a764d1f-f5c5-4e75-9528-7c0273656ddd",
+      "ConcordiaCourseId": "023142"
+    },
+    {
+      "Id": "40b2a0d7-de67-4b5c-802e-a304071570c4",
+      "ConcordiaCourseId": "023143"
+    },
+    {
+      "Id": "e801667c-c192-4acd-941c-ebe9dc7cfec6",
+      "ConcordiaCourseId": "023144"
+    },
+    {
+      "Id": "a2fae8c3-8927-490a-a2ba-977b1b39dae8",
+      "ConcordiaCourseId": "023145"
+    },
+    {
+      "Id": "cbd9d15c-1b1d-4056-9960-699ed5c6bb68",
+      "ConcordiaCourseId": "023158"
+    },
+    {
+      "Id": "c965be4f-97f8-4cd3-ab56-2a1cfe22fcaa",
+      "ConcordiaCourseId": "023160"
+    },
+    {
+      "Id": "e3149bce-69f5-455a-98ee-5d207d7d23ef",
+      "ConcordiaCourseId": "023161"
+    },
+    {
+      "Id": "6182bff2-908f-4c01-9be4-501de91931d2",
+      "ConcordiaCourseId": "023162"
+    },
+    {
+      "Id": "a2e7f216-ecda-420a-a13c-c20edcacb9a3",
+      "ConcordiaCourseId": "046853"
+    },
+    {
+      "Id": "c1c0893e-2a6d-4d62-8313-460e35640e30",
+      "ConcordiaCourseId": "046854"
+    },
+    {
+      "Id": "2c36fa69-c9f6-46b0-8aee-9df7b1e64d2e",
+      "ConcordiaCourseId": "046855"
+    },
+    {
+      "Id": "83c84729-4cda-4726-bb06-424b99b2824a",
+      "ConcordiaCourseId": "046856"
+    },
+    {
+      "Id": "a454711a-690f-4528-ad03-ba701654ab12",
+      "ConcordiaCourseId": "046857"
+    },
+    {
+      "Id": "5461ba6e-8417-433e-a44a-e58862537610",
+      "ConcordiaCourseId": "046858"
+    },
+    {
+      "Id": "b90a7f47-fc6b-4616-8d62-3c73cc490523",
+      "ConcordiaCourseId": "046859"
+    },
+    {
+      "Id": "d36c81d5-91fb-4574-b989-fdd051e49706",
+      "ConcordiaCourseId": "046860"
+    },
+    {
+      "Id": "2a155cc4-763d-4f1c-a75f-2a4cb92d39be",
+      "ConcordiaCourseId": "046861"
+    },
+    {
+      "Id": "28d48e66-499b-4e97-8e28-d42470910f50",
+      "ConcordiaCourseId": "046862"
+    },
+    {
+      "Id": "4fc87cc3-e915-42b9-9210-33a83e89f6c3",
+      "ConcordiaCourseId": "046863"
+    },
+    {
+      "Id": "a5adf416-fcf3-4146-bb5e-0f17b99e283c",
+      "ConcordiaCourseId": "046864"
+    },
+    {
+      "Id": "6611d902-b1ff-4d5f-bdb8-e2cdd84f63e7",
+      "ConcordiaCourseId": "023402"
+    },
+    {
+      "Id": "73d4ecd8-43ea-4677-8f7f-d243039d16be",
+      "ConcordiaCourseId": "023403"
+    },
+    {
+      "Id": "acdc9b8d-6406-4e98-8f57-a4474ac9f6c2",
+      "ConcordiaCourseId": "023406"
+    },
+    {
+      "Id": "6f440836-6b42-4156-ad93-305ccf2754be",
+      "ConcordiaCourseId": "023409"
+    },
+    {
+      "Id": "120d822f-d738-49c3-abc8-869ec6700d89",
+      "ConcordiaCourseId": "046865"
+    },
+    {
+      "Id": "eb86d9c7-22e0-451f-a4f5-d1df0ce72339",
+      "ConcordiaCourseId": "046866"
+    },
+    {
+      "Id": "6b2f4000-9445-458b-b0f0-e48ff0e584c6",
+      "ConcordiaCourseId": "046867"
+    },
+    {
+      "Id": "7b761c84-977f-4653-bdc1-fcb629cbd266",
+      "ConcordiaCourseId": "046868"
+    },
+    {
+      "Id": "aaa1c7ec-24fe-4ced-8631-1b53af5fbae2",
+      "ConcordiaCourseId": "046869"
+    },
+    {
+      "Id": "849f5081-feaf-4e6c-9eaa-d3ff7bcb0f49",
+      "ConcordiaCourseId": "046870"
+    },
+    {
+      "Id": "d674d587-491b-48e4-9cee-30f5ed35c4f5",
+      "ConcordiaCourseId": "046871"
+    },
+    {
+      "Id": "e60e6ac4-c051-43a4-9d91-ade6a7c10879",
+      "ConcordiaCourseId": "046872"
+    },
+    {
+      "Id": "2e17f01e-6ff8-4bc6-b7ee-535b2295036a",
+      "ConcordiaCourseId": "023465"
+    },
+    {
+      "Id": "922e2621-7a2e-40a0-86b3-8a16171c3007",
+      "ConcordiaCourseId": "023467"
+    },
+    {
+      "Id": "fda55a94-4d26-4732-9919-8df7075d9d37",
+      "ConcordiaCourseId": "023471"
+    },
+    {
+      "Id": "3cdeac80-8b47-434d-96d1-1c2b2b04db63",
+      "ConcordiaCourseId": "023477"
+    },
+    {
+      "Id": "e072bf36-8737-42f8-abad-6a19c8514d52",
+      "ConcordiaCourseId": "023478"
+    },
+    {
+      "Id": "1a0709a8-85aa-41d0-a1f0-d2f2750bb4cf",
+      "ConcordiaCourseId": "023480"
+    },
+    {
+      "Id": "10c7570f-5aed-4db4-8f82-a4be75166797",
+      "ConcordiaCourseId": "023481"
+    },
+    {
+      "Id": "d86fab9d-10fa-4314-8404-a88a7b0ba6cc",
+      "ConcordiaCourseId": "023482"
+    },
+    {
+      "Id": "6abcae8f-dcc4-442d-92b4-345374a899e8",
+      "ConcordiaCourseId": "023483"
+    },
+    {
+      "Id": "a466be27-fd9c-4f64-a41d-9723ecfc227c",
+      "ConcordiaCourseId": "023486"
+    },
+    {
+      "Id": "c10efa1e-6dc4-422f-9a50-ae6731cdf220",
+      "ConcordiaCourseId": "023488"
+    },
+    {
+      "Id": "c47cec10-c055-413e-b170-44da4eac2a2e",
+      "ConcordiaCourseId": "023489"
+    },
+    {
+      "Id": "4a6441be-cc90-4d47-98a0-4d0e6f2da38c",
+      "ConcordiaCourseId": "023490"
+    },
+    {
+      "Id": "b770b617-a0d8-4e6d-b76d-9039d8de4472",
+      "ConcordiaCourseId": "023491"
+    },
+    {
+      "Id": "95dde3aa-94de-4d68-abde-8b6a53535d4e",
+      "ConcordiaCourseId": "023519"
+    },
+    {
+      "Id": "8cc4c7e2-f91a-43aa-81f0-bc7628bcf8a0",
+      "ConcordiaCourseId": "023525"
+    },
+    {
+      "Id": "0796f8f1-099d-4e0a-ad3e-a89796f70ea8",
+      "ConcordiaCourseId": "023527"
+    },
+    {
+      "Id": "5a096ed9-2601-4605-a49c-0efcee320cd9",
+      "ConcordiaCourseId": "023530"
+    },
+    {
+      "Id": "52c5003c-0450-4a70-b400-eb4cb460974d",
+      "ConcordiaCourseId": "023539"
+    },
+    {
+      "Id": "6558c957-994d-4688-8d04-e650d9ec002d",
+      "ConcordiaCourseId": "023540"
+    },
+    {
+      "Id": "a7066330-bd11-4fd3-8de7-e04b2e546a26",
+      "ConcordiaCourseId": "023542"
+    },
+    {
+      "Id": "e0edacaa-3eac-4617-818b-71bf9c75b81b",
+      "ConcordiaCourseId": "023543"
+    },
+    {
+      "Id": "66d57117-9813-46b4-b944-622628ee5250",
+      "ConcordiaCourseId": "023546"
+    },
+    {
+      "Id": "b9481379-b8bd-41d5-99fa-7d535f5adc09",
+      "ConcordiaCourseId": "023547"
+    },
+    {
+      "Id": "1a7a5e11-d675-493f-969c-31a4820eb712",
+      "ConcordiaCourseId": "023548"
+    },
+    {
+      "Id": "6bdc755e-b71a-4e43-9b49-519651e7cbd7",
+      "ConcordiaCourseId": "023549"
+    },
+    {
+      "Id": "f6b2efb3-d78e-4fe2-a3d1-b63559c6f542",
+      "ConcordiaCourseId": "023550"
+    },
+    {
+      "Id": "e8ce4aad-e71b-44c1-81f0-4c94278684b7",
+      "ConcordiaCourseId": "023551"
+    },
+    {
+      "Id": "459f9bbf-80b6-4f5c-b98f-ad908046165a",
+      "ConcordiaCourseId": "023563"
+    },
+    {
+      "Id": "0ef673c0-45a5-408d-865d-a78eccfbb68b",
+      "ConcordiaCourseId": "046873"
+    },
+    {
+      "Id": "67a055c7-0ee7-4059-9846-1a1d9c0ba65f",
+      "ConcordiaCourseId": "046874"
+    },
+    {
+      "Id": "e9c6b930-c360-4c4d-916f-7a4ff2d63c1b",
+      "ConcordiaCourseId": "046875"
+    },
+    {
+      "Id": "6dc4a662-ac40-4ada-8411-c79b2ca20852",
+      "ConcordiaCourseId": "046876"
+    },
+    {
+      "Id": "8b155196-42fa-4c43-86b2-8ce75fbd2486",
+      "ConcordiaCourseId": "046877"
+    },
+    {
+      "Id": "99f0cc56-9937-466f-9436-98869d1d032b",
+      "ConcordiaCourseId": "046878"
+    },
+    {
+      "Id": "4a1218d1-fe3d-4b8b-95a3-6297f544215a",
+      "ConcordiaCourseId": "046879"
+    },
+    {
+      "Id": "aac5a8fd-6a06-44ae-9762-ca7bf36896c6",
+      "ConcordiaCourseId": "046880"
+    },
+    {
+      "Id": "bab7311d-a11d-422b-8b03-8a5b88dd2ae4",
+      "ConcordiaCourseId": "046881"
+    },
+    {
+      "Id": "73e81bdd-75f6-47d3-848a-4e79c48056d3",
+      "ConcordiaCourseId": "049207"
+    },
+    {
+      "Id": "328d8fa8-a391-49ff-9cfd-368284f05f20",
+      "ConcordiaCourseId": "049208"
+    },
+    {
+      "Id": "d41d920e-eda3-47d9-b082-7185531fa0f8",
+      "ConcordiaCourseId": "049209"
+    },
+    {
+      "Id": "c118fb6c-dc28-4f89-a62d-c58637426758",
+      "ConcordiaCourseId": "049211"
+    },
+    {
+      "Id": "7dda4131-5689-4afe-a6df-7209e67261d1",
+      "ConcordiaCourseId": "049212"
+    },
+    {
+      "Id": "3080224b-29cf-4199-b0c5-e6f528a464a4",
+      "ConcordiaCourseId": "050372"
+    },
+    {
+      "Id": "a72831fe-cd2a-4338-ab9e-8456c687333b",
+      "ConcordiaCourseId": "023669"
+    },
+    {
+      "Id": "913b58c0-ac08-4a95-9b49-448d161b1c43",
+      "ConcordiaCourseId": "023670"
+    },
+    {
+      "Id": "b5db2b6c-6ff4-4d0f-9cb4-2d5fc6a3ec0b",
+      "ConcordiaCourseId": "023671"
+    },
+    {
+      "Id": "f94b636c-bece-4675-b867-acbaafcb0d44",
+      "ConcordiaCourseId": "023672"
+    },
+    {
+      "Id": "892a8882-e99d-4e89-9c28-d5c67d650c72",
+      "ConcordiaCourseId": "023674"
+    },
+    {
+      "Id": "9f4c336f-8ea9-4fa9-ba0a-f9b11f5cdbfb",
+      "ConcordiaCourseId": "023675"
+    },
+    {
+      "Id": "66b4322c-4643-4b8a-b3b3-7cf7d9a9e5e7",
+      "ConcordiaCourseId": "023676"
+    },
+    {
+      "Id": "49304298-1fef-485b-a40d-45591039c820",
+      "ConcordiaCourseId": "023677"
+    },
+    {
+      "Id": "62919e2a-cb4f-495f-ba69-22a756c0f9cf",
+      "ConcordiaCourseId": "023685"
+    },
+    {
+      "Id": "549954cc-197d-471b-aeff-d72e72661d9b",
+      "ConcordiaCourseId": "046882"
+    },
+    {
+      "Id": "800afabf-2d52-49a4-baca-e56f0c8d6256",
+      "ConcordiaCourseId": "046883"
+    },
+    {
+      "Id": "c2a437f4-0bbf-40ba-8daf-e95b152e8a47",
+      "ConcordiaCourseId": "047223"
+    },
+    {
+      "Id": "09b08799-8df7-4b2a-a67c-e1fcc82de8aa",
+      "ConcordiaCourseId": "047229"
+    },
+    {
+      "Id": "ec863953-927c-48f4-acb0-5706eae30d12",
+      "ConcordiaCourseId": "047444"
+    },
+    {
+      "Id": "7cf8ab19-93e8-48e2-9f7d-ece5f90491b9",
+      "ConcordiaCourseId": "048846"
+    },
+    {
+      "Id": "f2c5be78-5354-438d-8df1-6153f1d4b189",
+      "ConcordiaCourseId": "050420"
+    },
+    {
+      "Id": "015918c3-32ed-4f85-8ab5-edf0ea561930",
+      "ConcordiaCourseId": "045575"
+    },
+    {
+      "Id": "59df7733-06b4-4e4c-9ce1-7552ab1200d7",
+      "ConcordiaCourseId": "046884"
+    },
+    {
+      "Id": "c3fbd7a1-fff9-4c8e-9b9b-ba65ce545351",
+      "ConcordiaCourseId": "046885"
+    },
+    {
+      "Id": "156e339d-3b41-4121-b628-1d982b42db7c",
+      "ConcordiaCourseId": "046886"
+    },
+    {
+      "Id": "a02e62f2-de02-4084-b266-2500abfcd576",
+      "ConcordiaCourseId": "046887"
+    },
+    {
+      "Id": "35254012-e1bc-4986-9ed0-ccdf26a05e90",
+      "ConcordiaCourseId": "046888"
+    },
+    {
+      "Id": "a2e35fcd-3259-4983-bf9f-f4d65e039bbe",
+      "ConcordiaCourseId": "046889"
+    },
+    {
+      "Id": "d740a0f7-305a-4362-8a8d-ac33238624bd",
+      "ConcordiaCourseId": "046890"
+    },
+    {
+      "Id": "bc00eb42-5d04-4d62-92e5-167064ebedb8",
+      "ConcordiaCourseId": "046891"
+    },
+    {
+      "Id": "d4594daf-93d2-40d4-ada3-23ebab44f771",
+      "ConcordiaCourseId": "023736"
+    },
+    {
+      "Id": "a35a9812-9b8c-4282-bfdf-09c7288b8d9b",
+      "ConcordiaCourseId": "023737"
+    },
+    {
+      "Id": "1fa7a96b-1074-4efa-add7-e108a2b3f285",
+      "ConcordiaCourseId": "046892"
+    },
+    {
+      "Id": "b93fcc7f-3b1c-4401-b6cd-dfcd4e8dc30e",
+      "ConcordiaCourseId": "050427"
+    },
+    {
+      "Id": "71a2f5f9-50cb-4f87-90c4-aa74e52dc8f0",
+      "ConcordiaCourseId": "023738"
+    },
+    {
+      "Id": "2cc479ec-6428-428e-a620-58517c337144",
+      "ConcordiaCourseId": "023739"
+    },
+    {
+      "Id": "f8fc447f-9061-4958-b2ed-db3bb0afb97b",
+      "ConcordiaCourseId": "023746"
+    },
+    {
+      "Id": "7bcd6399-1614-4aab-a684-dd97fd82c096",
+      "ConcordiaCourseId": "023748"
+    },
+    {
+      "Id": "25968e09-8b30-4f08-948d-9614b45ba33c",
+      "ConcordiaCourseId": "023756"
+    },
+    {
+      "Id": "1fa65373-ba0b-4135-9ee5-d435df0d099c",
+      "ConcordiaCourseId": "023758"
+    },
+    {
+      "Id": "6d306c1b-258d-41bb-9443-2e247487d507",
+      "ConcordiaCourseId": "023763"
+    },
+    {
+      "Id": "be83737d-e453-4137-b0f1-8b01d03b8933",
+      "ConcordiaCourseId": "023766"
+    },
+    {
+      "Id": "5d3fc648-98b7-480e-a154-797b289a91d4",
+      "ConcordiaCourseId": "023768"
+    },
+    {
+      "Id": "9e1c4920-e622-4c7d-b041-3ec12f0352ad",
+      "ConcordiaCourseId": "023769"
+    },
+    {
+      "Id": "f71a6054-cc6f-4c71-8459-f7b7da86e313",
+      "ConcordiaCourseId": "023780"
+    },
+    {
+      "Id": "b5961693-91e4-4ec8-ba16-93700d4fc7ea",
+      "ConcordiaCourseId": "023787"
+    },
+    {
+      "Id": "cd77b75e-ca73-458e-a506-74c4b643b22d",
+      "ConcordiaCourseId": "023788"
+    },
+    {
+      "Id": "aba656b0-15f8-4aa3-ac6d-55b13cca0085",
+      "ConcordiaCourseId": "023789"
+    },
+    {
+      "Id": "19198729-ed08-4fd1-a15a-91294516edf1",
+      "ConcordiaCourseId": "023790"
+    },
+    {
+      "Id": "018183e4-0980-440e-92bb-36416a80c602",
+      "ConcordiaCourseId": "023791"
+    },
+    {
+      "Id": "47583d54-3040-430f-a24d-79d83d3cd3ee",
+      "ConcordiaCourseId": "023793"
+    },
+    {
+      "Id": "18b63078-45c5-4975-ac15-152ab69f6142",
+      "ConcordiaCourseId": "023800"
+    },
+    {
+      "Id": "65238402-1251-4d7e-b250-6e9bd1bfcc7f",
+      "ConcordiaCourseId": "023811"
+    },
+    {
+      "Id": "acf40cc3-f102-4f96-973e-76eede653851",
+      "ConcordiaCourseId": "023812"
+    },
+    {
+      "Id": "a067cd7b-2e9b-4e1e-963b-34bc98935a94",
+      "ConcordiaCourseId": "023813"
+    },
+    {
+      "Id": "0b21121b-3601-42fa-a35b-49fcb0de89d4",
+      "ConcordiaCourseId": "023814"
+    },
+    {
+      "Id": "d1edac69-87be-45d2-bdf7-733495e0f17d",
+      "ConcordiaCourseId": "023815"
+    },
+    {
+      "Id": "69481786-fd28-48f6-98f4-91ed1d22ee61",
+      "ConcordiaCourseId": "023816"
+    },
+    {
+      "Id": "25c15478-5f03-46eb-8c41-fa014f651906",
+      "ConcordiaCourseId": "023819"
+    },
+    {
+      "Id": "c58f13a2-a74b-45f4-8267-4e4ab2d002d6",
+      "ConcordiaCourseId": "023859"
+    },
+    {
+      "Id": "f87afa78-a29c-44c7-b3ec-5b11df6d3db7",
+      "ConcordiaCourseId": "023885"
+    },
+    {
+      "Id": "5df48b24-5478-4eac-8358-60566877f914",
+      "ConcordiaCourseId": "023886"
+    },
+    {
+      "Id": "d474db4d-8c6c-46b6-8c0a-d6f21ca9121e",
+      "ConcordiaCourseId": "023887"
+    },
+    {
+      "Id": "47f6450c-ea46-4db3-93e4-4a51e8d99e66",
+      "ConcordiaCourseId": "023888"
+    },
+    {
+      "Id": "c56df202-a61e-4228-ba8e-3105ee7ccc93",
+      "ConcordiaCourseId": "023890"
+    },
+    {
+      "Id": "e4d16234-3186-40e6-ab66-5ff37a789c41",
+      "ConcordiaCourseId": "023898"
+    },
+    {
+      "Id": "b131210b-e140-4f10-95e8-9720861dd565",
+      "ConcordiaCourseId": "041647"
+    },
+    {
+      "Id": "4499965a-6aaa-40a2-829b-1fe4e59bf3f3",
+      "ConcordiaCourseId": "046893"
+    },
+    {
+      "Id": "829f85ec-56e4-45a4-a7cc-c9bce1af9730",
+      "ConcordiaCourseId": "048103"
+    },
+    {
+      "Id": "aee67be5-8123-40d1-aa1a-863453fb811c",
+      "ConcordiaCourseId": "048104"
+    },
+    {
+      "Id": "25947250-2137-4744-ad7b-dce871071f2a",
+      "ConcordiaCourseId": "048105"
+    },
+    {
+      "Id": "e925b7af-9f4d-4586-9e03-da415e90831a",
+      "ConcordiaCourseId": "048106"
+    },
+    {
+      "Id": "3206f537-80cd-4920-91b2-c3158200170a",
+      "ConcordiaCourseId": "048107"
+    },
+    {
+      "Id": "5157a37c-80e0-4643-819a-175556b561a1",
+      "ConcordiaCourseId": "049017"
+    },
+    {
+      "Id": "3cf55c0e-74c3-4b0e-bf95-8e7d9e9da88a",
+      "ConcordiaCourseId": "049018"
+    },
+    {
+      "Id": "2b43260a-0a66-4c34-a437-5b1189e2f2f2",
+      "ConcordiaCourseId": "050043"
+    },
+    {
+      "Id": "59274f46-db15-44c9-ba69-6e89d12129e2",
+      "ConcordiaCourseId": "050044"
+    },
+    {
+      "Id": "1ba9eff6-5b05-4eb5-8492-33c97cf53b93",
+      "ConcordiaCourseId": "023969"
+    },
+    {
+      "Id": "0fe56bb3-94ce-4c9e-a35b-2e32b3ccdc0e",
+      "ConcordiaCourseId": "023970"
+    },
+    {
+      "Id": "813ac775-bd6f-42ac-b142-69fcba0990f7",
+      "ConcordiaCourseId": "023971"
+    },
+    {
+      "Id": "e307621a-24c3-4a79-ac1e-46d019f72ae6",
+      "ConcordiaCourseId": "023972"
+    },
+    {
+      "Id": "30a8f26e-cbc7-499a-9765-07d917b677bc",
+      "ConcordiaCourseId": "023974"
+    },
+    {
+      "Id": "95810311-e468-4790-810a-c88edf85abab",
+      "ConcordiaCourseId": "023975"
+    },
+    {
+      "Id": "0f38f5c1-7eb6-42bc-b396-95414a073d36",
+      "ConcordiaCourseId": "046894"
+    },
+    {
+      "Id": "b6d0a428-414a-4678-90bc-73aafe3339f8",
+      "ConcordiaCourseId": "047187"
+    },
+    {
+      "Id": "ed50bccb-b6ec-4389-af2d-a860a176f5f8",
+      "ConcordiaCourseId": "047188"
+    },
+    {
+      "Id": "a958fbef-df36-44ff-a0ec-2a23b4160848",
+      "ConcordiaCourseId": "047533"
+    },
+    {
+      "Id": "82a1ff02-63dd-4d28-b918-b6bc7a249cba",
+      "ConcordiaCourseId": "047791"
+    },
+    {
+      "Id": "40fb3c26-3f12-44e8-86ee-210306308475",
+      "ConcordiaCourseId": "048378"
+    },
+    {
+      "Id": "9efbc0cd-b21f-40b6-be13-99eade02eb17",
+      "ConcordiaCourseId": "048525"
+    },
+    {
+      "Id": "082dc686-56bc-4fe2-a4dd-b277fc3aafda",
+      "ConcordiaCourseId": "048844"
+    },
+    {
+      "Id": "2367e1d3-df52-4603-8227-4e27b91f971c",
+      "ConcordiaCourseId": "023982"
+    },
+    {
+      "Id": "2f3dc668-e9b4-4d9f-a179-a1ef844c8c55",
+      "ConcordiaCourseId": "023993"
+    },
+    {
+      "Id": "5148c361-5245-434d-aa3b-48cdcd7755fc",
+      "ConcordiaCourseId": "023994"
+    },
+    {
+      "Id": "69ad73f8-53bc-46a7-8442-8f91ee190014",
+      "ConcordiaCourseId": "023995"
+    },
+    {
+      "Id": "e82a9759-7023-4045-92b9-f46efbf94d8e",
+      "ConcordiaCourseId": "024012"
+    },
+    {
+      "Id": "fcdd162a-b86f-4328-85a0-67a79058e3e1",
+      "ConcordiaCourseId": "024013"
+    },
+    {
+      "Id": "82e89761-379c-4cd1-8b18-88ecc5cde5ab",
+      "ConcordiaCourseId": "024014"
+    },
+    {
+      "Id": "3d7c1ce8-fe4f-45f7-95d9-04eda7548ca4",
+      "ConcordiaCourseId": "024017"
+    },
+    {
+      "Id": "a9448f5c-d3d7-41c3-836c-36353e7a0b2b",
+      "ConcordiaCourseId": "024021"
+    },
+    {
+      "Id": "421ebd6b-a655-4ba7-bd1a-fd032ad1391f",
+      "ConcordiaCourseId": "024022"
+    },
+    {
+      "Id": "8e5bf3ea-0c90-4de7-90fd-85ceca1ee67e",
+      "ConcordiaCourseId": "024024"
+    },
+    {
+      "Id": "10c47b18-d3a8-4c33-8131-d88c9d501554",
+      "ConcordiaCourseId": "024025"
+    },
+    {
+      "Id": "ddb1b656-9af5-49b2-8218-5ed0535ab28f",
+      "ConcordiaCourseId": "024027"
+    },
+    {
+      "Id": "e85b6b75-a161-436b-95d9-2656dfabc483",
+      "ConcordiaCourseId": "024034"
+    },
+    {
+      "Id": "25760a8c-340d-448b-bdac-15e283fea86e",
+      "ConcordiaCourseId": "024035"
+    },
+    {
+      "Id": "afb5c862-9f61-4846-83d8-2ac7a899c709",
+      "ConcordiaCourseId": "024039"
+    },
+    {
+      "Id": "4eeb3375-af47-4bf4-abe6-e59fb6463bbd",
+      "ConcordiaCourseId": "024051"
+    },
+    {
+      "Id": "3b28b661-8aed-4b55-9fa2-ffdad7f9b68c",
+      "ConcordiaCourseId": "024059"
+    },
+    {
+      "Id": "ae36e480-6b82-41bd-bcff-4ce8eb2dad4b",
+      "ConcordiaCourseId": "024073"
+    },
+    {
+      "Id": "09b1c714-4cf5-4b10-b203-f8b7a8ef37ae",
+      "ConcordiaCourseId": "024074"
+    },
+    {
+      "Id": "4f7736f8-ebf6-4406-a17e-3dbab06f6985",
+      "ConcordiaCourseId": "024078"
+    },
+    {
+      "Id": "40bd2298-45a6-4c72-9c33-242c767124c8",
+      "ConcordiaCourseId": "024079"
+    },
+    {
+      "Id": "98dd8d50-9da5-4927-8169-619b0a92c6fc",
+      "ConcordiaCourseId": "024080"
+    },
+    {
+      "Id": "b09d4b7d-0463-4b27-a4a7-f08f12f3eeed",
+      "ConcordiaCourseId": "041651"
+    },
+    {
+      "Id": "85691913-7531-4f10-a9ff-42ac13e95748",
+      "ConcordiaCourseId": "046895"
+    },
+    {
+      "Id": "850aa6a2-c249-46eb-9255-3fd41b6f9c52",
+      "ConcordiaCourseId": "047614"
+    },
+    {
+      "Id": "ccfd0bc4-6c1b-4560-951e-47ecb2046535",
+      "ConcordiaCourseId": "047977"
+    },
+    {
+      "Id": "17e08764-705d-4cb6-8be7-df658f6c4db5",
+      "ConcordiaCourseId": "048108"
+    },
+    {
+      "Id": "00876c63-794f-41f2-a9fa-ecb7a03bc4df",
+      "ConcordiaCourseId": "048109"
+    },
+    {
+      "Id": "e3106ced-38e3-463b-9b8f-b3b375cff24a",
+      "ConcordiaCourseId": "049384"
+    },
+    {
+      "Id": "1af55a16-a445-4ba9-8cc5-a9b7fd0b917a",
+      "ConcordiaCourseId": "050774"
+    },
+    {
+      "Id": "03d657d9-1845-40af-aa7e-b8846c0067f0",
+      "ConcordiaCourseId": "024128"
+    },
+    {
+      "Id": "995cabd2-ec93-4d81-a508-454e23f07b91",
+      "ConcordiaCourseId": "024129"
+    },
+    {
+      "Id": "64fed789-5902-4c55-8852-6b438bb9818b",
+      "ConcordiaCourseId": "024130"
+    },
+    {
+      "Id": "2e326c1a-993a-45a2-83d4-d46eef9bf4a9",
+      "ConcordiaCourseId": "024131"
+    },
+    {
+      "Id": "0beee1e6-7898-436b-b43c-7d8ff82e0d49",
+      "ConcordiaCourseId": "024132"
+    },
+    {
+      "Id": "b33898d7-7edf-4dba-aced-e899a7d8613e",
+      "ConcordiaCourseId": "024133"
+    },
+    {
+      "Id": "e019041a-7da8-4eec-91da-b359fc9cd557",
+      "ConcordiaCourseId": "024134"
+    },
+    {
+      "Id": "62f377b8-bbfc-4673-aa82-65d09c2683ea",
+      "ConcordiaCourseId": "024135"
+    },
+    {
+      "Id": "3f2a829c-07e2-425e-ba4c-19cb774336a6",
+      "ConcordiaCourseId": "024136"
+    },
+    {
+      "Id": "a2a47704-ff5a-4634-98a8-9c7700a8649d",
+      "ConcordiaCourseId": "024137"
+    },
+    {
+      "Id": "fddc3798-6379-4743-aeff-67d9722eda44",
+      "ConcordiaCourseId": "024138"
+    },
+    {
+      "Id": "65761b76-19ff-4d54-9029-f944b40ae21a",
+      "ConcordiaCourseId": "024139"
+    },
+    {
+      "Id": "45eb5ba0-4cc9-406b-bd2f-73cebc05a4f4",
+      "ConcordiaCourseId": "024140"
+    },
+    {
+      "Id": "111d43d6-a1dd-4408-a92b-6f38deb09a8b",
+      "ConcordiaCourseId": "024141"
+    },
+    {
+      "Id": "61d9b5c3-5ba7-402a-b2fd-d12a85378954",
+      "ConcordiaCourseId": "024142"
+    },
+    {
+      "Id": "f4e96c46-18a3-43f5-87dc-fbb0ffc3bc0b",
+      "ConcordiaCourseId": "024143"
+    },
+    {
+      "Id": "567d9625-1b22-45a6-83a4-8b928d110502",
+      "ConcordiaCourseId": "024147"
+    },
+    {
+      "Id": "5e921ee5-0f49-42ad-8fa7-e7bc4fb2e504",
+      "ConcordiaCourseId": "024152"
+    },
+    {
+      "Id": "6632a2b9-51e3-41ef-a2b7-c367497d23ef",
+      "ConcordiaCourseId": "024162"
+    },
+    {
+      "Id": "faf12fe4-b1d0-416b-b7e1-e179d94b63c2",
+      "ConcordiaCourseId": "024164"
+    },
+    {
+      "Id": "8e74a816-c701-4ed2-bcc1-3ff69e484c07",
+      "ConcordiaCourseId": "024165"
+    },
+    {
+      "Id": "c0ca9b92-9e37-492c-974b-b109ed20f234",
+      "ConcordiaCourseId": "024180"
+    },
+    {
+      "Id": "7455df3b-3c97-44ae-9123-905719b894d4",
+      "ConcordiaCourseId": "024182"
+    },
+    {
+      "Id": "35aeb7df-fe3b-4742-8989-5672c528499c",
+      "ConcordiaCourseId": "024184"
+    },
+    {
+      "Id": "0442e5de-f27c-4b1d-915a-00495580901d",
+      "ConcordiaCourseId": "024186"
+    },
+    {
+      "Id": "a5bc1c1b-7fed-4fa6-bf5a-783c7cb38fe9",
+      "ConcordiaCourseId": "024191"
+    },
+    {
+      "Id": "c9ae7073-1c99-4ce4-9660-a0c3ad7a351c",
+      "ConcordiaCourseId": "024224"
+    },
+    {
+      "Id": "734276d2-b1af-41ba-b5f5-4ac875487e94",
+      "ConcordiaCourseId": "024226"
+    },
+    {
+      "Id": "32cfaf83-4c21-4359-b687-6b092a3f92f1",
+      "ConcordiaCourseId": "024233"
+    },
+    {
+      "Id": "abe82d52-f73a-4570-b10b-31b2f4696d4b",
+      "ConcordiaCourseId": "024234"
+    },
+    {
+      "Id": "3d1a4ae2-cfdb-4e99-b594-3e3dd41a9778",
+      "ConcordiaCourseId": "024235"
+    },
+    {
+      "Id": "5ced9c3d-62d9-4572-b857-4836d1aeef57",
+      "ConcordiaCourseId": "024278"
+    },
+    {
+      "Id": "741a2d88-f145-4e18-bcdf-66b75b0e7cc2",
+      "ConcordiaCourseId": "024279"
+    },
+    {
+      "Id": "da71a767-7d4c-4cd8-b77f-75f25ef1dedb",
+      "ConcordiaCourseId": "024281"
+    },
+    {
+      "Id": "cdb70c6c-a29f-450e-99e7-ea6398c7393d",
+      "ConcordiaCourseId": "024282"
+    },
+    {
+      "Id": "a0d61bb3-711c-4024-a961-e81942c47116",
+      "ConcordiaCourseId": "024283"
+    },
+    {
+      "Id": "258263ca-30eb-4a9b-906d-6a08c03aa92d",
+      "ConcordiaCourseId": "024314"
+    },
+    {
+      "Id": "c4baffcd-2cb6-41f9-8d68-57eded9b2bdf",
+      "ConcordiaCourseId": "024315"
+    },
+    {
+      "Id": "5b8db7f1-7bd9-41c5-9ead-6aa98dcc8f4a",
+      "ConcordiaCourseId": "024361"
+    },
+    {
+      "Id": "0fc29770-a5a7-4675-8362-8fe5e2684d23",
+      "ConcordiaCourseId": "024362"
+    },
+    {
+      "Id": "678b67b5-03ee-49b2-aa75-6ab89fc8217f",
+      "ConcordiaCourseId": "024363"
+    },
+    {
+      "Id": "9c249863-6ae6-4cb1-ace2-8d2e641f3b01",
+      "ConcordiaCourseId": "024366"
+    },
+    {
+      "Id": "a6fbbffd-d2dc-4d9d-817b-707658fd92a9",
+      "ConcordiaCourseId": "041657"
+    },
+    {
+      "Id": "a685bb48-5554-4edf-bc8e-94fadbe03be1",
+      "ConcordiaCourseId": "041658"
+    },
+    {
+      "Id": "8a226bc0-660b-4c35-864c-248a9ef73836",
+      "ConcordiaCourseId": "041659"
+    },
+    {
+      "Id": "6aa6b102-ee92-4967-8cfb-6244ac2deb1d",
+      "ConcordiaCourseId": "041667"
+    },
+    {
+      "Id": "2fe0fed9-c240-45a5-a3a3-af1638a759aa",
+      "ConcordiaCourseId": "041668"
+    },
+    {
+      "Id": "fdc07dd3-6551-4749-a920-2d5f9b586e05",
+      "ConcordiaCourseId": "041669"
+    },
+    {
+      "Id": "fc858b40-d3d6-4e97-b3f3-329f1eca1c24",
+      "ConcordiaCourseId": "041674"
+    },
+    {
+      "Id": "8e44a589-40c8-4e34-ae36-a40b0d52d4ca",
+      "ConcordiaCourseId": "041692"
+    },
+    {
+      "Id": "637017d7-87a1-4b4a-9a72-71cb9de2829d",
+      "ConcordiaCourseId": "041729"
+    },
+    {
+      "Id": "bfbe9832-779c-4c9f-8230-3116c47f899e",
+      "ConcordiaCourseId": "041731"
+    },
+    {
+      "Id": "fa94551f-7d4b-42d0-ae1a-1297645435b0",
+      "ConcordiaCourseId": "041744"
+    },
+    {
+      "Id": "90acc26e-cfa8-4e6c-91c5-73002982f411",
+      "ConcordiaCourseId": "046896"
+    },
+    {
+      "Id": "e3b8b9f0-df5c-4e47-99f3-4af267cb83bc",
+      "ConcordiaCourseId": "046897"
+    },
+    {
+      "Id": "f821ecd8-7461-45cf-9021-81ff2ebf5860",
+      "ConcordiaCourseId": "046898"
+    },
+    {
+      "Id": "1dd7d21e-333f-4c96-974a-c5315ed1e384",
+      "ConcordiaCourseId": "046899"
+    },
+    {
+      "Id": "b5758660-f3cd-4574-9926-d825e1c77981",
+      "ConcordiaCourseId": "046900"
+    },
+    {
+      "Id": "3097eb9d-8a31-49a4-9313-d831d05f2db2",
+      "ConcordiaCourseId": "046901"
+    },
+    {
+      "Id": "d42ccea5-9fdd-4fcb-bab6-89bf3a2fc4e8",
+      "ConcordiaCourseId": "046902"
+    },
+    {
+      "Id": "79f4a100-cbbc-4773-88ea-0f8ae14d8764",
+      "ConcordiaCourseId": "046903"
+    },
+    {
+      "Id": "827c15e9-b063-4ba1-a69f-674c8b98acfe",
+      "ConcordiaCourseId": "046904"
+    },
+    {
+      "Id": "3c11cf93-584d-4ad3-943a-6e36e7f6ec16",
+      "ConcordiaCourseId": "046905"
+    },
+    {
+      "Id": "0211f6a3-c340-479a-a0d5-ae31e73fa178",
+      "ConcordiaCourseId": "046906"
+    },
+    {
+      "Id": "0708266b-10c2-4bf0-87ec-d5beb4df5be0",
+      "ConcordiaCourseId": "046907"
+    },
+    {
+      "Id": "96a859e1-12fb-4a7b-9e6a-f83961e55ca5",
+      "ConcordiaCourseId": "046908"
+    },
+    {
+      "Id": "ab8a40ec-80ad-4259-b37d-d5d016ab4d9d",
+      "ConcordiaCourseId": "046909"
+    },
+    {
+      "Id": "dbcd0dfa-cd21-48df-919e-2055cd0ce0c2",
+      "ConcordiaCourseId": "046910"
+    },
+    {
+      "Id": "e59299fc-184c-4ec6-b311-e6f8a6882d4e",
+      "ConcordiaCourseId": "046911"
+    },
+    {
+      "Id": "13e57342-7ffe-477a-844b-34977b40b91b",
+      "ConcordiaCourseId": "046912"
+    },
+    {
+      "Id": "bf3cd43c-9350-42ee-b055-8ff39c7dd9d1",
+      "ConcordiaCourseId": "046913"
+    },
+    {
+      "Id": "b600fdb4-1634-42c4-af1f-401b38f0e082",
+      "ConcordiaCourseId": "046914"
+    },
+    {
+      "Id": "fae8f7c5-7da9-44f6-b4b6-1f3e8319378f",
+      "ConcordiaCourseId": "046915"
+    },
+    {
+      "Id": "3257dcbc-dfd9-4913-bf5b-70a573e9f3f6",
+      "ConcordiaCourseId": "046916"
+    },
+    {
+      "Id": "07b09775-457a-4c6c-a18d-6975d4967b7f",
+      "ConcordiaCourseId": "046917"
+    },
+    {
+      "Id": "76f0c612-6e30-4f7f-8bc5-b6db633c22a1",
+      "ConcordiaCourseId": "046918"
+    },
+    {
+      "Id": "99daf2a5-b840-4e7e-aebe-d65aa7d7f9cc",
+      "ConcordiaCourseId": "047181"
+    },
+    {
+      "Id": "16efecb1-5031-43e5-a4a4-3f5d0cef5526",
+      "ConcordiaCourseId": "047183"
+    },
+    {
+      "Id": "f396513e-826e-4fd1-8a96-0d76674024e3",
+      "ConcordiaCourseId": "047184"
+    },
+    {
+      "Id": "73c8372c-a79b-4a79-9a8a-7e898b9546a5",
+      "ConcordiaCourseId": "047185"
+    },
+    {
+      "Id": "8e58952b-5c58-4f05-8800-43e9a36c7eb1",
+      "ConcordiaCourseId": "047259"
+    },
+    {
+      "Id": "25e79879-7c2d-477e-a641-48eea1f2dfd7",
+      "ConcordiaCourseId": "047276"
+    },
+    {
+      "Id": "42fc816c-44b7-49bf-95ca-7b2cd03591a0",
+      "ConcordiaCourseId": "047277"
+    },
+    {
+      "Id": "80fe4638-b67f-4c59-9c53-4f119b9836a4",
+      "ConcordiaCourseId": "047867"
+    },
+    {
+      "Id": "ce407da9-2f05-49dc-8ad4-0f6c4c154ce9",
+      "ConcordiaCourseId": "048039"
+    },
+    {
+      "Id": "881316f5-48cc-4626-ad37-5c5e1b20155b",
+      "ConcordiaCourseId": "048414"
+    },
+    {
+      "Id": "ffb12251-9ba7-4fdf-bec5-d17a0f7dc5b6",
+      "ConcordiaCourseId": "049590"
+    },
+    {
+      "Id": "0b47480f-6fde-4911-aa46-f4d747026600",
+      "ConcordiaCourseId": "050075"
+    },
+    {
+      "Id": "be75ce21-8b0d-4dc5-879e-2ddd42a7c7b1",
+      "ConcordiaCourseId": "050509"
+    },
+    {
+      "Id": "9bae8f91-afdc-41c6-9abc-0fce672c0ce4",
+      "ConcordiaCourseId": "050511"
+    },
+    {
+      "Id": "264525a9-12e1-4110-af05-c544f876af18",
+      "ConcordiaCourseId": "024431"
+    },
+    {
+      "Id": "835f5744-d500-4cee-a42e-0eead017a32c",
+      "ConcordiaCourseId": "024433"
+    },
+    {
+      "Id": "15537a22-a7f5-4b80-a3c9-bba97b22a048",
+      "ConcordiaCourseId": "024435"
+    },
+    {
+      "Id": "bd52e13e-24a7-45f3-87aa-c24e59bc0c2b",
+      "ConcordiaCourseId": "024439"
+    },
+    {
+      "Id": "d922ca01-fefe-4576-bada-df11fcc70756",
+      "ConcordiaCourseId": "024441"
+    },
+    {
+      "Id": "14245408-6580-4e67-b7d2-8e0af786e8b2",
+      "ConcordiaCourseId": "024442"
+    },
+    {
+      "Id": "be8146a2-43c4-4b63-aac0-a7d974d22925",
+      "ConcordiaCourseId": "024445"
+    },
+    {
+      "Id": "97d7cfb9-5048-4fe3-aa7a-2abf563ab6d8",
+      "ConcordiaCourseId": "024448"
+    },
+    {
+      "Id": "4ddf8af9-e531-4f46-bb94-791a690ec00e",
+      "ConcordiaCourseId": "024450"
+    },
+    {
+      "Id": "697f63f1-6b10-49e7-ac8c-33695e0d5c78",
+      "ConcordiaCourseId": "024456"
+    },
+    {
+      "Id": "590f5c53-ae89-4079-b32a-4aef1dfd9b81",
+      "ConcordiaCourseId": "024465"
+    },
+    {
+      "Id": "92040f04-fae0-4019-aaac-a00d4a7e40ae",
+      "ConcordiaCourseId": "024505"
+    },
+    {
+      "Id": "d36a2d9f-ae23-4566-bde9-dc503b8f5e6e",
+      "ConcordiaCourseId": "024506"
+    },
+    {
+      "Id": "5001c41a-cd36-427e-adb2-2efc9a2aff53",
+      "ConcordiaCourseId": "024510"
+    },
+    {
+      "Id": "45b3493f-d2d5-4d75-adad-a77c2a63af09",
+      "ConcordiaCourseId": "024511"
+    },
+    {
+      "Id": "45d6f762-a202-46cd-8878-798911fabc0c",
+      "ConcordiaCourseId": "024575"
+    },
+    {
+      "Id": "85c9e0fe-c7f2-41e1-838f-a5313d8959c4",
+      "ConcordiaCourseId": "024592"
+    },
+    {
+      "Id": "810eaa2b-927c-4e2d-b45d-bdc72a18bd6b",
+      "ConcordiaCourseId": "024593"
+    },
+    {
+      "Id": "4d419d96-e40b-4476-97ec-b0b6f07b34f9",
+      "ConcordiaCourseId": "024596"
+    },
+    {
+      "Id": "5f82e899-169d-4247-92a2-272b10baf27f",
+      "ConcordiaCourseId": "024597"
+    },
+    {
+      "Id": "c697c5ef-1e19-4dd7-b569-d358a9387fff",
+      "ConcordiaCourseId": "024598"
+    },
+    {
+      "Id": "9bb163a9-b7ad-48f1-8b8f-4b72a51f4fcf",
+      "ConcordiaCourseId": "024600"
+    },
+    {
+      "Id": "c26bff73-826e-4dd6-87bd-44854350bdbb",
+      "ConcordiaCourseId": "024601"
+    },
+    {
+      "Id": "15040c60-f23d-44ae-9cf1-f0ec74d52518",
+      "ConcordiaCourseId": "024616"
+    },
+    {
+      "Id": "642152fc-34bc-4742-8c4e-0f1b82e5d11a",
+      "ConcordiaCourseId": "024620"
+    },
+    {
+      "Id": "e729819c-8ab5-49bb-b648-ebd401b6f860",
+      "ConcordiaCourseId": "024650"
+    },
+    {
+      "Id": "4f622c64-d881-4094-ac98-60facd57f786",
+      "ConcordiaCourseId": "024661"
+    },
+    {
+      "Id": "29ef7561-46cf-444b-bdf3-42c34c8c5eb6",
+      "ConcordiaCourseId": "024667"
+    },
+    {
+      "Id": "fef161f0-176e-4827-a89f-f8743b523537",
+      "ConcordiaCourseId": "024681"
+    },
+    {
+      "Id": "13446b0b-376b-4361-afa0-7e3dfedbfbb7",
+      "ConcordiaCourseId": "024683"
+    },
+    {
+      "Id": "a00b9c02-b5a8-4e32-a61c-fb0fc4cc0a64",
+      "ConcordiaCourseId": "024684"
+    },
+    {
+      "Id": "2182520a-e8e1-49ae-ad44-21c9e332cba4",
+      "ConcordiaCourseId": "024685"
+    },
+    {
+      "Id": "e78fdee8-fdcf-445a-8219-cd90c4ce870a",
+      "ConcordiaCourseId": "024686"
+    },
+    {
+      "Id": "0c2c2896-31e2-4fd3-98cb-27c6b57f641f",
+      "ConcordiaCourseId": "024687"
+    },
+    {
+      "Id": "e27e0018-0db9-40fa-9bc3-8f9898f71eb3",
+      "ConcordiaCourseId": "024688"
+    },
+    {
+      "Id": "4c0a18d3-470d-4ff4-b3ac-7c911aaf779b",
+      "ConcordiaCourseId": "024690"
+    },
+    {
+      "Id": "270cd95b-485c-48b4-add6-55bd415e6ee0",
+      "ConcordiaCourseId": "024691"
+    },
+    {
+      "Id": "cd33d4b3-9426-4e8a-a4f0-7864fa562c04",
+      "ConcordiaCourseId": "024692"
+    },
+    {
+      "Id": "d9a53a83-f0be-47db-bc18-039dbc634162",
+      "ConcordiaCourseId": "024693"
+    },
+    {
+      "Id": "299b2831-5c7c-4656-970c-a1746769f55a",
+      "ConcordiaCourseId": "024694"
+    },
+    {
+      "Id": "c84cf4e2-c16b-4fcb-92c5-0dc4ce2b0908",
+      "ConcordiaCourseId": "024710"
+    },
+    {
+      "Id": "bfd4e129-565c-4976-95d0-efd416abcebc",
+      "ConcordiaCourseId": "024714"
+    },
+    {
+      "Id": "a1b493c6-40a4-496b-8e9f-580b38e7dbc3",
+      "ConcordiaCourseId": "024717"
+    },
+    {
+      "Id": "cffccff1-56be-4352-a9c8-f4cc870c04a3",
+      "ConcordiaCourseId": "024760"
+    },
+    {
+      "Id": "d4abd740-31fa-4647-96e3-9980064928ee",
+      "ConcordiaCourseId": "024767"
+    },
+    {
+      "Id": "90c61152-a5e0-42c1-b9ec-8976e62528db",
+      "ConcordiaCourseId": "024783"
+    },
+    {
+      "Id": "b8c17c23-bf56-49f3-8dc6-4897ae591d0c",
+      "ConcordiaCourseId": "024794"
+    },
+    {
+      "Id": "173719e7-a9a8-40cf-9d40-645bd875965f",
+      "ConcordiaCourseId": "024804"
+    },
+    {
+      "Id": "4d116fe6-e00f-4c5b-86ec-15b1d294f8e8",
+      "ConcordiaCourseId": "024810"
+    },
+    {
+      "Id": "437ecb46-f401-4954-9b08-7d7a78b9906a",
+      "ConcordiaCourseId": "024818"
+    },
+    {
+      "Id": "6844bd0a-a5d4-42fb-b6cf-d621fe62c062",
+      "ConcordiaCourseId": "024820"
+    },
+    {
+      "Id": "93e5c885-2c6b-4a63-917a-65a4e38c9ead",
+      "ConcordiaCourseId": "024823"
+    },
+    {
+      "Id": "4fcb8d94-8246-4d8d-b1f1-a54e455d1040",
+      "ConcordiaCourseId": "024836"
+    },
+    {
+      "Id": "03d76c60-bd42-41a6-9b1d-90eb2aa485e1",
+      "ConcordiaCourseId": "024837"
+    },
+    {
+      "Id": "03c0a10b-552b-46e3-aac3-f44cef9fe700",
+      "ConcordiaCourseId": "024838"
+    },
+    {
+      "Id": "0ff6424f-7519-4c63-8f21-d7fdd4413776",
+      "ConcordiaCourseId": "024851"
+    },
+    {
+      "Id": "bc3718bb-8d16-43d4-afe0-187bc0f2a60c",
+      "ConcordiaCourseId": "024854"
+    },
+    {
+      "Id": "5b75d5b1-ae4f-484b-adaa-d8bedeb03c59",
+      "ConcordiaCourseId": "024857"
+    },
+    {
+      "Id": "f5fd7492-8cbd-492e-981c-c45f7255249a",
+      "ConcordiaCourseId": "024859"
+    },
+    {
+      "Id": "98dd5b74-afe0-4904-87ec-996a2b015a20",
+      "ConcordiaCourseId": "024864"
+    },
+    {
+      "Id": "a0d96e93-d70b-411d-822b-d8e20be6f092",
+      "ConcordiaCourseId": "024871"
+    },
+    {
+      "Id": "1cf8676e-c3ea-4c50-b8a0-90ed80984940",
+      "ConcordiaCourseId": "024877"
+    },
+    {
+      "Id": "420abe7e-48bf-4ec5-b18e-4dfd07d6637a",
+      "ConcordiaCourseId": "024878"
+    },
+    {
+      "Id": "c11ecdfd-e829-495c-83d2-99ba75779e09",
+      "ConcordiaCourseId": "024880"
+    },
+    {
+      "Id": "0364c1ed-0cd0-435e-9666-9d597f683781",
+      "ConcordiaCourseId": "024903"
+    },
+    {
+      "Id": "0e239eed-16c9-41b3-9a82-4e0ce0be3c2c",
+      "ConcordiaCourseId": "024907"
+    },
+    {
+      "Id": "389c89d0-8690-46d2-8894-b712d7627dbb",
+      "ConcordiaCourseId": "024910"
+    },
+    {
+      "Id": "cc3fa3a5-2ffb-4b5a-9518-27990b9059de",
+      "ConcordiaCourseId": "024918"
+    },
+    {
+      "Id": "3bde8eef-62af-45f5-b8e2-95152e51f0f3",
+      "ConcordiaCourseId": "024924"
+    },
+    {
+      "Id": "712692a8-c265-4f96-aff9-3a2dc0154e07",
+      "ConcordiaCourseId": "024932"
+    },
+    {
+      "Id": "19111304-1ede-4f94-aa9f-a54b394d8466",
+      "ConcordiaCourseId": "024948"
+    },
+    {
+      "Id": "92df6e1b-af05-41c2-ae48-c127873a26a8",
+      "ConcordiaCourseId": "024950"
+    },
+    {
+      "Id": "a59f882c-5e55-4d04-8a24-4bb0cb4da6c0",
+      "ConcordiaCourseId": "024970"
+    },
+    {
+      "Id": "2911a457-6d58-457d-b61c-0983d086bd97",
+      "ConcordiaCourseId": "024979"
+    },
+    {
+      "Id": "1e8b75f6-b33e-4b21-8bda-770cf153bedd",
+      "ConcordiaCourseId": "024982"
+    },
+    {
+      "Id": "2ca7029f-b57f-44aa-9974-ba4eacac84d9",
+      "ConcordiaCourseId": "024997"
+    },
+    {
+      "Id": "fed836d5-02ae-475f-bab5-46c6c02c1814",
+      "ConcordiaCourseId": "025002"
+    },
+    {
+      "Id": "47e4b006-33b8-4179-8f9e-dd0e48205abf",
+      "ConcordiaCourseId": "041771"
+    },
+    {
+      "Id": "5bbfba05-d4ae-42bc-9db8-5b081e5e3938",
+      "ConcordiaCourseId": "041815"
+    },
+    {
+      "Id": "47ef9f4f-d250-4d2d-8d8c-b9a2686c15be",
+      "ConcordiaCourseId": "045616"
+    },
+    {
+      "Id": "5c7e3add-cfc2-449a-b263-88995dc84500",
+      "ConcordiaCourseId": "046919"
+    },
+    {
+      "Id": "d99fdebd-7662-455f-b024-cc0f2b632ac9",
+      "ConcordiaCourseId": "046920"
+    },
+    {
+      "Id": "90afcb25-e83e-439c-b19e-f87c17630f77",
+      "ConcordiaCourseId": "046921"
+    },
+    {
+      "Id": "32cf8f63-63af-4e8c-bb37-25931bbdbde1",
+      "ConcordiaCourseId": "046922"
+    },
+    {
+      "Id": "305d0553-182a-41fa-82d2-b8d6d155010c",
+      "ConcordiaCourseId": "046923"
+    },
+    {
+      "Id": "3708125c-995d-42c7-96ea-4fa432cc0ced",
+      "ConcordiaCourseId": "046924"
+    },
+    {
+      "Id": "5d0326cd-f8d0-4e8b-b53a-d64147874a0d",
+      "ConcordiaCourseId": "046925"
+    },
+    {
+      "Id": "ecbfba4a-541e-4d02-9862-01aaf5cc8041",
+      "ConcordiaCourseId": "046926"
+    },
+    {
+      "Id": "4ece3ca0-b76d-45cc-a75f-d272c662ba93",
+      "ConcordiaCourseId": "046927"
+    },
+    {
+      "Id": "727e3ed1-659e-4a1b-88dd-b20fe7a7cb4c",
+      "ConcordiaCourseId": "046928"
+    },
+    {
+      "Id": "6fa61e41-e5de-40c8-803e-f4b58b55ede6",
+      "ConcordiaCourseId": "046929"
+    },
+    {
+      "Id": "83378608-50aa-4121-a8ff-ca24ec23918d",
+      "ConcordiaCourseId": "046930"
+    },
+    {
+      "Id": "9a82c2f1-a4e4-4556-b55f-1e7eb50655a8",
+      "ConcordiaCourseId": "046931"
+    },
+    {
+      "Id": "078a3327-f350-47be-a899-ed6a926effe3",
+      "ConcordiaCourseId": "046932"
+    },
+    {
+      "Id": "06573d53-23cc-4ab3-8981-8214377e9d9b",
+      "ConcordiaCourseId": "025245"
+    },
+    {
+      "Id": "7b1dba6d-b71e-4692-a43f-889288bf059b",
+      "ConcordiaCourseId": "025246"
+    },
+    {
+      "Id": "2a4f1a27-9faa-4d42-9111-c890278109cd",
+      "ConcordiaCourseId": "025247"
+    },
+    {
+      "Id": "02299a4e-e736-47ad-95b5-b29e938e5096",
+      "ConcordiaCourseId": "025248"
+    },
+    {
+      "Id": "48ce4584-31da-4ecd-8524-801a7071ae94",
+      "ConcordiaCourseId": "025249"
+    },
+    {
+      "Id": "6b00a6c2-2e05-4588-93ff-fcc5fefc2bd4",
+      "ConcordiaCourseId": "025252"
+    },
+    {
+      "Id": "3e9b02c7-b7f2-4b0c-9fba-cc14dbc868fe",
+      "ConcordiaCourseId": "025253"
+    },
+    {
+      "Id": "462ce8ad-e40c-4058-af9f-34ecbfc19f86",
+      "ConcordiaCourseId": "025254"
+    },
+    {
+      "Id": "59044342-8637-46ad-b99e-f8c6b27d17f6",
+      "ConcordiaCourseId": "025256"
+    },
+    {
+      "Id": "1aa522a9-909d-4819-ae92-d2e80f80ec6c",
+      "ConcordiaCourseId": "025257"
+    },
+    {
+      "Id": "005184ef-6d67-4aa5-82dc-f486e4f5254c",
+      "ConcordiaCourseId": "025260"
+    },
+    {
+      "Id": "5152d50e-d2c1-43a6-84c5-996dcff82016",
+      "ConcordiaCourseId": "025262"
+    },
+    {
+      "Id": "35849e2f-7adf-43be-8d8a-4640e6cb815a",
+      "ConcordiaCourseId": "025264"
+    },
+    {
+      "Id": "91e8695d-5c8c-4cf9-b283-716e328e3b61",
+      "ConcordiaCourseId": "025267"
+    },
+    {
+      "Id": "0add63e1-aa34-4010-bb36-81a970946078",
+      "ConcordiaCourseId": "025268"
+    },
+    {
+      "Id": "16b870ec-63f9-4566-b045-a3329f719d5b",
+      "ConcordiaCourseId": "025269"
+    },
+    {
+      "Id": "50b5ce1e-23db-441f-966a-1ad025ca5dad",
+      "ConcordiaCourseId": "048058"
+    },
+    {
+      "Id": "91c65521-395b-4161-be8c-2bbf698ff293",
+      "ConcordiaCourseId": "048059"
+    },
+    {
+      "Id": "029a89fb-b576-4fcc-b271-f0d4efda71f3",
+      "ConcordiaCourseId": "048060"
+    },
+    {
+      "Id": "ff988299-b977-47c6-ba96-7d26a02501e8",
+      "ConcordiaCourseId": "048061"
+    },
+    {
+      "Id": "8b558b50-a8dc-4a3c-9571-90c206ee1f6c",
+      "ConcordiaCourseId": "048062"
+    },
+    {
+      "Id": "fcf2b8e4-eee6-4c93-a6c1-e0c770b25a9f",
+      "ConcordiaCourseId": "048063"
+    },
+    {
+      "Id": "6952a269-dcd2-4b87-a5af-d32c1eae7478",
+      "ConcordiaCourseId": "048064"
+    },
+    {
+      "Id": "f31d1f60-08e1-43ab-8b60-a5913795860c",
+      "ConcordiaCourseId": "048066"
+    },
+    {
+      "Id": "a95c190e-5668-46b9-aec2-bb088f4225a7",
+      "ConcordiaCourseId": "048067"
+    },
+    {
+      "Id": "19326db4-d658-4793-96d8-7d60a60277a0",
+      "ConcordiaCourseId": "048068"
+    },
+    {
+      "Id": "b75ba672-de2d-4afc-8b88-c3dc0e09bebc",
+      "ConcordiaCourseId": "048110"
+    },
+    {
+      "Id": "7c8664d9-892d-4f27-9e64-b674ca909db2",
+      "ConcordiaCourseId": "048111"
+    },
+    {
+      "Id": "d0c4a711-8b2f-4ad3-9a8e-6dc104e739a8",
+      "ConcordiaCourseId": "048112"
+    },
+    {
+      "Id": "5327f465-b500-4216-ae4c-07660bf9a66f",
+      "ConcordiaCourseId": "048113"
+    },
+    {
+      "Id": "d7ca12a6-4814-4442-ba14-e2018f3b47e7",
+      "ConcordiaCourseId": "048114"
+    },
+    {
+      "Id": "c0ff7e97-6800-453d-b4ca-787f6b5c4bae",
+      "ConcordiaCourseId": "048115"
+    },
+    {
+      "Id": "071eac82-da0b-4683-bea5-74acb01f37b2",
+      "ConcordiaCourseId": "048144"
+    },
+    {
+      "Id": "33f969d3-f43d-42f2-a422-444797025051",
+      "ConcordiaCourseId": "048145"
+    },
+    {
+      "Id": "3d7e6403-6b27-4fdd-b483-36b3ba099609",
+      "ConcordiaCourseId": "048146"
+    },
+    {
+      "Id": "58eee737-5f4d-45f9-af19-9107c800eee5",
+      "ConcordiaCourseId": "048147"
+    },
+    {
+      "Id": "530c3f0c-3467-42ad-aa4d-bf9c17693420",
+      "ConcordiaCourseId": "050045"
+    },
+    {
+      "Id": "d3119268-23d1-4098-b30e-c49815a7a7ce",
+      "ConcordiaCourseId": "025279"
+    },
+    {
+      "Id": "e392f031-3b79-4944-8894-1fc637a57316",
+      "ConcordiaCourseId": "025280"
+    },
+    {
+      "Id": "c8fbd673-ebc5-417a-9669-340ef4b3b6af",
+      "ConcordiaCourseId": "025281"
+    },
+    {
+      "Id": "7408a1b4-4999-4c7f-b636-82122161b2b8",
+      "ConcordiaCourseId": "025282"
+    },
+    {
+      "Id": "cc2d2891-0679-495d-bf53-53b2910d5bdd",
+      "ConcordiaCourseId": "025283"
+    },
+    {
+      "Id": "c7d4b1a9-4da9-4e62-b64b-a587b9090481",
+      "ConcordiaCourseId": "025284"
+    },
+    {
+      "Id": "5e755a51-56d3-4d6b-b65c-1f15f00ba281",
+      "ConcordiaCourseId": "025285"
+    },
+    {
+      "Id": "27f40e0b-c28b-456b-9307-e18501cbf9ee",
+      "ConcordiaCourseId": "025286"
+    },
+    {
+      "Id": "377f7c60-e6dd-4fbd-ad7c-59d51de0f709",
+      "ConcordiaCourseId": "025287"
+    },
+    {
+      "Id": "1be8da13-b30f-4344-880e-35f257650533",
+      "ConcordiaCourseId": "025288"
+    },
+    {
+      "Id": "1496254a-6cf4-481a-a6b2-32992347c418",
+      "ConcordiaCourseId": "046933"
+    },
+    {
+      "Id": "c50f6f23-5049-40c4-889b-2aa11e3d8972",
+      "ConcordiaCourseId": "046934"
+    },
+    {
+      "Id": "5a6039bd-f492-4a5c-9fd4-e97e3e6dd941",
+      "ConcordiaCourseId": "047189"
+    },
+    {
+      "Id": "068c286d-4dc4-4b13-b625-c62d41436270",
+      "ConcordiaCourseId": "025309"
+    },
+    {
+      "Id": "ac8d080c-5497-42f9-88b8-f1d9213c6322",
+      "ConcordiaCourseId": "025310"
+    },
+    {
+      "Id": "64d5c61a-54b2-49a5-a2f3-a5b21debc80b",
+      "ConcordiaCourseId": "025312"
+    },
+    {
+      "Id": "c0b7d20d-0f75-4794-a0b9-9a9bb869077b",
+      "ConcordiaCourseId": "025313"
+    },
+    {
+      "Id": "36517e68-9803-43e4-aa78-216cb3409738",
+      "ConcordiaCourseId": "025314"
+    },
+    {
+      "Id": "bb88e774-e65e-4a67-b565-0ca1f3233d28",
+      "ConcordiaCourseId": "025315"
+    },
+    {
+      "Id": "66489cf9-460f-4f00-b3e6-187c6ac5c73d",
+      "ConcordiaCourseId": "025320"
+    },
+    {
+      "Id": "4b4a7880-890f-4cb1-b762-b15efbc6173f",
+      "ConcordiaCourseId": "025321"
+    },
+    {
+      "Id": "026f0ade-921a-4a2c-9e26-7f49c85a12b5",
+      "ConcordiaCourseId": "025322"
+    },
+    {
+      "Id": "9a9e3251-6be3-475f-84c5-e2a781f509b9",
+      "ConcordiaCourseId": "025323"
+    },
+    {
+      "Id": "1800a2f4-a0d3-4421-b3b8-0a8ff9060231",
+      "ConcordiaCourseId": "025324"
+    },
+    {
+      "Id": "c89dff7a-023f-40e8-8059-448b8fc913d2",
+      "ConcordiaCourseId": "025325"
+    },
+    {
+      "Id": "76bebbdd-ae91-43ca-ab8b-a4bf30dd2ca6",
+      "ConcordiaCourseId": "025326"
+    },
+    {
+      "Id": "495d82f8-96d8-4a2e-9afc-9ac8ca4db217",
+      "ConcordiaCourseId": "025327"
+    },
+    {
+      "Id": "c8d37a1d-ddf2-4b55-be0a-aec9eb988272",
+      "ConcordiaCourseId": "025330"
+    },
+    {
+      "Id": "4732b28e-bfbc-4d39-bd49-71e5ca00b83c",
+      "ConcordiaCourseId": "025331"
+    },
+    {
+      "Id": "0d6f92c2-22bd-42b7-ba49-d263a3604847",
+      "ConcordiaCourseId": "025333"
+    },
+    {
+      "Id": "deafac63-d0c6-4043-8bea-d513922c1665",
+      "ConcordiaCourseId": "025335"
+    },
+    {
+      "Id": "94852f03-075b-4152-9fe1-10b912aea8a4",
+      "ConcordiaCourseId": "025336"
+    },
+    {
+      "Id": "e750687f-35fa-46d6-9a2c-901adcd70b1a",
+      "ConcordiaCourseId": "025337"
+    },
+    {
+      "Id": "4ee124c8-4766-498a-84eb-55b1a0a2406a",
+      "ConcordiaCourseId": "025338"
+    },
+    {
+      "Id": "a3d1d340-3c5b-4bf8-b537-5385b0a9ed36",
+      "ConcordiaCourseId": "025339"
+    },
+    {
+      "Id": "f9efec8d-17c0-4d8a-96a6-9b00f3b39780",
+      "ConcordiaCourseId": "025340"
+    },
+    {
+      "Id": "e9bab9f1-90f3-4d45-a048-39d414194c2b",
+      "ConcordiaCourseId": "025341"
+    },
+    {
+      "Id": "77ef5c89-4ea6-4641-a46f-4e66e366d129",
+      "ConcordiaCourseId": "025342"
+    },
+    {
+      "Id": "98941668-b4b2-455c-a175-6c033c5ed92e",
+      "ConcordiaCourseId": "025349"
+    },
+    {
+      "Id": "bd909aac-5709-447e-8e87-ffba63bd2a42",
+      "ConcordiaCourseId": "025350"
+    },
+    {
+      "Id": "cef44dd5-8565-4571-9f23-10c23beec0b7",
+      "ConcordiaCourseId": "025352"
+    },
+    {
+      "Id": "ee9e586c-8f12-4fcb-afd0-5ce64abba983",
+      "ConcordiaCourseId": "025353"
+    },
+    {
+      "Id": "843d0415-142d-46c7-9881-37ebf78cc7e8",
+      "ConcordiaCourseId": "025354"
+    },
+    {
+      "Id": "f3946732-fbab-44b3-81a4-8f4fdc38349e",
+      "ConcordiaCourseId": "025356"
+    },
+    {
+      "Id": "eb9fa7ae-b3f2-4ce7-8d53-8b3936611e6d",
+      "ConcordiaCourseId": "025357"
+    },
+    {
+      "Id": "f2c59415-f322-4811-ab66-960c92337d22",
+      "ConcordiaCourseId": "025359"
+    },
+    {
+      "Id": "3264241f-ebef-4d86-a2a7-1643311a92ca",
+      "ConcordiaCourseId": "025363"
+    },
+    {
+      "Id": "e678604b-c070-410c-89a5-9c7a43b6ec84",
+      "ConcordiaCourseId": "025364"
+    },
+    {
+      "Id": "c5051930-431a-470d-9d23-201463cb2a41",
+      "ConcordiaCourseId": "025365"
+    },
+    {
+      "Id": "8ff2d265-d266-4244-96f2-3afaced23813",
+      "ConcordiaCourseId": "025366"
+    },
+    {
+      "Id": "59ecaa9c-d052-47cb-97ce-db4fb617c75b",
+      "ConcordiaCourseId": "025372"
+    },
+    {
+      "Id": "c0135484-26b8-4c3e-826b-e76b6355ed92",
+      "ConcordiaCourseId": "025374"
+    },
+    {
+      "Id": "72d82e85-e16b-4b91-bb99-21d4973c6af0",
+      "ConcordiaCourseId": "025375"
+    },
+    {
+      "Id": "4c25191c-79d3-48d9-a432-871757714dd2",
+      "ConcordiaCourseId": "025376"
+    },
+    {
+      "Id": "338d1de4-d22e-42d1-bc13-85f3cbd192fe",
+      "ConcordiaCourseId": "025377"
+    },
+    {
+      "Id": "41b8a4e9-acd7-4155-8bac-198df8ec3422",
+      "ConcordiaCourseId": "025407"
+    },
+    {
+      "Id": "9da633f4-5460-40b6-b267-29f746193e33",
+      "ConcordiaCourseId": "025414"
+    },
+    {
+      "Id": "5c491de6-e79b-4ed9-b666-c7fc1c5434d9",
+      "ConcordiaCourseId": "025418"
+    },
+    {
+      "Id": "0ccc154c-ff73-4549-832e-3a3c9c42bd95",
+      "ConcordiaCourseId": "025420"
+    },
+    {
+      "Id": "472c60fb-cdf9-41e6-bd6d-33e959108ddd",
+      "ConcordiaCourseId": "025426"
+    },
+    {
+      "Id": "eb3dac8f-ff13-4c3e-bd8c-7cb31b5c9b58",
+      "ConcordiaCourseId": "025430"
+    },
+    {
+      "Id": "062b7117-36ec-4121-8ad1-fb7b7d89c52a",
+      "ConcordiaCourseId": "025432"
+    },
+    {
+      "Id": "119d15ff-df67-44e3-805b-f6c011394efe",
+      "ConcordiaCourseId": "025435"
+    },
+    {
+      "Id": "562b23a4-8ab2-4672-abac-4c48c834f89c",
+      "ConcordiaCourseId": "025437"
+    },
+    {
+      "Id": "658c94f2-64ec-4e68-a25a-572bfbdca8a5",
+      "ConcordiaCourseId": "025439"
+    },
+    {
+      "Id": "168ff708-8278-440f-98b6-2d525655b57f",
+      "ConcordiaCourseId": "025441"
+    },
+    {
+      "Id": "9f4d1374-0d42-4f67-869a-3218adf74b7a",
+      "ConcordiaCourseId": "025443"
+    },
+    {
+      "Id": "99fa18d9-746f-4797-9bc5-69596499822a",
+      "ConcordiaCourseId": "025446"
+    },
+    {
+      "Id": "707eddf8-a51a-4079-af54-f38d9586cd02",
+      "ConcordiaCourseId": "025448"
+    },
+    {
+      "Id": "5f55b62b-5b56-44c8-8d8c-12cb9fea138e",
+      "ConcordiaCourseId": "025450"
+    },
+    {
+      "Id": "516abf49-42f7-4161-91b7-01a4d95c6553",
+      "ConcordiaCourseId": "025452"
+    },
+    {
+      "Id": "5804680e-a755-45dd-87eb-074464012ba3",
+      "ConcordiaCourseId": "025454"
+    },
+    {
+      "Id": "8b10831c-7770-44d0-a7a1-0f36704d0181",
+      "ConcordiaCourseId": "025455"
+    },
+    {
+      "Id": "2724c6ee-beb8-48d4-9284-4b20c5874993",
+      "ConcordiaCourseId": "025457"
+    },
+    {
+      "Id": "e61fa7f6-a091-4c72-8f8d-a5339ee91945",
+      "ConcordiaCourseId": "025461"
+    },
+    {
+      "Id": "c2c056e5-d9b4-4569-965c-68385481318b",
+      "ConcordiaCourseId": "025463"
+    },
+    {
+      "Id": "c3a70995-9afc-4102-81ba-40a9aff25010",
+      "ConcordiaCourseId": "025465"
+    },
+    {
+      "Id": "34cfe126-866e-4deb-9956-78b80cd49cb4",
+      "ConcordiaCourseId": "025467"
+    },
+    {
+      "Id": "c201550c-ae57-44a1-9c40-016b9b234b56",
+      "ConcordiaCourseId": "025472"
+    },
+    {
+      "Id": "6ae508f8-bea9-44f0-b8be-22d4dd13eaf8",
+      "ConcordiaCourseId": "025474"
+    },
+    {
+      "Id": "dcb335e9-aa71-4d92-a627-806bfa570cf5",
+      "ConcordiaCourseId": "025478"
+    },
+    {
+      "Id": "5030026c-c1d0-41e6-969b-a05bf9905e0a",
+      "ConcordiaCourseId": "025479"
+    },
+    {
+      "Id": "ff0f0c8a-ac55-4dc6-893e-b3e7f9dfdf34",
+      "ConcordiaCourseId": "025480"
+    },
+    {
+      "Id": "cd8f244c-9f68-4de6-8dcf-cb9f7f59c91f",
+      "ConcordiaCourseId": "025482"
+    },
+    {
+      "Id": "c3093f43-2235-4ff9-88a4-ea18791ba662",
+      "ConcordiaCourseId": "025483"
+    },
+    {
+      "Id": "a2cdbeb9-3524-4998-b3d4-34d6fdf36772",
+      "ConcordiaCourseId": "025484"
+    },
+    {
+      "Id": "fdf1e78c-3eb7-4670-a410-1e05550d3fad",
+      "ConcordiaCourseId": "025486"
+    },
+    {
+      "Id": "d9bf9983-5e64-4f5c-90f4-45d74ce60403",
+      "ConcordiaCourseId": "025502"
+    },
+    {
+      "Id": "71579380-f372-4eb0-a50e-35927ad86419",
+      "ConcordiaCourseId": "025510"
+    },
+    {
+      "Id": "f25a95fd-ec38-46f7-af83-cf96392e6416",
+      "ConcordiaCourseId": "025511"
+    },
+    {
+      "Id": "af15b0de-c369-41a5-924f-e9734b3454b0",
+      "ConcordiaCourseId": "025512"
+    },
+    {
+      "Id": "c79dcdf0-5a85-433b-8523-df3582089ef7",
+      "ConcordiaCourseId": "025521"
+    },
+    {
+      "Id": "13717f69-be17-4090-a077-1af5aac4f679",
+      "ConcordiaCourseId": "025532"
+    },
+    {
+      "Id": "3e24fc53-bf8d-4515-92ef-0bf9e85f6aac",
+      "ConcordiaCourseId": "025533"
+    },
+    {
+      "Id": "d718f8d1-eebf-4765-9e45-066b4bc1ebaf",
+      "ConcordiaCourseId": "041837"
+    },
+    {
+      "Id": "99672798-5e63-4066-8a40-be93062d2c0f",
+      "ConcordiaCourseId": "041838"
+    },
+    {
+      "Id": "ebd1c5dc-3880-4438-99c8-3fa3ebd5c513",
+      "ConcordiaCourseId": "041839"
+    },
+    {
+      "Id": "541d3651-0c11-41dd-adec-9c312bc6f44e",
+      "ConcordiaCourseId": "041840"
+    },
+    {
+      "Id": "a169ce87-9527-42bd-8c70-a8f91f68906e",
+      "ConcordiaCourseId": "041841"
+    },
+    {
+      "Id": "c5cad907-f106-4768-8bda-adbded3339d7",
+      "ConcordiaCourseId": "041842"
+    },
+    {
+      "Id": "a9f09cca-8151-4c90-817d-36bfdf313169",
+      "ConcordiaCourseId": "041843"
+    },
+    {
+      "Id": "6a1b98da-a729-4934-a1c9-3f01330e3041",
+      "ConcordiaCourseId": "041844"
+    },
+    {
+      "Id": "4ce739c6-f586-44a1-82b8-be857b290fdb",
+      "ConcordiaCourseId": "041845"
+    },
+    {
+      "Id": "95032389-fbaf-4c0a-a991-fd25fb2a16e3",
+      "ConcordiaCourseId": "041846"
+    },
+    {
+      "Id": "5941ad10-af28-42aa-8d92-0d6c7185c6a9",
+      "ConcordiaCourseId": "041849"
+    },
+    {
+      "Id": "3c64fba5-9bc9-4ddc-ba48-a1448ae18b87",
+      "ConcordiaCourseId": "041850"
+    },
+    {
+      "Id": "acbbad4d-3cca-4c83-87b2-3187afe4bb15",
+      "ConcordiaCourseId": "041851"
+    },
+    {
+      "Id": "3c0b663e-78ae-40ee-96d3-3c2c43e1f23f",
+      "ConcordiaCourseId": "041852"
+    },
+    {
+      "Id": "b5df332f-43ee-4b21-bdfc-0aea630a0a62",
+      "ConcordiaCourseId": "041853"
+    },
+    {
+      "Id": "fe7d670a-e7ce-47b8-8164-8e2c6fbd3e5a",
+      "ConcordiaCourseId": "041854"
+    },
+    {
+      "Id": "dbe21dea-e05f-43d2-91ba-a4a412414532",
+      "ConcordiaCourseId": "041855"
+    },
+    {
+      "Id": "1073f5eb-fe0a-4c2d-bd50-54fc44543933",
+      "ConcordiaCourseId": "041857"
+    },
+    {
+      "Id": "c7140907-f485-45d7-8430-5a4f222d318e",
+      "ConcordiaCourseId": "044187"
+    },
+    {
+      "Id": "a4c0d483-ba91-413a-9bd8-c4e31d1620b6",
+      "ConcordiaCourseId": "045628"
+    },
+    {
+      "Id": "28d87f65-4697-4456-a25a-4116f7f44be0",
+      "ConcordiaCourseId": "046935"
+    },
+    {
+      "Id": "3206b918-4695-4ae2-bc65-73167c3ccc22",
+      "ConcordiaCourseId": "046936"
+    },
+    {
+      "Id": "a3ec4589-088d-43b1-91a3-abcafcee0d58",
+      "ConcordiaCourseId": "047210"
+    },
+    {
+      "Id": "b14c7bed-a551-403c-9233-125fd37f4097",
+      "ConcordiaCourseId": "047523"
+    },
+    {
+      "Id": "74e8a1f9-6bb5-4daf-ac61-b14b03221819",
+      "ConcordiaCourseId": "047928"
+    },
+    {
+      "Id": "6e0aaa80-0a5a-4cd0-a6a2-b6bf1e7dadf0",
+      "ConcordiaCourseId": "048409"
+    },
+    {
+      "Id": "2959a738-8f35-4f43-9cc0-46ea02874fe4",
+      "ConcordiaCourseId": "048545"
+    },
+    {
+      "Id": "fbbdb922-7d82-4325-bc46-2702a9211bb2",
+      "ConcordiaCourseId": "048774"
+    },
+    {
+      "Id": "106af415-f54b-45f4-a323-07225e4e4497",
+      "ConcordiaCourseId": "048950"
+    },
+    {
+      "Id": "64975ebf-06fe-4edb-a58a-0518ac07840c",
+      "ConcordiaCourseId": "048951"
+    },
+    {
+      "Id": "0c97b853-5c90-4bb0-a0a7-7b7755683fa1",
+      "ConcordiaCourseId": "048952"
+    },
+    {
+      "Id": "d0d1bb28-06f6-4ab0-8bde-906fb11b8ab2",
+      "ConcordiaCourseId": "048953"
+    },
+    {
+      "Id": "ca30b2b3-a75c-4005-acca-d3b3277c9737",
+      "ConcordiaCourseId": "049357"
+    },
+    {
+      "Id": "8212f7ae-9715-4a65-96d8-7ca1d310b297",
+      "ConcordiaCourseId": "049358"
+    },
+    {
+      "Id": "b6347d8c-baec-4240-acf7-046dae6e5cea",
+      "ConcordiaCourseId": "050060"
+    },
+    {
+      "Id": "f71d0d0d-1319-4c9f-b8fb-626e51ddddd8",
+      "ConcordiaCourseId": "050545"
+    },
+    {
+      "Id": "c2e60d62-ff94-4bc9-b610-31a9f2ace889",
+      "ConcordiaCourseId": "050792"
+    },
+    {
+      "Id": "d7511049-de89-402c-abdb-9d47b462bf14",
+      "ConcordiaCourseId": "050796"
+    },
+    {
+      "Id": "a6d6927d-68fe-4903-aea2-1013062f22c2",
+      "ConcordiaCourseId": "050797"
+    },
+    {
+      "Id": "2befa41f-3d20-4ea2-82af-6bb26ee0574c",
+      "ConcordiaCourseId": "046937"
+    },
+    {
+      "Id": "6ee4b5c4-5194-49d4-bbe9-0a6b9a150e58",
+      "ConcordiaCourseId": "025652"
+    },
+    {
+      "Id": "3e0d9059-6ac5-4d07-a8c2-06fcc9a103d0",
+      "ConcordiaCourseId": "025653"
+    },
+    {
+      "Id": "77de93f8-d041-4a72-80b9-10bba7882d9b",
+      "ConcordiaCourseId": "025654"
+    },
+    {
+      "Id": "1a63d8ef-3b48-4b09-b768-60a6f3efbd4e",
+      "ConcordiaCourseId": "025655"
+    },
+    {
+      "Id": "69405d9c-7fe9-4d46-95d3-3dac7ac2bd25",
+      "ConcordiaCourseId": "025660"
+    },
+    {
+      "Id": "1b7c60ed-d8f4-4b22-b642-9363172a9fc7",
+      "ConcordiaCourseId": "025663"
+    },
+    {
+      "Id": "c93e9e23-7497-4e07-86f8-cb49067fa5a6",
+      "ConcordiaCourseId": "025664"
+    },
+    {
+      "Id": "91250523-0e20-47d6-a684-2283173ae318",
+      "ConcordiaCourseId": "025675"
+    },
+    {
+      "Id": "8df1bee8-6b0d-44b9-988b-805bb0fc7290",
+      "ConcordiaCourseId": "041865"
+    },
+    {
+      "Id": "17aa6d98-c1bb-4cb9-b603-1a0cd64d0697",
+      "ConcordiaCourseId": "046938"
+    },
+    {
+      "Id": "1a6b3209-82f3-48df-8e8b-cd67b642c465",
+      "ConcordiaCourseId": "046939"
+    },
+    {
+      "Id": "1490865d-5ef5-48cf-8cf1-52d37c589dcf",
+      "ConcordiaCourseId": "048889"
+    },
+    {
+      "Id": "b57fdfa2-9bc9-4abf-ba1a-db5250ef4f2e",
+      "ConcordiaCourseId": "049335"
+    },
+    {
+      "Id": "20fce0c4-c1f8-40d9-b581-70a1e305208f",
+      "ConcordiaCourseId": "049729"
+    },
+    {
+      "Id": "b3b60d06-d134-4a34-83af-1ac88034d265",
+      "ConcordiaCourseId": "049705"
+    },
+    {
+      "Id": "91a526d8-eade-49b0-b773-e9833a8a6698",
+      "ConcordiaCourseId": "049716"
+    },
+    {
+      "Id": "0f41fb92-9094-49ae-97f2-9923913fa0fd",
+      "ConcordiaCourseId": "049717"
+    },
+    {
+      "Id": "b7b65490-826f-4dcf-a3d8-caeffd0e4edb",
+      "ConcordiaCourseId": "049718"
+    },
+    {
+      "Id": "e650f8da-fa8f-4146-b545-f14b8d1b1110",
+      "ConcordiaCourseId": "049720"
+    },
+    {
+      "Id": "50614887-7096-4dc4-9e94-503f55d7f0d9",
+      "ConcordiaCourseId": "049721"
+    },
+    {
+      "Id": "512c3424-7e35-4d39-a0f5-4d7fa934d7f7",
+      "ConcordiaCourseId": "050059"
+    },
+    {
+      "Id": "331b031d-8b9f-4d57-9896-569875655d19",
+      "ConcordiaCourseId": "046940"
+    },
+    {
+      "Id": "eac99f18-f148-47b3-8fc2-43e0c0e3c039",
+      "ConcordiaCourseId": "046941"
+    },
+    {
+      "Id": "e11b0af5-365c-4f1f-bf41-cce6eb164f31",
+      "ConcordiaCourseId": "046942"
+    },
+    {
+      "Id": "20700f19-df68-43a6-bf4c-319163f52306",
+      "ConcordiaCourseId": "046943"
+    },
+    {
+      "Id": "b724a599-8b7d-48ed-8188-55aab341c0bf",
+      "ConcordiaCourseId": "046944"
+    },
+    {
+      "Id": "6d8fc556-a96c-4930-97d7-d961d0c583f2",
+      "ConcordiaCourseId": "046945"
+    },
+    {
+      "Id": "70743d76-343d-403d-9bcc-9b56f5b6f619",
+      "ConcordiaCourseId": "046946"
+    },
+    {
+      "Id": "1fd611c9-a981-4b2f-8073-13d9977e4b46",
+      "ConcordiaCourseId": "046947"
+    },
+    {
+      "Id": "273994b9-d513-443b-b11b-97951ffe0ae4",
+      "ConcordiaCourseId": "046948"
+    },
+    {
+      "Id": "a4233f91-7c9e-432f-a31d-80f012864c75",
+      "ConcordiaCourseId": "046949"
+    },
+    {
+      "Id": "a3b6b1f3-fd63-46fa-bef2-0e38f9ec5dc7",
+      "ConcordiaCourseId": "046950"
+    },
+    {
+      "Id": "ba74a762-6b64-4377-988e-bfe77cd4eaba",
+      "ConcordiaCourseId": "041898"
+    },
+    {
+      "Id": "e959ea53-cb97-4d57-bbb4-d6bb1065267d",
+      "ConcordiaCourseId": "041899"
+    },
+    {
+      "Id": "d02adb09-510c-4377-bcf4-27c860a1b29f",
+      "ConcordiaCourseId": "025769"
+    },
+    {
+      "Id": "3a547e0d-08d3-49d5-bff8-8ae51646bd8a",
+      "ConcordiaCourseId": "025770"
+    },
+    {
+      "Id": "068fe58b-578f-4c39-a55e-4484ca8a9c90",
+      "ConcordiaCourseId": "025773"
+    },
+    {
+      "Id": "71ddbe33-63ec-4986-9616-58d901bb92a6",
+      "ConcordiaCourseId": "025777"
+    },
+    {
+      "Id": "52ade20c-56ce-4573-b037-be9ebfa5a729",
+      "ConcordiaCourseId": "025798"
+    },
+    {
+      "Id": "37391861-2491-49c3-b07a-b52312d9c0f1",
+      "ConcordiaCourseId": "025822"
+    },
+    {
+      "Id": "bf3acc5d-76ce-4e7f-bf24-09f3288b10be",
+      "ConcordiaCourseId": "025823"
+    },
+    {
+      "Id": "ac141729-4957-4adc-9678-97e538bd5022",
+      "ConcordiaCourseId": "025827"
+    },
+    {
+      "Id": "f3b3ba1d-76a8-4149-87dd-135c1e685d09",
+      "ConcordiaCourseId": "025829"
+    },
+    {
+      "Id": "93e47005-a66e-4285-99eb-6903afefeb06",
+      "ConcordiaCourseId": "025853"
+    },
+    {
+      "Id": "5271ad74-9922-415d-a936-cad727560765",
+      "ConcordiaCourseId": "025859"
+    },
+    {
+      "Id": "d169bab1-84db-437a-b995-fc4597f8781d",
+      "ConcordiaCourseId": "025860"
+    },
+    {
+      "Id": "1aae76d9-03b5-4ad4-bb0d-86cfc8a917b9",
+      "ConcordiaCourseId": "041902"
+    },
+    {
+      "Id": "479e8f43-51eb-4d51-b9da-f8d5b85ba5cd",
+      "ConcordiaCourseId": "041903"
+    },
+    {
+      "Id": "410386db-fe50-4852-980a-32d30c59eab7",
+      "ConcordiaCourseId": "041906"
+    },
+    {
+      "Id": "19af4fd3-dc2d-43d0-95f1-be31386aa70f",
+      "ConcordiaCourseId": "041949"
+    },
+    {
+      "Id": "9a8c2292-38ce-4c65-90bf-55564d3b197f",
+      "ConcordiaCourseId": "041951"
+    },
+    {
+      "Id": "a996eba1-b6ea-4f14-852c-15f1b952cca8",
+      "ConcordiaCourseId": "041955"
+    },
+    {
+      "Id": "184f9171-d71a-4a57-9cdd-50c67620181f",
+      "ConcordiaCourseId": "041997"
+    },
+    {
+      "Id": "5967e458-b1cf-44d0-8e4d-c5870cf5b137",
+      "ConcordiaCourseId": "041998"
+    },
+    {
+      "Id": "5a12a18f-4e9f-4229-ad0d-d91cdca95e68",
+      "ConcordiaCourseId": "046952"
+    },
+    {
+      "Id": "521907a1-d82b-4fa4-a6aa-a267c33eb458",
+      "ConcordiaCourseId": "046953"
+    },
+    {
+      "Id": "c041c816-d8bd-4ea3-80a6-a2cc8f0c8396",
+      "ConcordiaCourseId": "046954"
+    },
+    {
+      "Id": "f56cc407-5335-4a7c-b9f5-f6334539216b",
+      "ConcordiaCourseId": "046955"
+    },
+    {
+      "Id": "03f9f5d1-7a49-4e51-afbc-0a2ba6a30412",
+      "ConcordiaCourseId": "046956"
+    },
+    {
+      "Id": "a61fafd0-19be-4e01-b2a0-6733161c28fb",
+      "ConcordiaCourseId": "047378"
+    },
+    {
+      "Id": "98acd28a-ba1b-4f1c-ada1-d776dfb2e490",
+      "ConcordiaCourseId": "048944"
+    },
+    {
+      "Id": "83107295-2712-484a-84d2-5c84d7818ca7",
+      "ConcordiaCourseId": "048945"
+    },
+    {
+      "Id": "8f6e5827-d25c-4450-9570-4cef045d9f25",
+      "ConcordiaCourseId": "049347"
+    },
+    {
+      "Id": "5399eb26-27cc-4066-b932-2b9c1a6d2678",
+      "ConcordiaCourseId": "049348"
+    },
+    {
+      "Id": "364c6a70-0fd6-43bf-b06c-78e29b0e5b19",
+      "ConcordiaCourseId": "049349"
+    },
+    {
+      "Id": "0a986bbb-58fe-47a8-b3d0-4cee047aeda7",
+      "ConcordiaCourseId": "049350"
+    },
+    {
+      "Id": "7058879e-e7fe-429a-866b-6144492a497a",
+      "ConcordiaCourseId": "049351"
+    },
+    {
+      "Id": "0cfab617-6bd3-49e5-b7df-020a154cc32f",
+      "ConcordiaCourseId": "049352"
+    },
+    {
+      "Id": "57ef89ff-b5d6-4860-93e2-3b57515b0b7b",
+      "ConcordiaCourseId": "050124"
+    },
+    {
+      "Id": "01d52e1d-32e2-4bcc-9e6a-912bb017e9b0",
+      "ConcordiaCourseId": "046957"
+    },
+    {
+      "Id": "a4c006fa-ebf0-40cf-a15c-f3fa37aec6a9",
+      "ConcordiaCourseId": "050664"
+    },
+    {
+      "Id": "5f8f20d4-aa70-4ffa-b269-548920de08e2",
+      "ConcordiaCourseId": "025927"
+    },
+    {
+      "Id": "0f40e830-a5ef-4773-9975-8570ed2bda29",
+      "ConcordiaCourseId": "025928"
+    },
+    {
+      "Id": "5de8eb56-50fb-4080-aac1-50965a8966dd",
+      "ConcordiaCourseId": "025929"
+    },
+    {
+      "Id": "8656ea43-189d-480f-94bf-381e6aa12476",
+      "ConcordiaCourseId": "025931"
+    },
+    {
+      "Id": "e3fef495-0a77-4253-8e0a-4571d50898f5",
+      "ConcordiaCourseId": "025935"
+    },
+    {
+      "Id": "5fd22e9f-85a6-495c-81f9-005044283e47",
+      "ConcordiaCourseId": "025936"
+    },
+    {
+      "Id": "6f7ea733-52c5-437c-814b-e2aea63deb29",
+      "ConcordiaCourseId": "025937"
+    },
+    {
+      "Id": "062c36c7-2e24-480f-9c68-9941e849e1de",
+      "ConcordiaCourseId": "025938"
+    },
+    {
+      "Id": "d291b5d2-5077-4878-856e-15d953f32a4f",
+      "ConcordiaCourseId": "025939"
+    },
+    {
+      "Id": "fbef905d-fce6-4129-9342-9eb63e6a137c",
+      "ConcordiaCourseId": "025940"
+    },
+    {
+      "Id": "cef4228b-e6c4-4c68-a860-14ffdb4a7606",
+      "ConcordiaCourseId": "025961"
+    },
+    {
+      "Id": "7cf5b133-dedd-4802-9e66-2b6d62fec508",
+      "ConcordiaCourseId": "025963"
+    },
+    {
+      "Id": "704875a4-d7fa-42a1-b1d7-6a612b47d404",
+      "ConcordiaCourseId": "025965"
+    },
+    {
+      "Id": "a77562c7-b4f3-406b-978d-e65df5456e99",
+      "ConcordiaCourseId": "025966"
+    },
+    {
+      "Id": "98598a75-32e2-4dc1-9f04-c0747e5b7974",
+      "ConcordiaCourseId": "025986"
+    },
+    {
+      "Id": "c90e3815-c66c-4537-aa38-39bf19db2a18",
+      "ConcordiaCourseId": "025989"
+    },
+    {
+      "Id": "25762145-284b-4dc3-b439-8f309a3a2616",
+      "ConcordiaCourseId": "025991"
+    },
+    {
+      "Id": "cfacda66-ca85-4948-bdf9-0d7b10fb7fcc",
+      "ConcordiaCourseId": "025993"
+    },
+    {
+      "Id": "e6b4cdca-9a4f-40e8-8cfd-1740b352fd5b",
+      "ConcordiaCourseId": "025995"
+    },
+    {
+      "Id": "f669e521-a60b-491d-949d-1234ded7ea2a",
+      "ConcordiaCourseId": "026018"
+    },
+    {
+      "Id": "1712cd7a-be75-44a4-92fa-4514c378bf04",
+      "ConcordiaCourseId": "026019"
+    },
+    {
+      "Id": "15386349-d46e-4667-bfbe-e9d431632265",
+      "ConcordiaCourseId": "026020"
+    },
+    {
+      "Id": "f27dcd8b-c864-4c15-a1d8-15be2926ac21",
+      "ConcordiaCourseId": "026022"
+    },
+    {
+      "Id": "b7baba46-4525-441b-86a4-088d6bfbc9a8",
+      "ConcordiaCourseId": "026025"
+    },
+    {
+      "Id": "923edf80-54ae-431b-8637-6d15b80574fc",
+      "ConcordiaCourseId": "026028"
+    },
+    {
+      "Id": "13cf7008-02ce-4b74-a4f6-2772df2c8b8a",
+      "ConcordiaCourseId": "026030"
+    },
+    {
+      "Id": "d28ae89e-6c1a-4508-b63e-b6a08e9da29c",
+      "ConcordiaCourseId": "026031"
+    },
+    {
+      "Id": "bc3d4a95-93b7-49ae-bd88-8e569c5c80b2",
+      "ConcordiaCourseId": "026033"
+    },
+    {
+      "Id": "aa46cc3e-fdd2-4fbd-8d3a-a88e050901e9",
+      "ConcordiaCourseId": "026056"
+    },
+    {
+      "Id": "459c8e40-440d-4525-8eab-680103b4705a",
+      "ConcordiaCourseId": "026057"
+    },
+    {
+      "Id": "fd2c62cc-0f52-4dfd-9aed-7a862034af70",
+      "ConcordiaCourseId": "042038"
+    },
+    {
+      "Id": "3492b4bd-43a4-47f0-be75-5133204850f5",
+      "ConcordiaCourseId": "046958"
+    },
+    {
+      "Id": "2d3af638-2620-4578-b229-501060f63475",
+      "ConcordiaCourseId": "047473"
+    },
+    {
+      "Id": "efe82555-108c-4017-84f5-bc33e1482a5b",
+      "ConcordiaCourseId": "048874"
+    },
+    {
+      "Id": "8c4a8100-dcd1-4d0e-9800-56715eaba87c",
+      "ConcordiaCourseId": "048875"
+    },
+    {
+      "Id": "1ee5aace-3fae-4792-b13d-f654a43e9820",
+      "ConcordiaCourseId": "048876"
+    },
+    {
+      "Id": "2740226f-35e2-455f-8050-f66363945d38",
+      "ConcordiaCourseId": "048877"
+    },
+    {
+      "Id": "7c34398e-5a0f-4b9f-899d-7589261f5812",
+      "ConcordiaCourseId": "048878"
+    },
+    {
+      "Id": "9440af52-eefb-4924-beee-e9374a276483",
+      "ConcordiaCourseId": "048879"
+    },
+    {
+      "Id": "8bfc9a7d-7dcf-4c42-a3fe-e7589b4d8363",
+      "ConcordiaCourseId": "048880"
+    },
+    {
+      "Id": "3dff921a-e5ac-4dec-8aa9-014aee69fcee",
+      "ConcordiaCourseId": "048905"
+    },
+    {
+      "Id": "f4c21de1-090e-4445-a648-5694587aee06",
+      "ConcordiaCourseId": "048978"
+    },
+    {
+      "Id": "3fef3966-7e6f-4f1b-8d20-13996b040f7e",
+      "ConcordiaCourseId": "048981"
+    },
+    {
+      "Id": "86346202-06fb-4a61-8ec3-186a3c4097be",
+      "ConcordiaCourseId": "048982"
+    },
+    {
+      "Id": "83437f91-357c-4a0d-88c3-083a9b2e2070",
+      "ConcordiaCourseId": "048983"
+    },
+    {
+      "Id": "ef338534-3d01-46af-840c-f29e30e2437a",
+      "ConcordiaCourseId": "048984"
+    },
+    {
+      "Id": "08e964e3-8719-4372-8e55-86f36f9bbcad",
+      "ConcordiaCourseId": "048985"
+    },
+    {
+      "Id": "d543c865-3be9-4e17-bf0f-94c714f6ae36",
+      "ConcordiaCourseId": "050079"
+    },
+    {
+      "Id": "90699874-f320-4893-99cb-d758c974dab9",
+      "ConcordiaCourseId": "050080"
+    },
+    {
+      "Id": "823bc0ec-a9e9-4cba-bb34-370faa706572",
+      "ConcordiaCourseId": "050081"
+    },
+    {
+      "Id": "33a4bf1c-aff9-4231-ba67-abc631850cdb",
+      "ConcordiaCourseId": "050159"
+    },
+    {
+      "Id": "64e124a2-fae4-48ee-a203-a8509fa4397f",
+      "ConcordiaCourseId": "050160"
+    },
+    {
+      "Id": "6fabe3da-25c7-4694-950e-e42e0b5b268b",
+      "ConcordiaCourseId": "050161"
+    },
+    {
+      "Id": "9aa58986-6986-44f4-8097-d48c5c33836d",
+      "ConcordiaCourseId": "050309"
+    },
+    {
+      "Id": "79438161-5bc9-4205-98d1-3a237873aab8",
+      "ConcordiaCourseId": "050310"
+    },
+    {
+      "Id": "eddfb1e5-5eb7-4cb1-850a-33d22ef1c4d2",
+      "ConcordiaCourseId": "050312"
+    },
+    {
+      "Id": "af5eb622-6dc5-4685-b268-a7da96c87fe4",
+      "ConcordiaCourseId": "050313"
+    },
+    {
+      "Id": "6fabdfb9-6940-4446-83e8-251775618d49",
+      "ConcordiaCourseId": "050314"
+    },
+    {
+      "Id": "483e3f38-c1ac-431a-ab55-8299bc6a19bc",
+      "ConcordiaCourseId": "050318"
+    },
+    {
+      "Id": "a7b4f5f5-54bc-4dce-967c-7ba12aa39cb3",
+      "ConcordiaCourseId": "050319"
+    },
+    {
+      "Id": "6df575c4-3863-4799-98d9-309a9f14ab19",
+      "ConcordiaCourseId": "050673"
+    },
+    {
+      "Id": "5ec25aa7-d76d-4141-942e-44334a04501f",
+      "ConcordiaCourseId": "047716"
+    },
+    {
+      "Id": "ab676cc4-1e2b-48cf-b155-b6b740c979bb",
+      "ConcordiaCourseId": "047718"
+    },
+    {
+      "Id": "b9c2e001-22be-450c-be74-3cb1f82e7063",
+      "ConcordiaCourseId": "047719"
+    },
+    {
+      "Id": "6bd25d96-5a98-427d-9df4-046b2397b330",
+      "ConcordiaCourseId": "047721"
+    },
+    {
+      "Id": "561a9408-f798-4ca5-a4f2-9ee463ba830e",
+      "ConcordiaCourseId": "047723"
+    },
+    {
+      "Id": "cb1c8f9d-9340-45e4-b715-2278b24a1844",
+      "ConcordiaCourseId": "047724"
+    },
+    {
+      "Id": "2b2e4fe7-6478-4536-bad9-65d4ae0be260",
+      "ConcordiaCourseId": "050154"
+    },
+    {
+      "Id": "047ef1ec-07f1-45b4-a5dc-2fa0cc630700",
+      "ConcordiaCourseId": "050368"
+    },
+    {
+      "Id": "823a7f01-20bb-412d-9b37-dcdcda52f6ac",
+      "ConcordiaCourseId": "026059"
+    },
+    {
+      "Id": "516c5a2b-0383-4a02-a936-9b0d7ded6dc3",
+      "ConcordiaCourseId": "026060"
+    },
+    {
+      "Id": "ab055eec-60d7-4dcd-8138-46300f5ac28b",
+      "ConcordiaCourseId": "026061"
+    },
+    {
+      "Id": "b9288f2a-123e-433b-a40a-ca8d0944b881",
+      "ConcordiaCourseId": "026062"
+    },
+    {
+      "Id": "d5cb8a32-6dac-4f8b-9b57-dd032dfdbd4d",
+      "ConcordiaCourseId": "026063"
+    },
+    {
+      "Id": "d683aceb-2826-483e-ae3f-65d5606a514e",
+      "ConcordiaCourseId": "026064"
+    },
+    {
+      "Id": "64003221-ee0e-4dda-9325-3067f84ae7a7",
+      "ConcordiaCourseId": "026065"
+    },
+    {
+      "Id": "3adeb84f-6f3f-4804-9133-0f9dd13ba0a4",
+      "ConcordiaCourseId": "026066"
+    },
+    {
+      "Id": "9c42b542-6729-4cd7-833d-4b1e131bbe7b",
+      "ConcordiaCourseId": "026067"
+    },
+    {
+      "Id": "7a8a8c1c-6277-4129-b2b6-41c785a23bd8",
+      "ConcordiaCourseId": "026068"
+    },
+    {
+      "Id": "97ca0eea-1bf2-4da4-a89e-56ba54ff9615",
+      "ConcordiaCourseId": "026069"
+    },
+    {
+      "Id": "83ae3ee6-6f21-4fe8-8741-9be79dfaa298",
+      "ConcordiaCourseId": "026070"
+    },
+    {
+      "Id": "e88eb5de-f305-4c9a-b956-2d5549e6c1b8",
+      "ConcordiaCourseId": "026071"
+    },
+    {
+      "Id": "989755ff-5b2c-4bba-9dd4-369480637633",
+      "ConcordiaCourseId": "026072"
+    },
+    {
+      "Id": "9f2c184e-bb25-4159-870a-a925b5ab8245",
+      "ConcordiaCourseId": "026073"
+    },
+    {
+      "Id": "02489d4c-d355-45c4-8c11-472c964a997a",
+      "ConcordiaCourseId": "026074"
+    },
+    {
+      "Id": "0ec36dea-28d7-43fa-9bba-2b28dcb73f83",
+      "ConcordiaCourseId": "026075"
+    },
+    {
+      "Id": "783c5eac-a0f1-49b4-93f2-fa4e34529ef8",
+      "ConcordiaCourseId": "042039"
+    },
+    {
+      "Id": "3ea18900-1cb7-4a74-8556-2ec4846d47f9",
+      "ConcordiaCourseId": "042040"
+    },
+    {
+      "Id": "d0811cb1-6f73-4bc1-bafd-baba38d58528",
+      "ConcordiaCourseId": "048561"
+    },
+    {
+      "Id": "31d41e73-3731-4a79-8a6f-203a13ccf720",
+      "ConcordiaCourseId": "048562"
+    },
+    {
+      "Id": "ab3d7e11-6eb0-457b-b2cb-07e8f4989c63",
+      "ConcordiaCourseId": "049957"
+    },
+    {
+      "Id": "0d9a1a08-1873-4003-8340-8ee381a5c21d",
+      "ConcordiaCourseId": "026088"
+    },
+    {
+      "Id": "a4132581-75ee-4978-a029-312fe0ba965f",
+      "ConcordiaCourseId": "026090"
+    },
+    {
+      "Id": "5d1f6d1b-a883-4d5b-bc9e-64de7b5cca35",
+      "ConcordiaCourseId": "026091"
+    },
+    {
+      "Id": "aef98223-7f19-4730-989f-61eede51322e",
+      "ConcordiaCourseId": "026093"
+    },
+    {
+      "Id": "ceaa4b12-1b86-49b1-b10a-68dbbda02602",
+      "ConcordiaCourseId": "026095"
+    },
+    {
+      "Id": "fd2d45b7-e3bf-4639-a4cc-91690d98bc7c",
+      "ConcordiaCourseId": "026117"
+    },
+    {
+      "Id": "64ccd638-40da-4fe6-a2f4-adda847cfcb6",
+      "ConcordiaCourseId": "026140"
+    },
+    {
+      "Id": "3c17f100-5b78-42d3-9d41-97d05e13ec57",
+      "ConcordiaCourseId": "026143"
+    },
+    {
+      "Id": "1b1b6819-56ed-4803-9c1b-0cf7188ae094",
+      "ConcordiaCourseId": "026144"
+    },
+    {
+      "Id": "a8b02f09-96b7-45ac-bc2a-e811c25a0087",
+      "ConcordiaCourseId": "026154"
+    },
+    {
+      "Id": "2bd6cec6-5fde-48b2-aa67-a583d24fe529",
+      "ConcordiaCourseId": "026156"
+    },
+    {
+      "Id": "a9944003-39b4-4b8e-8e7b-6f7204f94604",
+      "ConcordiaCourseId": "026178"
+    },
+    {
+      "Id": "3582e725-557e-4e31-ab0a-bf357b046be1",
+      "ConcordiaCourseId": "026197"
+    },
+    {
+      "Id": "9ba56e13-f667-429e-b44c-0335ca05334a",
+      "ConcordiaCourseId": "026205"
+    },
+    {
+      "Id": "eaef8537-3677-401b-87a5-78aa27776a5f",
+      "ConcordiaCourseId": "026206"
+    },
+    {
+      "Id": "3b5e7cd4-bcdd-4b60-9e09-4c731a6a264e",
+      "ConcordiaCourseId": "026207"
+    },
+    {
+      "Id": "8806bb2c-148c-494b-821d-bf635b2b195d",
+      "ConcordiaCourseId": "026209"
+    },
+    {
+      "Id": "2f181c2b-5fe8-489d-9078-93d8bfd76ba6",
+      "ConcordiaCourseId": "026210"
+    },
+    {
+      "Id": "9ba44b65-aa69-412b-af96-00afe9362579",
+      "ConcordiaCourseId": "026221"
+    },
+    {
+      "Id": "bbb6c4fc-e1d4-4a10-8625-7f82d2436a78",
+      "ConcordiaCourseId": "026234"
+    },
+    {
+      "Id": "266f9012-43d6-4b30-b596-70b6001e32ac",
+      "ConcordiaCourseId": "026243"
+    },
+    {
+      "Id": "6e92cf73-2ec4-4609-a2cb-be67eecbf9b1",
+      "ConcordiaCourseId": "026259"
+    },
+    {
+      "Id": "66532185-9494-4bce-8782-b9c0e6eb4694",
+      "ConcordiaCourseId": "026266"
+    },
+    {
+      "Id": "1c2c4c19-1638-4d13-b13e-8bba24f2fbdf",
+      "ConcordiaCourseId": "026267"
+    },
+    {
+      "Id": "d7823fb3-fe04-4933-8509-0ecc1f85d018",
+      "ConcordiaCourseId": "042068"
+    },
+    {
+      "Id": "c569ff97-13fb-4c85-9753-11b0d8887e7b",
+      "ConcordiaCourseId": "042110"
+    },
+    {
+      "Id": "c4f88881-fb3b-4c51-b641-b246c93f04e4",
+      "ConcordiaCourseId": "044194"
+    },
+    {
+      "Id": "8ae5b409-36d5-4533-84f4-8bf921ea7e7a",
+      "ConcordiaCourseId": "046959"
+    },
+    {
+      "Id": "fa3ebffd-5e36-4f06-8055-d61e4becc0b5",
+      "ConcordiaCourseId": "046960"
+    },
+    {
+      "Id": "ff544f61-3166-4cd0-be09-43bd62a81959",
+      "ConcordiaCourseId": "046961"
+    },
+    {
+      "Id": "92e594c3-a983-4fcf-a32e-f322c4861763",
+      "ConcordiaCourseId": "046962"
+    },
+    {
+      "Id": "e75fd70d-1c42-4dae-853b-26d96c0485f3",
+      "ConcordiaCourseId": "046963"
+    },
+    {
+      "Id": "08dfb5e2-9786-4a1a-9e30-f02f2aee2984",
+      "ConcordiaCourseId": "046964"
+    },
+    {
+      "Id": "498cebc8-f772-4804-b871-eaa57e867548",
+      "ConcordiaCourseId": "047379"
+    },
+    {
+      "Id": "698e92dd-963d-42b4-bb61-73fcad6a6838",
+      "ConcordiaCourseId": "047380"
+    },
+    {
+      "Id": "09ac58be-a33f-4af6-ae81-d2a42b76e64a",
+      "ConcordiaCourseId": "047381"
+    },
+    {
+      "Id": "43ce7421-cd8e-4233-a7ef-5e5c5b6f1def",
+      "ConcordiaCourseId": "047948"
+    },
+    {
+      "Id": "f2c6960d-c07b-4cc7-8803-d570007fad1e",
+      "ConcordiaCourseId": "048462"
+    },
+    {
+      "Id": "8bbd233f-89e2-4da7-af2f-a6dd38b7118b",
+      "ConcordiaCourseId": "048946"
+    },
+    {
+      "Id": "4d40bc20-cfe3-49dc-b0c0-4ebe003f681b",
+      "ConcordiaCourseId": "048947"
+    },
+    {
+      "Id": "a399f4b7-d79d-4d05-8fcc-7ca8e72fe363",
+      "ConcordiaCourseId": "049353"
+    },
+    {
+      "Id": "1e11bf8f-d897-4a0d-944f-399c72df4eab",
+      "ConcordiaCourseId": "049730"
+    },
+    {
+      "Id": "9da9373b-b455-402a-b04f-6b0778620056",
+      "ConcordiaCourseId": "049731"
+    },
+    {
+      "Id": "880e114c-1131-481e-bd95-ef35af3c701d",
+      "ConcordiaCourseId": "050126"
+    },
+    {
+      "Id": "3a0fdd7d-5e26-4cc4-8257-f5e5bdf987f3",
+      "ConcordiaCourseId": "050127"
+    },
+    {
+      "Id": "cf84c622-e847-407d-a1f6-cf03f86ae1a0",
+      "ConcordiaCourseId": "050128"
+    },
+    {
+      "Id": "49bb8c35-aaa1-4f62-a2eb-a9381f3c1643",
+      "ConcordiaCourseId": "050129"
+    },
+    {
+      "Id": "544ece10-a887-40f1-9ad5-4c87191f23e4",
+      "ConcordiaCourseId": "050426"
+    },
+    {
+      "Id": "01f8df72-6c5e-4ea7-843d-ceee47b1723a",
+      "ConcordiaCourseId": "050454"
+    },
+    {
+      "Id": "36f5078d-04cc-432e-ba12-fdaa308470b4",
+      "ConcordiaCourseId": "050469"
+    },
+    {
+      "Id": "3f131650-6c03-4449-b0c1-298a61dc5653",
+      "ConcordiaCourseId": "046965"
+    },
+    {
+      "Id": "5831439a-123b-41c1-b179-5c0c1c94bcac",
+      "ConcordiaCourseId": "046966"
+    },
+    {
+      "Id": "950f04c9-c41e-4d44-a9fa-54f69fb70874",
+      "ConcordiaCourseId": "026399"
+    },
+    {
+      "Id": "426d47a5-c32a-400a-8fd8-f115e1ccbe9c",
+      "ConcordiaCourseId": "026400"
+    },
+    {
+      "Id": "9dde1dee-60c2-47d0-bea4-c82f690780f1",
+      "ConcordiaCourseId": "026401"
+    },
+    {
+      "Id": "d4b43895-e588-4fbe-bf3d-f8adb736076f",
+      "ConcordiaCourseId": "026402"
+    },
+    {
+      "Id": "a9ebeeec-9d97-439b-832c-12ccf5635ea6",
+      "ConcordiaCourseId": "026403"
+    },
+    {
+      "Id": "9f6c920a-11eb-4add-a82b-87d53b02bd5d",
+      "ConcordiaCourseId": "047743"
+    },
+    {
+      "Id": "905ba08b-6fa0-4f6e-95ab-97e597f1f9e7",
+      "ConcordiaCourseId": "047744"
+    },
+    {
+      "Id": "c43043d5-869e-46a4-bf06-eb0b066710c1",
+      "ConcordiaCourseId": "047746"
+    },
+    {
+      "Id": "5eda884c-3f3e-4589-9bb2-eb2e570522ab",
+      "ConcordiaCourseId": "047747"
+    },
+    {
+      "Id": "7465cbd3-9653-44ee-9acb-d59d1d724839",
+      "ConcordiaCourseId": "047748"
+    },
+    {
+      "Id": "c90fefda-6e3b-4a09-af08-29112108c725",
+      "ConcordiaCourseId": "047750"
+    },
+    {
+      "Id": "de7cafab-1a17-4ae0-8bbd-37e063ccb256",
+      "ConcordiaCourseId": "047751"
+    },
+    {
+      "Id": "c985a622-5e6d-4f77-af22-e822927f33ca",
+      "ConcordiaCourseId": "047752"
+    },
+    {
+      "Id": "ba20f264-f16e-4141-a727-966a6228ff7f",
+      "ConcordiaCourseId": "047753"
+    },
+    {
+      "Id": "e3e8bdf2-8d21-464c-b760-33b89b17d86b",
+      "ConcordiaCourseId": "047756"
+    },
+    {
+      "Id": "3af76958-32ac-4ce0-a4f4-65a980a3f562",
+      "ConcordiaCourseId": "047758"
+    },
+    {
+      "Id": "f59b23cd-d0e0-423c-bc1a-89ccdfe98545",
+      "ConcordiaCourseId": "047762"
+    },
+    {
+      "Id": "f4398fdb-c2eb-4447-b441-4fbc0bc0ea23",
+      "ConcordiaCourseId": "047764"
+    },
+    {
+      "Id": "764eb85b-665b-44a0-afd2-43fa27b541b7",
+      "ConcordiaCourseId": "047765"
+    },
+    {
+      "Id": "e0bc16b3-5bb9-4a0e-bcc7-b64fea939d59",
+      "ConcordiaCourseId": "047766"
+    },
+    {
+      "Id": "0c9929dd-8609-4d85-93c3-02c41971035a",
+      "ConcordiaCourseId": "047767"
+    },
+    {
+      "Id": "16a78686-80b2-4cfa-be99-bcd257a85abf",
+      "ConcordiaCourseId": "047769"
+    },
+    {
+      "Id": "2f295924-c3c3-40e9-ac8d-bef0c56efc1a",
+      "ConcordiaCourseId": "047776"
+    },
+    {
+      "Id": "4d1a29da-1ce4-48f3-803d-d90a8929a023",
+      "ConcordiaCourseId": "047778"
+    },
+    {
+      "Id": "9d27a0f6-418c-4f56-b397-f09ffb01d002",
+      "ConcordiaCourseId": "047779"
+    },
+    {
+      "Id": "7f8a944a-bd16-4eaf-a942-e388d09bafd5",
+      "ConcordiaCourseId": "047780"
+    },
+    {
+      "Id": "e7248004-492b-427e-95e5-55e111d14c10",
+      "ConcordiaCourseId": "047781"
+    },
+    {
+      "Id": "b9a792e0-cc37-4076-ad1a-4ce3607adb45",
+      "ConcordiaCourseId": "047782"
+    },
+    {
+      "Id": "76e8a89c-df2e-4438-af19-cc171c9edc29",
+      "ConcordiaCourseId": "047783"
+    },
+    {
+      "Id": "9cdebf4a-5c03-46e4-86a1-d07fb073195c",
+      "ConcordiaCourseId": "047784"
+    },
+    {
+      "Id": "3019d5ae-4492-4ae0-8850-7f6e1a79524e",
+      "ConcordiaCourseId": "047785"
+    },
+    {
+      "Id": "41a0e2a7-c06a-4117-b925-73ca3edebd21",
+      "ConcordiaCourseId": "047786"
+    },
+    {
+      "Id": "b037c740-9821-46d6-82e7-be389437b044",
+      "ConcordiaCourseId": "047844"
+    },
+    {
+      "Id": "d28d5043-3fa4-441f-950f-73ee5b81423e",
+      "ConcordiaCourseId": "047845"
+    },
+    {
+      "Id": "cfa715f5-1b0e-40c2-88ba-997e9fc89323",
+      "ConcordiaCourseId": "047846"
+    },
+    {
+      "Id": "6c537c70-e674-46ef-b2ab-ff981a950e79",
+      "ConcordiaCourseId": "047847"
+    },
+    {
+      "Id": "45a88a90-8432-4517-adc5-2bdff7e1b33f",
+      "ConcordiaCourseId": "049679"
+    },
+    {
+      "Id": "5e358a4e-227c-4561-a019-bf379fbdc678",
+      "ConcordiaCourseId": "049719"
+    },
+    {
+      "Id": "21131e2e-1545-4944-9284-00671667f3fb",
+      "ConcordiaCourseId": "049724"
+    },
+    {
+      "Id": "79d6c259-038d-4e2a-9841-d6004b82cedb",
+      "ConcordiaCourseId": "049725"
+    },
+    {
+      "Id": "73f84c70-8590-4feb-9ada-d7c5d40ed27a",
+      "ConcordiaCourseId": "050412"
+    },
+    {
+      "Id": "591f6034-fce7-45a6-8b7e-a9e3eb9d2df3",
+      "ConcordiaCourseId": "050413"
+    },
+    {
+      "Id": "1ab63c49-98d0-4935-8a64-1d6984b74fcb",
+      "ConcordiaCourseId": "050414"
+    },
+    {
+      "Id": "02c5e787-b69c-402e-8740-79cb6cc5f035",
+      "ConcordiaCourseId": "050415"
+    },
+    {
+      "Id": "34c1be62-322b-4cdb-9730-f9843a442e74",
+      "ConcordiaCourseId": "026485"
+    },
+    {
+      "Id": "b01e7629-9239-4af9-9143-2b438c0a111f",
+      "ConcordiaCourseId": "026488"
+    },
+    {
+      "Id": "edca0068-5748-4d6b-81d5-6f6773004d27",
+      "ConcordiaCourseId": "026493"
+    },
+    {
+      "Id": "e516995e-5f17-4838-9c14-70a2ae43eac2",
+      "ConcordiaCourseId": "026494"
+    },
+    {
+      "Id": "481b487a-d643-48d9-84ec-a04e0265bc06",
+      "ConcordiaCourseId": "026495"
+    },
+    {
+      "Id": "c8aad488-06a8-45aa-b068-8a82b5083e7b",
+      "ConcordiaCourseId": "026503"
+    },
+    {
+      "Id": "80351a7e-3a62-4b22-8658-d94aced2249d",
+      "ConcordiaCourseId": "026508"
+    },
+    {
+      "Id": "b42f30b4-4a93-4bf1-9f69-6b5346f2cd30",
+      "ConcordiaCourseId": "026509"
+    },
+    {
+      "Id": "40d97a06-eebc-45c0-85fe-d02696b339d0",
+      "ConcordiaCourseId": "026511"
+    },
+    {
+      "Id": "0aba6ab2-100d-4021-a41a-e83d0602a3d3",
+      "ConcordiaCourseId": "026512"
+    },
+    {
+      "Id": "62cfb7ce-8429-43a9-9bad-88856fadeefb",
+      "ConcordiaCourseId": "026514"
+    },
+    {
+      "Id": "ecbb7c4f-867e-4a45-bb27-723654ed45c5",
+      "ConcordiaCourseId": "026522"
+    },
+    {
+      "Id": "a2078b71-a2e8-4e9f-82d1-47dbf724246e",
+      "ConcordiaCourseId": "026523"
+    },
+    {
+      "Id": "4cf18857-f03d-49ed-b377-b764b5442402",
+      "ConcordiaCourseId": "026524"
+    },
+    {
+      "Id": "900a130d-7ee6-48ea-9c95-2c908fe75f98",
+      "ConcordiaCourseId": "026525"
+    },
+    {
+      "Id": "8c6d5e6d-a6d7-4b48-bbd0-c811936587bf",
+      "ConcordiaCourseId": "026526"
+    },
+    {
+      "Id": "5185e5f4-34ea-43e6-994d-3c801503755c",
+      "ConcordiaCourseId": "026527"
+    },
+    {
+      "Id": "16934c1e-2af4-4af8-8998-6dc7c46f42a5",
+      "ConcordiaCourseId": "026531"
+    },
+    {
+      "Id": "d9d264b4-ced2-4fc6-abc2-842e0cf7f340",
+      "ConcordiaCourseId": "026532"
+    },
+    {
+      "Id": "db17dead-fcee-44c4-8e38-919dea06bad7",
+      "ConcordiaCourseId": "026561"
+    },
+    {
+      "Id": "5523b0b6-ff41-4404-8173-c7a6981e6550",
+      "ConcordiaCourseId": "026573"
+    },
+    {
+      "Id": "6dac8e3b-7e31-4022-bdee-9a34b57d29f2",
+      "ConcordiaCourseId": "026574"
+    },
+    {
+      "Id": "03689e2f-d1ba-46ad-a5be-1e997c6c61c3",
+      "ConcordiaCourseId": "026580"
+    },
+    {
+      "Id": "05d737b1-dd80-4a2d-8be9-a3c033b15cab",
+      "ConcordiaCourseId": "026581"
+    },
+    {
+      "Id": "7597d425-6456-4aea-949f-e87fa1fd409b",
+      "ConcordiaCourseId": "026584"
+    },
+    {
+      "Id": "95a01206-df76-47f9-9e55-d33d45b4540b",
+      "ConcordiaCourseId": "026592"
+    },
+    {
+      "Id": "f01461b8-0b1d-4614-9042-1bbac0ab8bb4",
+      "ConcordiaCourseId": "026602"
+    },
+    {
+      "Id": "325ac227-f09a-4282-a0d8-bd666cdbeb69",
+      "ConcordiaCourseId": "026603"
+    },
+    {
+      "Id": "c00f04c2-a9ec-44ef-ba83-ed26629e80c9",
+      "ConcordiaCourseId": "026605"
+    },
+    {
+      "Id": "563f3c20-7b12-4d9c-99fe-a60bdbcedeca",
+      "ConcordiaCourseId": "026612"
+    },
+    {
+      "Id": "2887cac0-6fd7-46a1-b0b5-d341eb7f7d78",
+      "ConcordiaCourseId": "026621"
+    },
+    {
+      "Id": "237300ce-6cbe-4121-b261-1b54933005b8",
+      "ConcordiaCourseId": "026624"
+    },
+    {
+      "Id": "26e722f5-75d0-4a07-bb4a-aa3745204a00",
+      "ConcordiaCourseId": "026625"
+    },
+    {
+      "Id": "9a6c4831-db29-40f2-8c59-d59927488bc8",
+      "ConcordiaCourseId": "026629"
+    },
+    {
+      "Id": "71ddb733-41e3-4e26-bc33-cec09e26db39",
+      "ConcordiaCourseId": "026638"
+    },
+    {
+      "Id": "97eba260-c68c-4e1f-9f39-34ed73b9a038",
+      "ConcordiaCourseId": "026643"
+    },
+    {
+      "Id": "a0e041d8-b789-48a8-ab39-36c962d764a8",
+      "ConcordiaCourseId": "026651"
+    },
+    {
+      "Id": "bde2b0ae-e6b2-469e-9f3c-62fd43e3677c",
+      "ConcordiaCourseId": "026661"
+    },
+    {
+      "Id": "767fe137-5f12-4a75-8415-cfaece9f8cb4",
+      "ConcordiaCourseId": "026663"
+    },
+    {
+      "Id": "6d21bc85-76a1-4c47-a758-bab07e953409",
+      "ConcordiaCourseId": "026664"
+    },
+    {
+      "Id": "3c90555d-168e-4e0b-915c-313990799f39",
+      "ConcordiaCourseId": "026708"
+    },
+    {
+      "Id": "7975290a-f674-44a9-9b44-194777d43c47",
+      "ConcordiaCourseId": "026710"
+    },
+    {
+      "Id": "ced5767c-cfc6-4061-b8e8-538269fd8603",
+      "ConcordiaCourseId": "026712"
+    },
+    {
+      "Id": "4d96a58b-e4f5-4235-a729-a452dd85e1cb",
+      "ConcordiaCourseId": "026722"
+    },
+    {
+      "Id": "3af280a0-740e-4016-8d25-56ab6ea6d3f3",
+      "ConcordiaCourseId": "026729"
+    },
+    {
+      "Id": "93a70799-565e-4457-bf43-b324b575d906",
+      "ConcordiaCourseId": "026732"
+    },
+    {
+      "Id": "dc8b7770-78ce-4c69-8147-c06ff5245f0e",
+      "ConcordiaCourseId": "026741"
+    },
+    {
+      "Id": "5be338bb-cb05-47ef-adc0-1336589ed32b",
+      "ConcordiaCourseId": "026742"
+    },
+    {
+      "Id": "595eca78-e21e-4125-8233-020d30687c6c",
+      "ConcordiaCourseId": "026749"
+    },
+    {
+      "Id": "22d11fba-aaf8-46f0-af25-caaff9d14600",
+      "ConcordiaCourseId": "026752"
+    },
+    {
+      "Id": "290370fe-4b91-4b16-8d63-f54762973735",
+      "ConcordiaCourseId": "026756"
+    },
+    {
+      "Id": "af60ffd2-e2fd-4f0b-8149-09b70f5ead43",
+      "ConcordiaCourseId": "026757"
+    },
+    {
+      "Id": "a13b0a02-0135-4858-a5c1-02ee20dacdc0",
+      "ConcordiaCourseId": "026759"
+    },
+    {
+      "Id": "4eeb4c16-18ba-43d2-9967-187aeac59705",
+      "ConcordiaCourseId": "026760"
+    },
+    {
+      "Id": "1ff0b430-b1df-44f0-873e-041b22656858",
+      "ConcordiaCourseId": "026761"
+    },
+    {
+      "Id": "841e4d20-f845-4ff1-a5df-36e42b08641a",
+      "ConcordiaCourseId": "026762"
+    },
+    {
+      "Id": "b646e401-1114-4e4a-b2c3-5e360330f631",
+      "ConcordiaCourseId": "026763"
+    },
+    {
+      "Id": "eb9da2ae-9c7a-4180-aa16-562c0e8776fb",
+      "ConcordiaCourseId": "026764"
+    },
+    {
+      "Id": "3c7c8240-667a-43c2-9b56-c8cd80783f4d",
+      "ConcordiaCourseId": "026765"
+    },
+    {
+      "Id": "fc6f731d-ac5a-4fed-89da-0887abf95ee0",
+      "ConcordiaCourseId": "026766"
+    },
+    {
+      "Id": "0c965432-db92-4861-80c3-16bdb7a11e8e",
+      "ConcordiaCourseId": "026767"
+    },
+    {
+      "Id": "d9624e4f-76f5-4d51-b0f4-de9565a3dff0",
+      "ConcordiaCourseId": "026774"
+    },
+    {
+      "Id": "0a6ebf94-c2df-4289-b5f3-7f47ff28640c",
+      "ConcordiaCourseId": "026775"
+    },
+    {
+      "Id": "53a304b4-7aad-4646-a1d1-70186b75b428",
+      "ConcordiaCourseId": "026802"
+    },
+    {
+      "Id": "b6749e9e-b554-4c16-a8c4-dd420b788647",
+      "ConcordiaCourseId": "026803"
+    },
+    {
+      "Id": "71f2dd47-845a-47c8-87ae-a21fd672021f",
+      "ConcordiaCourseId": "026863"
+    },
+    {
+      "Id": "96e566d4-7583-4be1-86ff-794e62c0ecdc",
+      "ConcordiaCourseId": "026865"
+    },
+    {
+      "Id": "edb2326e-7891-41b0-9cfe-75576945de27",
+      "ConcordiaCourseId": "026868"
+    },
+    {
+      "Id": "ceeb768b-93a5-45b0-ae57-a91605157d3d",
+      "ConcordiaCourseId": "026869"
+    },
+    {
+      "Id": "4b470c6d-0b13-48a2-8147-a6bb7e8b2ac9",
+      "ConcordiaCourseId": "026870"
+    },
+    {
+      "Id": "43661836-f91c-45e1-96d3-f6747d12d78a",
+      "ConcordiaCourseId": "026874"
+    },
+    {
+      "Id": "93659ac6-a131-4367-a42d-1416fc366c9a",
+      "ConcordiaCourseId": "026875"
+    },
+    {
+      "Id": "200e0989-4603-4077-9893-a355521ba5fe",
+      "ConcordiaCourseId": "026882"
+    },
+    {
+      "Id": "b0f9be5c-2c70-4d2a-8df3-92233358e541",
+      "ConcordiaCourseId": "026883"
+    },
+    {
+      "Id": "3cc84ecf-2844-4190-a994-5e7b0707fde8",
+      "ConcordiaCourseId": "026884"
+    },
+    {
+      "Id": "c3ad92ba-75c8-40f6-b94c-7f3296722341",
+      "ConcordiaCourseId": "026885"
+    },
+    {
+      "Id": "59ed8b92-ef52-4b76-9ab4-7e3677801f84",
+      "ConcordiaCourseId": "026888"
+    },
+    {
+      "Id": "6c5d1eb5-3d7b-4742-a7b9-b6221f8df009",
+      "ConcordiaCourseId": "026890"
+    },
+    {
+      "Id": "3d7cc39f-4051-44c8-85fd-a206d5e6cc33",
+      "ConcordiaCourseId": "026892"
+    },
+    {
+      "Id": "64909cad-2545-42dc-8769-f52570f82692",
+      "ConcordiaCourseId": "026896"
+    },
+    {
+      "Id": "1df70522-646a-40fb-86bb-4ce01055d978",
+      "ConcordiaCourseId": "026897"
+    },
+    {
+      "Id": "2c76df76-74ee-4f63-922d-ce7b4f83b96e",
+      "ConcordiaCourseId": "026901"
+    },
+    {
+      "Id": "d4e680cc-b011-4e97-8815-cfc65935d1b6",
+      "ConcordiaCourseId": "026903"
+    },
+    {
+      "Id": "0f7e8a29-936e-4785-a023-d392c91b7e6f",
+      "ConcordiaCourseId": "026906"
+    },
+    {
+      "Id": "4877a0a7-d857-43e8-92c6-4273e19f04c0",
+      "ConcordiaCourseId": "026908"
+    },
+    {
+      "Id": "78fdbfba-be2b-4770-8bac-6aa710293ecc",
+      "ConcordiaCourseId": "026915"
+    },
+    {
+      "Id": "8dd6c5d0-2291-4bf0-843f-712ac5abbebf",
+      "ConcordiaCourseId": "026928"
+    },
+    {
+      "Id": "78770353-15ec-4312-b473-f5c3f8e82e6e",
+      "ConcordiaCourseId": "026944"
+    },
+    {
+      "Id": "066b4d3b-defe-44d1-a259-842f92b175fd",
+      "ConcordiaCourseId": "026946"
+    },
+    {
+      "Id": "cd7fecf7-6735-46de-b65d-6d772e00fc7b",
+      "ConcordiaCourseId": "026950"
+    },
+    {
+      "Id": "ad09cd72-8deb-4e7b-9bec-b5bc32055d4d",
+      "ConcordiaCourseId": "037988"
+    },
+    {
+      "Id": "9a49b65b-a1a3-459c-9edb-4b45be4a33e7",
+      "ConcordiaCourseId": "042132"
+    },
+    {
+      "Id": "9bdb4372-1cd7-401e-b235-09179c121653",
+      "ConcordiaCourseId": "042133"
+    },
+    {
+      "Id": "84d43fca-44c8-4c0f-bfea-23d732153c30",
+      "ConcordiaCourseId": "042134"
+    },
+    {
+      "Id": "9bfcf420-60e3-4712-930f-bda0ab1923fc",
+      "ConcordiaCourseId": "042138"
+    },
+    {
+      "Id": "efb5ffa8-600a-4f4f-8469-e6c741e04347",
+      "ConcordiaCourseId": "042153"
+    },
+    {
+      "Id": "93a1f44c-28cc-4d67-b220-0448cf074abb",
+      "ConcordiaCourseId": "042154"
+    },
+    {
+      "Id": "a163541d-db04-482c-9aff-6c958c65812a",
+      "ConcordiaCourseId": "042156"
+    },
+    {
+      "Id": "e1c27336-8f61-4412-bcf7-7cb66ba157c9",
+      "ConcordiaCourseId": "042177"
+    },
+    {
+      "Id": "05dd8c8a-4f59-480c-aa10-bce4f2d639a8",
+      "ConcordiaCourseId": "042178"
+    },
+    {
+      "Id": "9b9e35dc-2e94-405f-bcbf-5024cebced90",
+      "ConcordiaCourseId": "046967"
+    },
+    {
+      "Id": "69decb38-9e04-4692-846d-07a47b864a8f",
+      "ConcordiaCourseId": "046968"
+    },
+    {
+      "Id": "023cdf96-153e-47e1-8330-3f8e11ef3d8f",
+      "ConcordiaCourseId": "046969"
+    },
+    {
+      "Id": "d1e517ee-ae14-4db0-bcb4-f1789b19e167",
+      "ConcordiaCourseId": "046970"
+    },
+    {
+      "Id": "94b35e45-cd3d-46f6-b9c8-6bc527726d01",
+      "ConcordiaCourseId": "046971"
+    },
+    {
+      "Id": "5718ea9e-9266-4c9c-97e9-32249d8c8552",
+      "ConcordiaCourseId": "046972"
+    },
+    {
+      "Id": "8d7c7437-5759-452d-abd7-5643de29331f",
+      "ConcordiaCourseId": "046973"
+    },
+    {
+      "Id": "649f232a-0304-4f7d-a118-9684a3478712",
+      "ConcordiaCourseId": "046974"
+    },
+    {
+      "Id": "616a8dc6-7398-49ad-80f8-2de2ee98807c",
+      "ConcordiaCourseId": "046975"
+    },
+    {
+      "Id": "287cf80f-33a6-4c93-b2ae-7c5392f10a7e",
+      "ConcordiaCourseId": "047279"
+    },
+    {
+      "Id": "5426dd46-004e-49ef-ba72-be14bd7e2ebe",
+      "ConcordiaCourseId": "047330"
+    },
+    {
+      "Id": "e68a84e9-247d-4fb3-b5f3-fa688ffbab96",
+      "ConcordiaCourseId": "048452"
+    },
+    {
+      "Id": "284b6951-9ea5-4c4a-9fb3-e77e4a206926",
+      "ConcordiaCourseId": "048776"
+    },
+    {
+      "Id": "4bfc8444-8e08-44e8-986b-94d21cc4e5d2",
+      "ConcordiaCourseId": "048777"
+    },
+    {
+      "Id": "62fc916b-da2d-487c-a0dd-67493626969b",
+      "ConcordiaCourseId": "048779"
+    },
+    {
+      "Id": "5063ed43-80c8-4f79-982f-5fba61d633ff",
+      "ConcordiaCourseId": "048845"
+    },
+    {
+      "Id": "faa5eb64-5aa9-449f-b549-849f2e435f9b",
+      "ConcordiaCourseId": "048847"
+    },
+    {
+      "Id": "926949aa-1f0c-423c-8f05-a2abfe90eef3",
+      "ConcordiaCourseId": "049239"
+    },
+    {
+      "Id": "064516b5-9f9b-43a1-b81b-f1f112883bf0",
+      "ConcordiaCourseId": "049240"
+    },
+    {
+      "Id": "7f13e1de-ab03-4488-8481-f0c74ba42727",
+      "ConcordiaCourseId": "049262"
+    },
+    {
+      "Id": "d277cb30-7ffb-4d9a-9b5b-1c5bebf52cfc",
+      "ConcordiaCourseId": "049581"
+    },
+    {
+      "Id": "483eee30-7c64-4dc5-ba69-b05884c6a6d4",
+      "ConcordiaCourseId": "049582"
+    },
+    {
+      "Id": "94ca67e8-44f5-4471-9c88-d34a1023dc86",
+      "ConcordiaCourseId": "049584"
+    },
+    {
+      "Id": "c9740e48-2910-4d58-96d8-c75748837591",
+      "ConcordiaCourseId": "050066"
+    },
+    {
+      "Id": "61b83aa6-539d-459c-b7d5-ea78a8f8c4cd",
+      "ConcordiaCourseId": "050067"
+    },
+    {
+      "Id": "d8f3b271-589d-4cbd-b5d4-f7d0114bff01",
+      "ConcordiaCourseId": "050633"
+    },
+    {
+      "Id": "943331d2-2d7f-48a4-bf8d-9c84beb9f9cf",
+      "ConcordiaCourseId": "050669"
+    },
+    {
+      "Id": "79dbc0d6-ead2-4dcf-867c-c13967c00b4f",
+      "ConcordiaCourseId": "046976"
+    },
+    {
+      "Id": "4d53dba4-b41d-4e14-a35f-aad4e04e46ec",
+      "ConcordiaCourseId": "027097"
+    },
+    {
+      "Id": "294a21a3-aa66-4ba7-94b0-c6d28f8d95c5",
+      "ConcordiaCourseId": "027098"
+    },
+    {
+      "Id": "d8d1c9d3-12b1-47af-88c3-2a7608c4e53b",
+      "ConcordiaCourseId": "027099"
+    },
+    {
+      "Id": "cb824d2b-5643-438b-a384-b6e002fa98c5",
+      "ConcordiaCourseId": "027102"
+    },
+    {
+      "Id": "6a6d67f5-94f1-4492-8b21-5313fc8087b9",
+      "ConcordiaCourseId": "027103"
+    },
+    {
+      "Id": "72930864-1b39-462a-805b-9f5ae17b1d39",
+      "ConcordiaCourseId": "027105"
+    },
+    {
+      "Id": "d62caf42-1368-4345-bd16-4834694cc662",
+      "ConcordiaCourseId": "027106"
+    },
+    {
+      "Id": "e287bbe0-f2cd-4fde-acb0-d8c4d7003a3e",
+      "ConcordiaCourseId": "027110"
+    },
+    {
+      "Id": "bfa7dcbd-df28-45bb-940a-b983e698a812",
+      "ConcordiaCourseId": "027111"
+    },
+    {
+      "Id": "15688ae8-575c-401e-a6e0-1a9c3f30b3d9",
+      "ConcordiaCourseId": "027133"
+    },
+    {
+      "Id": "9b9db3e0-cce9-4268-9f99-8bd44d1e352d",
+      "ConcordiaCourseId": "027134"
+    },
+    {
+      "Id": "256a13fc-4fcc-4d84-a24e-8700cc841f05",
+      "ConcordiaCourseId": "027135"
+    },
+    {
+      "Id": "2b35e163-e2c2-4c17-9ec3-25586ef86eb3",
+      "ConcordiaCourseId": "027136"
+    },
+    {
+      "Id": "7fdbe599-702c-4ed3-98a3-08d58f2473f8",
+      "ConcordiaCourseId": "027137"
+    },
+    {
+      "Id": "7d8438aa-afdb-4224-8616-b8859fb6bd25",
+      "ConcordiaCourseId": "027138"
+    },
+    {
+      "Id": "02216948-8962-469b-b9c7-1868349ac86f",
+      "ConcordiaCourseId": "027157"
+    },
+    {
+      "Id": "91049f8f-90eb-4461-8d9c-9c0c1959a0f9",
+      "ConcordiaCourseId": "027159"
+    },
+    {
+      "Id": "4171c3ee-b803-4b46-b74d-f6d1e29d01d5",
+      "ConcordiaCourseId": "027161"
+    },
+    {
+      "Id": "453bde28-cb42-4e00-944a-12d7da2dee92",
+      "ConcordiaCourseId": "027162"
+    },
+    {
+      "Id": "9f795192-67a0-4279-b956-fb7bd4b6241e",
+      "ConcordiaCourseId": "042196"
+    },
+    {
+      "Id": "26beaf38-bfd7-4048-8084-3a093369bc02",
+      "ConcordiaCourseId": "046977"
+    },
+    {
+      "Id": "39228288-1134-4683-941d-aaf66b78097e",
+      "ConcordiaCourseId": "046978"
+    },
+    {
+      "Id": "46ffd8b3-ce67-4706-aa4b-195052dbdbc0",
+      "ConcordiaCourseId": "046979"
+    },
+    {
+      "Id": "9339c788-10ec-4418-bf7b-2b2d68b9ed41",
+      "ConcordiaCourseId": "046980"
+    },
+    {
+      "Id": "4c284414-df4c-47c0-9d30-799a1b971c10",
+      "ConcordiaCourseId": "046981"
+    },
+    {
+      "Id": "9f99bd5a-e00c-4c39-a317-2c1005123e99",
+      "ConcordiaCourseId": "046982"
+    },
+    {
+      "Id": "85902579-d505-4d29-b537-25bcf291caaf",
+      "ConcordiaCourseId": "027198"
+    },
+    {
+      "Id": "d6702fbf-f6f0-4601-997c-8b1903804d31",
+      "ConcordiaCourseId": "027204"
+    },
+    {
+      "Id": "16e8d4cc-375c-49b3-b8d8-007864927a87",
+      "ConcordiaCourseId": "027205"
+    },
+    {
+      "Id": "afdef0a4-0745-4f10-8c7a-d71093a096e0",
+      "ConcordiaCourseId": "027207"
+    },
+    {
+      "Id": "6a65ec16-10bd-4e5b-805c-ba4cc0bde910",
+      "ConcordiaCourseId": "027216"
+    },
+    {
+      "Id": "77ca7a71-431d-4ee5-882a-400f21115ef7",
+      "ConcordiaCourseId": "027217"
+    },
+    {
+      "Id": "04a2aeac-ecc5-4e9d-8366-01c553ec87f0",
+      "ConcordiaCourseId": "027218"
+    },
+    {
+      "Id": "b70f2b97-5e0b-4e5a-8e51-a97c7acf7c70",
+      "ConcordiaCourseId": "027220"
+    },
+    {
+      "Id": "c2a844b4-fc80-4ff9-a7e9-5bf3c91affcf",
+      "ConcordiaCourseId": "027223"
+    },
+    {
+      "Id": "ca1e3cc1-56a5-49cb-b8e2-bd2114bffab9",
+      "ConcordiaCourseId": "027226"
+    },
+    {
+      "Id": "96faae1c-cb0b-4c0b-842c-bdd0c89e1345",
+      "ConcordiaCourseId": "027228"
+    },
+    {
+      "Id": "434925e3-a638-47aa-adcc-df1647c20d2b",
+      "ConcordiaCourseId": "027229"
+    },
+    {
+      "Id": "57a1af14-fa93-42e9-be53-e91e35440cc2",
+      "ConcordiaCourseId": "027230"
+    },
+    {
+      "Id": "bf7b7bf8-ff5e-4f03-8957-618482121767",
+      "ConcordiaCourseId": "027232"
+    },
+    {
+      "Id": "101ff774-e896-490c-b1d2-4f049ac33552",
+      "ConcordiaCourseId": "027233"
+    },
+    {
+      "Id": "577eabd4-fafa-43e0-8e00-f0d5adb716f0",
+      "ConcordiaCourseId": "027234"
+    },
+    {
+      "Id": "30034acc-c5f1-4a46-bc52-5bf1a178b687",
+      "ConcordiaCourseId": "027235"
+    },
+    {
+      "Id": "88701ba4-0ec2-45ae-81b3-97a6c82008e8",
+      "ConcordiaCourseId": "027237"
+    },
+    {
+      "Id": "7548d6e2-843d-4421-be3a-5d73deae0bb5",
+      "ConcordiaCourseId": "027241"
+    },
+    {
+      "Id": "b7a23772-87ab-4671-b11c-238b90eefb72",
+      "ConcordiaCourseId": "027266"
+    },
+    {
+      "Id": "afac850d-4b6d-46e2-afaf-1ef558474a8e",
+      "ConcordiaCourseId": "027267"
+    },
+    {
+      "Id": "f1812e76-a2bf-4345-b324-906bb995ad71",
+      "ConcordiaCourseId": "027270"
+    },
+    {
+      "Id": "2bb39e7c-e3bc-4e39-8024-6d4bba1eaa58",
+      "ConcordiaCourseId": "027279"
+    },
+    {
+      "Id": "67da8305-c247-402c-98e5-e363c603e1e0",
+      "ConcordiaCourseId": "027280"
+    },
+    {
+      "Id": "235e3cbd-1a0b-4fda-9be6-9bef0571cc74",
+      "ConcordiaCourseId": "027285"
+    },
+    {
+      "Id": "8e6f24bc-090e-4b77-8a37-040850fbed8c",
+      "ConcordiaCourseId": "027286"
+    },
+    {
+      "Id": "bf38896d-d17e-420f-b507-118b0f9d5dbc",
+      "ConcordiaCourseId": "027287"
+    },
+    {
+      "Id": "0dbb91b5-12b5-4565-9f57-db3c5d590c09",
+      "ConcordiaCourseId": "027296"
+    },
+    {
+      "Id": "f3304542-a326-451a-86c5-1d1e635f30aa",
+      "ConcordiaCourseId": "027299"
+    },
+    {
+      "Id": "7bca1be1-ab27-403d-bfaa-3110dc3fe0d5",
+      "ConcordiaCourseId": "027329"
+    },
+    {
+      "Id": "a20a08a8-51a5-4d6d-84e2-e72a8d614bb7",
+      "ConcordiaCourseId": "027331"
+    },
+    {
+      "Id": "5f79153e-50d4-4a0b-baf5-2bb329ea362e",
+      "ConcordiaCourseId": "027333"
+    },
+    {
+      "Id": "727505a6-0771-4233-82d0-4caea1a99c7a",
+      "ConcordiaCourseId": "027341"
+    },
+    {
+      "Id": "c1538d79-fdb9-4678-b1fd-7f855c2c3d99",
+      "ConcordiaCourseId": "027342"
+    },
+    {
+      "Id": "f839ce50-011f-4280-b052-6b2e05994de4",
+      "ConcordiaCourseId": "027346"
+    },
+    {
+      "Id": "4d7b660c-fc10-4b96-b082-39420a809292",
+      "ConcordiaCourseId": "027350"
+    },
+    {
+      "Id": "8b425c37-b8e0-454c-84dd-a7a2bbea9b3b",
+      "ConcordiaCourseId": "027363"
+    },
+    {
+      "Id": "06ae9d75-70a3-415c-9f1e-0a7e3f5a74e9",
+      "ConcordiaCourseId": "027364"
+    },
+    {
+      "Id": "ac52d132-e3c0-4053-8b37-21d3982507ee",
+      "ConcordiaCourseId": "027384"
+    },
+    {
+      "Id": "0d202b5b-f94a-4581-a8d2-a65be070e35e",
+      "ConcordiaCourseId": "027385"
+    },
+    {
+      "Id": "40d262d3-2f13-4693-9df8-cd6e28fa3634",
+      "ConcordiaCourseId": "027386"
+    },
+    {
+      "Id": "c752d965-dd71-46bb-8e8e-abc6ebb00591",
+      "ConcordiaCourseId": "027402"
+    },
+    {
+      "Id": "d57b4e7e-3f9a-43ef-b26a-dc6e6a776f88",
+      "ConcordiaCourseId": "027406"
+    },
+    {
+      "Id": "12321645-7e50-4c1b-983c-9c62206512a2",
+      "ConcordiaCourseId": "027407"
+    },
+    {
+      "Id": "914eb421-32ae-4769-9808-b25a518e873c",
+      "ConcordiaCourseId": "027409"
+    },
+    {
+      "Id": "7cad0bfe-0a11-4443-8373-e36dc3fa8d48",
+      "ConcordiaCourseId": "027421"
+    },
+    {
+      "Id": "79d881be-15dd-4d1e-826b-fd78be1eb35b",
+      "ConcordiaCourseId": "027429"
+    },
+    {
+      "Id": "d793aad7-bf64-42fb-84b7-dfbdce58676f",
+      "ConcordiaCourseId": "027435"
+    },
+    {
+      "Id": "7b686d4b-df12-43a9-9c65-9ef1112d5857",
+      "ConcordiaCourseId": "027440"
+    },
+    {
+      "Id": "7ec942a8-aa0b-4a7c-84a6-bae22515c177",
+      "ConcordiaCourseId": "027442"
+    },
+    {
+      "Id": "33a764c8-02f7-4ea8-882e-d00a8b58d732",
+      "ConcordiaCourseId": "027444"
+    },
+    {
+      "Id": "df0e1f3b-68c7-4bdf-b89e-fcf2875408b5",
+      "ConcordiaCourseId": "027447"
+    },
+    {
+      "Id": "4080db97-a363-401d-a9ab-57be5fce3a50",
+      "ConcordiaCourseId": "037999"
+    },
+    {
+      "Id": "cdea71ce-6ea5-40b5-abb8-d549c73cd5a1",
+      "ConcordiaCourseId": "038003"
+    },
+    {
+      "Id": "6278fea2-f359-426f-bad0-96e4ab74841a",
+      "ConcordiaCourseId": "042204"
+    },
+    {
+      "Id": "7184c8b7-d2d8-4817-8eed-b845ecb120ed",
+      "ConcordiaCourseId": "042206"
+    },
+    {
+      "Id": "c9174e0d-2ac7-4700-b9e1-b79665c3ec34",
+      "ConcordiaCourseId": "042207"
+    },
+    {
+      "Id": "c4da2165-94e8-46fd-b903-6e5bdd17c1b0",
+      "ConcordiaCourseId": "042208"
+    },
+    {
+      "Id": "fe7e33f4-32f7-431c-855d-d4fc1cb83a87",
+      "ConcordiaCourseId": "042209"
+    },
+    {
+      "Id": "c19dfb51-8863-4d88-8671-5b9de1441d92",
+      "ConcordiaCourseId": "042210"
+    },
+    {
+      "Id": "5fdd84e4-afbd-4f1d-8c43-c205ae4e2e68",
+      "ConcordiaCourseId": "046983"
+    },
+    {
+      "Id": "0b204ca8-96c2-4f96-8593-d0229ab36767",
+      "ConcordiaCourseId": "046984"
+    },
+    {
+      "Id": "4cc9aafa-5095-45e1-bf8f-45ac2e474c88",
+      "ConcordiaCourseId": "046985"
+    },
+    {
+      "Id": "4ca4588d-b291-494b-b0ab-3236195bccd6",
+      "ConcordiaCourseId": "046986"
+    },
+    {
+      "Id": "c5b92fe0-3fc8-40f7-86a0-66a9e2c3a90f",
+      "ConcordiaCourseId": "046987"
+    },
+    {
+      "Id": "f91b9b12-69d6-45be-9e5e-8fc1ed09b9c2",
+      "ConcordiaCourseId": "046988"
+    },
+    {
+      "Id": "9acf0caf-0ce8-48a6-b7fe-febacbe52706",
+      "ConcordiaCourseId": "046989"
+    },
+    {
+      "Id": "b4142b3e-7d77-4771-ab09-d855920564d2",
+      "ConcordiaCourseId": "046990"
+    },
+    {
+      "Id": "65ee7688-def6-42c5-af2d-662069d90e36",
+      "ConcordiaCourseId": "046991"
+    },
+    {
+      "Id": "3b8b990c-9daf-4d6b-85b3-c22994de6afb",
+      "ConcordiaCourseId": "047814"
+    },
+    {
+      "Id": "e65bee13-9276-42be-affe-648dbd63e5be",
+      "ConcordiaCourseId": "048349"
+    },
+    {
+      "Id": "02eeb846-f504-4c12-a851-ec9b338afdee",
+      "ConcordiaCourseId": "048350"
+    },
+    {
+      "Id": "89b48fd1-1c41-44bf-95e4-c315a2370f6a",
+      "ConcordiaCourseId": "048351"
+    },
+    {
+      "Id": "11568a4c-3572-4391-a93a-a53f1be04f6c",
+      "ConcordiaCourseId": "048372"
+    },
+    {
+      "Id": "dae6ae01-f00b-4033-b9c8-d04ad116a273",
+      "ConcordiaCourseId": "048373"
+    },
+    {
+      "Id": "f0c96676-e9e6-4c50-aeb9-317dd028a0a1",
+      "ConcordiaCourseId": "048374"
+    },
+    {
+      "Id": "826c1f6c-d16f-4f9d-84e3-ee3a72d31287",
+      "ConcordiaCourseId": "048375"
+    },
+    {
+      "Id": "f1a05a6b-d4ef-4a85-b155-4290228d7009",
+      "ConcordiaCourseId": "049249"
+    },
+    {
+      "Id": "e3b9a7f5-e174-4909-bd80-482c54b5421e",
+      "ConcordiaCourseId": "049250"
+    },
+    {
+      "Id": "3cc4f55e-6fff-4749-8e1e-f5f9b777731d",
+      "ConcordiaCourseId": "049631"
+    },
+    {
+      "Id": "c6b61aa5-ea99-4178-a470-e3a4a00d8a9b",
+      "ConcordiaCourseId": "050146"
+    },
+    {
+      "Id": "d7f1dce1-73ff-4d6d-b9c5-f63bc089faad",
+      "ConcordiaCourseId": "050147"
+    },
+    {
+      "Id": "278279d1-db39-4d24-a1e7-94cb4007f65a",
+      "ConcordiaCourseId": "050068"
+    },
+    {
+      "Id": "00d8fe94-79b8-4bc0-8329-0b27f2906cf8",
+      "ConcordiaCourseId": "050070"
+    },
+    {
+      "Id": "c58c1359-8312-4e7e-a6e9-7772ad0dbac9",
+      "ConcordiaCourseId": "050071"
+    },
+    {
+      "Id": "607c5288-f374-48d5-b251-4e0c2743496a",
+      "ConcordiaCourseId": "050072"
+    },
+    {
+      "Id": "2e221cf3-0677-4696-9938-3bda2be187de",
+      "ConcordiaCourseId": "050073"
+    },
+    {
+      "Id": "7c569b56-1983-4020-90eb-73ad1893ccde",
+      "ConcordiaCourseId": "027584"
+    },
+    {
+      "Id": "3ae9ccf8-9d57-4d82-b8ed-bc622540b7ed",
+      "ConcordiaCourseId": "027585"
+    },
+    {
+      "Id": "9ec5cd0d-2d69-4eac-9221-b7bf47fea29f",
+      "ConcordiaCourseId": "027586"
+    },
+    {
+      "Id": "e6a8f9fa-2dca-4ff6-b64f-112cce6c9e2e",
+      "ConcordiaCourseId": "027587"
+    },
+    {
+      "Id": "6add3bf0-142e-4155-bd76-a4ad423160c6",
+      "ConcordiaCourseId": "027588"
+    },
+    {
+      "Id": "56d86ce5-76f9-46d9-b4bb-c3779736c9a3",
+      "ConcordiaCourseId": "027589"
+    },
+    {
+      "Id": "a9f8dd3c-3586-45f8-bf15-381bf0277ead",
+      "ConcordiaCourseId": "027590"
+    },
+    {
+      "Id": "ea676d16-a2c9-4016-9524-76440a8c84cd",
+      "ConcordiaCourseId": "027591"
+    },
+    {
+      "Id": "62d9731a-d251-46e6-aa21-e75d85bd02df",
+      "ConcordiaCourseId": "027598"
+    },
+    {
+      "Id": "f9b280ba-9cb9-4ea8-91cf-2826381dc0d7",
+      "ConcordiaCourseId": "027600"
+    },
+    {
+      "Id": "1689079f-dbd3-489e-beb6-33b66accd7b3",
+      "ConcordiaCourseId": "027601"
+    },
+    {
+      "Id": "7fd0bc1b-5378-4f06-90c4-bd55d41244b4",
+      "ConcordiaCourseId": "027602"
+    },
+    {
+      "Id": "553a1052-4f98-4ab4-9094-271d1f53d35b",
+      "ConcordiaCourseId": "027603"
+    },
+    {
+      "Id": "1a9e6358-9c61-4750-a793-76e13d486b46",
+      "ConcordiaCourseId": "027604"
+    },
+    {
+      "Id": "1533957d-c714-4685-ab68-c5903c6d446b",
+      "ConcordiaCourseId": "027649"
+    },
+    {
+      "Id": "f33be0bf-7dfa-4006-a5df-a5e9058a2265",
+      "ConcordiaCourseId": "027653"
+    },
+    {
+      "Id": "837d5afb-2236-46d7-8a86-19d8c8c48e85",
+      "ConcordiaCourseId": "027654"
+    },
+    {
+      "Id": "2972989b-5b57-45ee-b16f-9028cb96f427",
+      "ConcordiaCourseId": "027655"
+    },
+    {
+      "Id": "d668944f-6d25-4520-9185-3ef7d3f9bfe6",
+      "ConcordiaCourseId": "027656"
+    },
+    {
+      "Id": "bf401865-1fb2-45a3-9eca-0469418663f8",
+      "ConcordiaCourseId": "027657"
+    },
+    {
+      "Id": "038dc170-f505-45dc-9f55-64539aca5125",
+      "ConcordiaCourseId": "027658"
+    },
+    {
+      "Id": "2cab4f3e-d19a-4ca6-ae61-16bfd39581d2",
+      "ConcordiaCourseId": "027659"
+    },
+    {
+      "Id": "04b6321a-9340-48ee-9cb8-4e9b42d47115",
+      "ConcordiaCourseId": "027661"
+    },
+    {
+      "Id": "330ed1d6-a052-44e3-b9cc-a4d3070f634b",
+      "ConcordiaCourseId": "027662"
+    },
+    {
+      "Id": "86993a09-04e9-417d-9127-a5de4cedd57f",
+      "ConcordiaCourseId": "027665"
+    },
+    {
+      "Id": "5bb912bc-586b-4b55-b28c-5df6325b0ca2",
+      "ConcordiaCourseId": "027667"
+    },
+    {
+      "Id": "584def96-d9aa-4402-ac00-82102d57cff6",
+      "ConcordiaCourseId": "027669"
+    },
+    {
+      "Id": "b0ef956a-e07c-4dcd-b180-37532ede0ef6",
+      "ConcordiaCourseId": "027673"
+    },
+    {
+      "Id": "995e1c61-2f69-4229-a038-42741bc5a4c2",
+      "ConcordiaCourseId": "027675"
+    },
+    {
+      "Id": "744a7338-b6bd-45c4-a226-656a7149b751",
+      "ConcordiaCourseId": "027676"
+    },
+    {
+      "Id": "69e58d1d-c416-4375-93b8-5b1538d87f66",
+      "ConcordiaCourseId": "027677"
+    },
+    {
+      "Id": "d8a5b7cb-3656-4818-b5ae-a448c42f892b",
+      "ConcordiaCourseId": "027680"
+    },
+    {
+      "Id": "80e23070-6f0b-4acf-a851-fbb1f7ea3263",
+      "ConcordiaCourseId": "027681"
+    },
+    {
+      "Id": "7c180405-6d4f-4b6b-af3a-e39fbc913b0a",
+      "ConcordiaCourseId": "027682"
+    },
+    {
+      "Id": "f91009c1-392c-453e-acb8-149ea966d628",
+      "ConcordiaCourseId": "027685"
+    },
+    {
+      "Id": "b8f52713-a3b2-4780-869e-c7206dc0a9b9",
+      "ConcordiaCourseId": "027687"
+    },
+    {
+      "Id": "129680ac-f5fc-412f-b598-fb963d8fb0c6",
+      "ConcordiaCourseId": "027689"
+    },
+    {
+      "Id": "2dbb975b-8b65-44d1-bc7b-57cd2d1e828b",
+      "ConcordiaCourseId": "027690"
+    },
+    {
+      "Id": "bbc18b08-6123-41a8-befc-24e437729bd2",
+      "ConcordiaCourseId": "027692"
+    },
+    {
+      "Id": "2fd7f5d5-639f-4232-8029-4d2e88686d77",
+      "ConcordiaCourseId": "027693"
+    },
+    {
+      "Id": "7364da12-ebf0-4f63-bb6c-2265ca5b83c2",
+      "ConcordiaCourseId": "027694"
+    },
+    {
+      "Id": "d087588f-c14c-4928-8631-fcd4b7e7cfb0",
+      "ConcordiaCourseId": "027695"
+    },
+    {
+      "Id": "0a2d6863-14e4-47cf-80ba-5687c3fe0a28",
+      "ConcordiaCourseId": "027696"
+    },
+    {
+      "Id": "9ab12586-c723-4c9c-99a1-d089574c53bc",
+      "ConcordiaCourseId": "027697"
+    },
+    {
+      "Id": "951d0b18-3590-4dbe-8842-f0460b1f5df5",
+      "ConcordiaCourseId": "027698"
+    },
+    {
+      "Id": "798c3481-0fd5-455b-9c14-fdb5a602378e",
+      "ConcordiaCourseId": "027699"
+    },
+    {
+      "Id": "a4d82a18-4abe-4dcc-8584-10aa5432b334",
+      "ConcordiaCourseId": "027700"
+    },
+    {
+      "Id": "3a9e0ac3-321f-4844-b345-958909766d23",
+      "ConcordiaCourseId": "027704"
+    },
+    {
+      "Id": "923167e2-684f-4703-b166-951e1aeeab17",
+      "ConcordiaCourseId": "027705"
+    },
+    {
+      "Id": "78051e4e-d7a8-40e6-bc09-90f5a99697f3",
+      "ConcordiaCourseId": "027708"
+    },
+    {
+      "Id": "62a50953-1e9a-4181-9791-0169670ebea8",
+      "ConcordiaCourseId": "027712"
+    },
+    {
+      "Id": "43eda8a5-a037-4365-8fe5-9c89f744f160",
+      "ConcordiaCourseId": "027715"
+    },
+    {
+      "Id": "cea3cea0-c694-46e3-8ea2-163f70c2034f",
+      "ConcordiaCourseId": "027716"
+    },
+    {
+      "Id": "73d214a8-1cf0-4285-81a0-15b5b54797d5",
+      "ConcordiaCourseId": "027717"
+    },
+    {
+      "Id": "1857282c-9dd5-4998-9565-88e1629f3102",
+      "ConcordiaCourseId": "027720"
+    },
+    {
+      "Id": "09c11194-edf4-49c6-b967-88e05e871318",
+      "ConcordiaCourseId": "027721"
+    },
+    {
+      "Id": "18073c2a-751d-49e1-85b0-5c2c43841e59",
+      "ConcordiaCourseId": "027723"
+    },
+    {
+      "Id": "96b4f5d0-87c6-4fc9-9b24-f33df41e1aa4",
+      "ConcordiaCourseId": "027730"
+    },
+    {
+      "Id": "3db9530c-c653-4af6-820b-ce4cfeba277d",
+      "ConcordiaCourseId": "027733"
+    },
+    {
+      "Id": "ef8c5dc0-a977-4515-b3ca-ff79470aa8a4",
+      "ConcordiaCourseId": "027734"
+    },
+    {
+      "Id": "e835aa08-ae8b-429c-892d-e7ff4f1bd281",
+      "ConcordiaCourseId": "027736"
+    },
+    {
+      "Id": "c665692d-d2f7-442c-ae0e-f77f552ba763",
+      "ConcordiaCourseId": "027737"
+    },
+    {
+      "Id": "e6b69707-10f7-4ea6-8d1c-dd7269945ac8",
+      "ConcordiaCourseId": "027738"
+    },
+    {
+      "Id": "17e9f5f9-e409-4c2b-9be7-3202116e6e91",
+      "ConcordiaCourseId": "027740"
+    },
+    {
+      "Id": "5c220c77-62a6-4464-8e41-d7019b9faf7c",
+      "ConcordiaCourseId": "027742"
+    },
+    {
+      "Id": "896b956f-d25a-49b3-8cf0-597885203632",
+      "ConcordiaCourseId": "027745"
+    },
+    {
+      "Id": "c086595b-0166-4385-8672-24eec609718d",
+      "ConcordiaCourseId": "027748"
+    },
+    {
+      "Id": "feecc02f-40dd-44cf-af24-9a227c56500a",
+      "ConcordiaCourseId": "027749"
+    },
+    {
+      "Id": "15795bbb-d079-4ca6-9ab0-1a253326e00a",
+      "ConcordiaCourseId": "027752"
+    },
+    {
+      "Id": "ee5d5957-4417-47a1-83ea-153bcc1d05a8",
+      "ConcordiaCourseId": "027757"
+    },
+    {
+      "Id": "c490548c-6b38-4314-8ccc-ec6e10d990cb",
+      "ConcordiaCourseId": "027759"
+    },
+    {
+      "Id": "6b5d3c66-5ba2-476f-a73f-3bfe15c9f667",
+      "ConcordiaCourseId": "027760"
+    },
+    {
+      "Id": "3c49fc7d-4b89-4703-8731-0cab34c5b6a8",
+      "ConcordiaCourseId": "027761"
+    },
+    {
+      "Id": "188f98d9-afe2-48f8-9ac7-b38f01c2ed38",
+      "ConcordiaCourseId": "027764"
+    },
+    {
+      "Id": "d3921758-4395-4976-938a-e91c08641557",
+      "ConcordiaCourseId": "027767"
+    },
+    {
+      "Id": "146e609c-cf02-4a9b-a939-8b65bc436b96",
+      "ConcordiaCourseId": "027768"
+    },
+    {
+      "Id": "b79b199f-3f25-4677-ac99-3bb574137fd6",
+      "ConcordiaCourseId": "027770"
+    },
+    {
+      "Id": "fa4ee615-2d24-40f7-843a-564cf1cbe01e",
+      "ConcordiaCourseId": "027771"
+    },
+    {
+      "Id": "bfdd824e-7804-4f84-a6ac-aba59aa90920",
+      "ConcordiaCourseId": "027772"
+    },
+    {
+      "Id": "23f963d7-d7a0-4739-a891-8ccc390a7daa",
+      "ConcordiaCourseId": "027815"
+    },
+    {
+      "Id": "3e72785b-f4f6-4fa4-8ac1-3fdbf97b2340",
+      "ConcordiaCourseId": "027817"
+    },
+    {
+      "Id": "90300bfb-6ffe-4e4f-84e0-4caf9bb4e8c8",
+      "ConcordiaCourseId": "027818"
+    },
+    {
+      "Id": "91b80115-96fe-4c5f-a06a-793aa31342f3",
+      "ConcordiaCourseId": "027819"
+    },
+    {
+      "Id": "4bbc4519-25b7-40c9-979f-c9a68ce8f5c8",
+      "ConcordiaCourseId": "027820"
+    },
+    {
+      "Id": "94f8387d-4a6a-479b-93d8-9454cac86950",
+      "ConcordiaCourseId": "027821"
+    },
+    {
+      "Id": "e45c6c70-2dc2-4865-97d9-3e003f42fbd1",
+      "ConcordiaCourseId": "027822"
+    },
+    {
+      "Id": "833c57dc-75a5-4282-85c1-25555a24a2e1",
+      "ConcordiaCourseId": "027823"
+    },
+    {
+      "Id": "8279eaa1-5a9f-419a-bd4d-73487dfbb597",
+      "ConcordiaCourseId": "027824"
+    },
+    {
+      "Id": "7988aa8c-152c-4ab1-b77d-8a173089b031",
+      "ConcordiaCourseId": "027825"
+    },
+    {
+      "Id": "4367d74f-9542-4bb0-a1cd-67c37a3cc6c9",
+      "ConcordiaCourseId": "027826"
+    },
+    {
+      "Id": "4a0644f2-60f2-4446-9b0a-d66fcc9a33c6",
+      "ConcordiaCourseId": "027828"
+    },
+    {
+      "Id": "e97ad1bf-716a-4ead-9b4b-007861a24f3d",
+      "ConcordiaCourseId": "027831"
+    },
+    {
+      "Id": "527b7138-442e-4bb9-8525-9b456a0738a5",
+      "ConcordiaCourseId": "027832"
+    },
+    {
+      "Id": "3b12884c-1029-4267-87eb-e0f88b53f9a4",
+      "ConcordiaCourseId": "027833"
+    },
+    {
+      "Id": "8823641e-1569-4af2-a151-61ce40eb7ad5",
+      "ConcordiaCourseId": "027834"
+    },
+    {
+      "Id": "cd1c25f7-3344-4dbc-baf7-188d3aca9634",
+      "ConcordiaCourseId": "027835"
+    },
+    {
+      "Id": "c62da739-727f-4754-85f7-23d02691bed8",
+      "ConcordiaCourseId": "027836"
+    },
+    {
+      "Id": "9f1a449f-8844-46b9-ab3a-3e1b29fdb223",
+      "ConcordiaCourseId": "027840"
+    },
+    {
+      "Id": "9aaa18cc-ccd6-4be7-94f9-d14dfc18dafd",
+      "ConcordiaCourseId": "027843"
+    },
+    {
+      "Id": "48f540cb-b078-48fe-beac-0e45eee306be",
+      "ConcordiaCourseId": "027847"
+    },
+    {
+      "Id": "86ca712a-c9da-4770-b971-31b157b8cb61",
+      "ConcordiaCourseId": "027848"
+    },
+    {
+      "Id": "86d820a6-3ec9-4873-8fcd-dc56b4bc7162",
+      "ConcordiaCourseId": "027849"
+    },
+    {
+      "Id": "9459caf9-47ad-4f71-9656-7cfe8848cc73",
+      "ConcordiaCourseId": "027850"
+    },
+    {
+      "Id": "35b8b302-5a38-43e7-99b3-e1db8e9379c7",
+      "ConcordiaCourseId": "027852"
+    },
+    {
+      "Id": "16c015b9-b4e4-4407-b252-4cd50f4421d5",
+      "ConcordiaCourseId": "027857"
+    },
+    {
+      "Id": "25e6ec54-954e-413b-88d7-1f94361610d1",
+      "ConcordiaCourseId": "027859"
+    },
+    {
+      "Id": "01f55da3-c857-47b9-b850-aae47bfa9cba",
+      "ConcordiaCourseId": "027861"
+    },
+    {
+      "Id": "4004c4a9-4021-40dd-a572-4791040359e3",
+      "ConcordiaCourseId": "027863"
+    },
+    {
+      "Id": "f07dadcd-09ca-4c7e-a0d4-eaa8f54180f0",
+      "ConcordiaCourseId": "027872"
+    },
+    {
+      "Id": "f77f1894-7871-4c6b-a679-6adf86b8d400",
+      "ConcordiaCourseId": "027882"
+    },
+    {
+      "Id": "905c6a9a-7120-4334-a5ef-c72982061e32",
+      "ConcordiaCourseId": "027891"
+    },
+    {
+      "Id": "2d3eb7e6-60a9-4d85-9566-a0a4c8b842fb",
+      "ConcordiaCourseId": "027893"
+    },
+    {
+      "Id": "2124b779-9332-4015-bdc0-bab7b854d8c9",
+      "ConcordiaCourseId": "027895"
+    },
+    {
+      "Id": "5eda1f9e-c717-474a-9368-f2d9f00d1bee",
+      "ConcordiaCourseId": "027897"
+    },
+    {
+      "Id": "a4b2dce2-f039-48ac-8209-8d3803553d90",
+      "ConcordiaCourseId": "027898"
+    },
+    {
+      "Id": "3ab533e8-4c20-4092-96d9-2e3b139f5759",
+      "ConcordiaCourseId": "027944"
+    },
+    {
+      "Id": "fe462a07-7b78-491a-8319-46c5a34df314",
+      "ConcordiaCourseId": "027945"
+    },
+    {
+      "Id": "ba3e3307-5cc1-4eab-9120-e1d16856a0f1",
+      "ConcordiaCourseId": "027966"
+    },
+    {
+      "Id": "133a86d7-8cdf-46c3-917b-6c08b9cede4b",
+      "ConcordiaCourseId": "027968"
+    },
+    {
+      "Id": "c5dc0e38-3d17-47c0-8a33-d79a3019515d",
+      "ConcordiaCourseId": "027989"
+    },
+    {
+      "Id": "d8b6e7e6-b75c-4cd4-8a6a-0ea15c78c1c3",
+      "ConcordiaCourseId": "027993"
+    },
+    {
+      "Id": "1569fb2d-91db-4706-8531-2711bf5a433e",
+      "ConcordiaCourseId": "027994"
+    },
+    {
+      "Id": "96f3534c-2bea-4d41-a26c-3f8393d78ed7",
+      "ConcordiaCourseId": "027995"
+    },
+    {
+      "Id": "e798b4fe-b0a3-46a7-ab9f-a7b1ad120479",
+      "ConcordiaCourseId": "027999"
+    },
+    {
+      "Id": "4069f253-3951-49af-8919-4b73429f66ee",
+      "ConcordiaCourseId": "028091"
+    },
+    {
+      "Id": "ee68d9b8-de2f-4291-9b08-328b2c94d298",
+      "ConcordiaCourseId": "028093"
+    },
+    {
+      "Id": "741cc101-77af-4977-b3b6-5fb6b2d5692b",
+      "ConcordiaCourseId": "028094"
+    },
+    {
+      "Id": "40f72ebc-ab2c-4d5e-9cd6-f062d6bd3493",
+      "ConcordiaCourseId": "028096"
+    },
+    {
+      "Id": "d2b2a566-f208-46a2-af33-bf650e8fcb7f",
+      "ConcordiaCourseId": "028098"
+    },
+    {
+      "Id": "62b32942-9a87-47b4-9709-e4f8e181e72b",
+      "ConcordiaCourseId": "028099"
+    },
+    {
+      "Id": "91301905-59b6-4351-9aa0-2634ded189c1",
+      "ConcordiaCourseId": "028100"
+    },
+    {
+      "Id": "f153c55c-f839-4ca2-9bb4-15f6738b9f94",
+      "ConcordiaCourseId": "028103"
+    },
+    {
+      "Id": "abcc38e1-2a61-4d69-8943-4487b069a37e",
+      "ConcordiaCourseId": "028107"
+    },
+    {
+      "Id": "bea8275b-df81-48ce-8f4c-16488dfc197e",
+      "ConcordiaCourseId": "028108"
+    },
+    {
+      "Id": "87cad62d-cb67-441b-b09d-7f21eb11be38",
+      "ConcordiaCourseId": "028125"
+    },
+    {
+      "Id": "25cd5ca3-3f29-4042-9d24-2e6c6ddb6f45",
+      "ConcordiaCourseId": "028129"
+    },
+    {
+      "Id": "c02f0e74-4bb3-43b5-8ad6-f87ec6b49fc1",
+      "ConcordiaCourseId": "028130"
+    },
+    {
+      "Id": "559a1810-9c35-4611-97a5-2f29d2cc21fc",
+      "ConcordiaCourseId": "028131"
+    },
+    {
+      "Id": "fc60993b-9849-4598-b289-b1b1e2b3d78d",
+      "ConcordiaCourseId": "028132"
+    },
+    {
+      "Id": "d3653587-6265-4e7b-9f26-6870cc21b103",
+      "ConcordiaCourseId": "028133"
+    },
+    {
+      "Id": "a986d015-5fe9-424d-b8b5-c08fc604553f",
+      "ConcordiaCourseId": "028143"
+    },
+    {
+      "Id": "45bac8ac-ee4b-4577-a160-e9c8fc4bb9d5",
+      "ConcordiaCourseId": "028144"
+    },
+    {
+      "Id": "1c5b128d-fc3b-4398-b359-76fa152a6f2a",
+      "ConcordiaCourseId": "028145"
+    },
+    {
+      "Id": "8a950be0-5669-45b1-971b-40c8f8cc2f0f",
+      "ConcordiaCourseId": "028146"
+    },
+    {
+      "Id": "400dc77e-3cc8-47f8-99ee-e797d4a881e2",
+      "ConcordiaCourseId": "028147"
+    },
+    {
+      "Id": "855c562b-91bc-4324-86ce-5b3aa777d5f9",
+      "ConcordiaCourseId": "028149"
+    },
+    {
+      "Id": "468f48e6-26b2-4f2f-9a07-b6fdb101a60c",
+      "ConcordiaCourseId": "028150"
+    },
+    {
+      "Id": "4af12b0c-adfc-407f-8eba-92d93c88c7da",
+      "ConcordiaCourseId": "028161"
+    },
+    {
+      "Id": "aa21ce7e-e4db-4d6f-bb8f-7f11bf7302f2",
+      "ConcordiaCourseId": "028163"
+    },
+    {
+      "Id": "f8c60c42-3cea-4d6b-b361-cd769f063dff",
+      "ConcordiaCourseId": "028166"
+    },
+    {
+      "Id": "2f5c1081-cd0d-4190-962c-e81e43e2635b",
+      "ConcordiaCourseId": "028167"
+    },
+    {
+      "Id": "8e160c15-9890-4b5d-945a-ad1ec94c0d03",
+      "ConcordiaCourseId": "028169"
+    },
+    {
+      "Id": "55bc4041-78b1-452d-88c2-02933d0c4596",
+      "ConcordiaCourseId": "028170"
+    },
+    {
+      "Id": "c962ec28-5c23-46c3-9fca-c28653880b40",
+      "ConcordiaCourseId": "028171"
+    },
+    {
+      "Id": "b9783682-8b58-463d-a569-f003dfcf33f8",
+      "ConcordiaCourseId": "028173"
+    },
+    {
+      "Id": "3596e47e-ca69-45e7-acab-406eec184002",
+      "ConcordiaCourseId": "028176"
+    },
+    {
+      "Id": "7486b415-245d-47f9-995f-09da6882fb90",
+      "ConcordiaCourseId": "028177"
+    },
+    {
+      "Id": "3ee82ffe-abf9-48ea-b29b-95611405e736",
+      "ConcordiaCourseId": "028178"
+    },
+    {
+      "Id": "57081ce5-1e71-416d-8b82-53491d6764be",
+      "ConcordiaCourseId": "028181"
+    },
+    {
+      "Id": "87c2da10-bb84-4cce-8c86-f5fbd9373f20",
+      "ConcordiaCourseId": "028258"
+    },
+    {
+      "Id": "8d7e4740-ef9a-4ae5-9b6f-51c883f2e112",
+      "ConcordiaCourseId": "028261"
+    },
+    {
+      "Id": "cc2f6558-52d4-47f2-9711-edaae63ff872",
+      "ConcordiaCourseId": "028290"
+    },
+    {
+      "Id": "1c086c64-6fdd-46c8-aa34-8dcd2a5b77fa",
+      "ConcordiaCourseId": "028328"
+    },
+    {
+      "Id": "af7dc9c5-478c-4446-986b-cfcb8e3b809e",
+      "ConcordiaCourseId": "028329"
+    },
+    {
+      "Id": "a95440c9-8e0c-4cdd-8b9a-08b4262c81ea",
+      "ConcordiaCourseId": "028330"
+    },
+    {
+      "Id": "4dc7a234-9866-4e62-b2c9-7de09d77adc3",
+      "ConcordiaCourseId": "028331"
+    },
+    {
+      "Id": "9eb77713-506d-4f5d-8d38-c9083232715c",
+      "ConcordiaCourseId": "028332"
+    },
+    {
+      "Id": "9614706c-ba11-430e-9e27-f15ce9b1205a",
+      "ConcordiaCourseId": "028338"
+    },
+    {
+      "Id": "85aeb12d-9f03-414c-a3a7-3a9b7a779253",
+      "ConcordiaCourseId": "042219"
+    },
+    {
+      "Id": "07877dfa-13ac-4bee-958a-28bc9feaad89",
+      "ConcordiaCourseId": "042225"
+    },
+    {
+      "Id": "1c31c14d-34d9-4627-ae00-a18ce12123f8",
+      "ConcordiaCourseId": "042240"
+    },
+    {
+      "Id": "dd166497-6d4a-4f69-9273-66eed9bdb087",
+      "ConcordiaCourseId": "042290"
+    },
+    {
+      "Id": "959d661b-da03-4331-80e5-fdd07092f966",
+      "ConcordiaCourseId": "042291"
+    },
+    {
+      "Id": "ac86fa45-ff82-4468-ba13-8f1e7a4e9a1d",
+      "ConcordiaCourseId": "042292"
+    },
+    {
+      "Id": "f9481f82-cd40-4be9-b37a-737fc5e93f6c",
+      "ConcordiaCourseId": "042293"
+    },
+    {
+      "Id": "b8621ee1-442b-4afd-bc7e-bcd3b16096af",
+      "ConcordiaCourseId": "045692"
+    },
+    {
+      "Id": "85a4157b-99f4-4013-9a78-bc25cf989841",
+      "ConcordiaCourseId": "046992"
+    },
+    {
+      "Id": "2679a777-b473-49e9-8cd3-d7bfd1044d9b",
+      "ConcordiaCourseId": "046993"
+    },
+    {
+      "Id": "9f41e21d-d460-436f-ab00-300e08442315",
+      "ConcordiaCourseId": "046994"
+    },
+    {
+      "Id": "31633081-981d-42fc-93aa-89c3d2533971",
+      "ConcordiaCourseId": "046995"
+    },
+    {
+      "Id": "4a452f22-3292-4a94-80bf-e8b98ee75809",
+      "ConcordiaCourseId": "046996"
+    },
+    {
+      "Id": "acd08033-30dd-499c-95a8-a3dd0ca3b294",
+      "ConcordiaCourseId": "046997"
+    },
+    {
+      "Id": "148d4999-9ead-4a6e-9534-894026c5f3dd",
+      "ConcordiaCourseId": "046998"
+    },
+    {
+      "Id": "408d24e8-91b5-49b4-91da-5d756a586375",
+      "ConcordiaCourseId": "046999"
+    },
+    {
+      "Id": "f899deee-c0d3-46e0-a0ff-bfd3f471a7bf",
+      "ConcordiaCourseId": "047000"
+    },
+    {
+      "Id": "990a0435-0901-49ca-a689-de34566eda25",
+      "ConcordiaCourseId": "047001"
+    },
+    {
+      "Id": "e7f8a8b7-c681-42fe-b244-ee50dfc8ffca",
+      "ConcordiaCourseId": "047002"
+    },
+    {
+      "Id": "e7a0c746-9fc7-45ee-bd2a-7a2ad48faeda",
+      "ConcordiaCourseId": "047003"
+    },
+    {
+      "Id": "c3b07875-cb9d-4277-8b71-1bce9a99285b",
+      "ConcordiaCourseId": "047004"
+    },
+    {
+      "Id": "c59ce32d-df9a-4d89-9e63-30e39aee4ede",
+      "ConcordiaCourseId": "047005"
+    },
+    {
+      "Id": "ab3450af-811b-422e-99a4-b05745cb1976",
+      "ConcordiaCourseId": "047006"
+    },
+    {
+      "Id": "88e35d04-98d6-417e-b206-20c36b275b0d",
+      "ConcordiaCourseId": "047007"
+    },
+    {
+      "Id": "5202ea96-8122-4cf7-b211-b2f8d45af425",
+      "ConcordiaCourseId": "047008"
+    },
+    {
+      "Id": "fc114c2e-24eb-423d-854e-d5c4992a0fb4",
+      "ConcordiaCourseId": "047009"
+    },
+    {
+      "Id": "0e37be59-a4e3-4060-be11-44b0798c21bc",
+      "ConcordiaCourseId": "047010"
+    },
+    {
+      "Id": "9f4e44b7-c3fe-44ff-b2ee-f5f6824bf577",
+      "ConcordiaCourseId": "047011"
+    },
+    {
+      "Id": "3cb47dac-458c-4ae1-8c6f-b7cb12d6abae",
+      "ConcordiaCourseId": "047012"
+    },
+    {
+      "Id": "a38752ca-54b7-4736-9a20-a93a2c719a93",
+      "ConcordiaCourseId": "047203"
+    },
+    {
+      "Id": "d84caf39-6eee-4c0f-8acc-67a76008ad60",
+      "ConcordiaCourseId": "047221"
+    },
+    {
+      "Id": "23d6f3c8-84a6-499c-864e-895b7b38a021",
+      "ConcordiaCourseId": "047419"
+    },
+    {
+      "Id": "fc3f189e-574a-4d5c-a894-7310f04dffae",
+      "ConcordiaCourseId": "047568"
+    },
+    {
+      "Id": "d81a385e-de15-46c5-98ad-e5bdfab123ec",
+      "ConcordiaCourseId": "047801"
+    },
+    {
+      "Id": "1e0f2da7-7b9d-4b15-a21b-59eaab0c0cbd",
+      "ConcordiaCourseId": "047983"
+    },
+    {
+      "Id": "ea1ce351-756c-46ef-a0e5-d952395a6778",
+      "ConcordiaCourseId": "049825"
+    },
+    {
+      "Id": "ea6b9630-ff54-40b2-8911-6b53d87b50b1",
+      "ConcordiaCourseId": "050805"
+    },
+    {
+      "Id": "6f79c9e8-7a43-4d7f-a92a-ae1198210f2b",
+      "ConcordiaCourseId": "050818"
+    },
+    {
+      "Id": "bf9a0e78-3ed0-4686-b06f-90e675a2a2d6",
+      "ConcordiaCourseId": "028573"
+    },
+    {
+      "Id": "f1395ab9-97a1-4c8a-b987-d8ae7c4d767b",
+      "ConcordiaCourseId": "028575"
+    },
+    {
+      "Id": "fa1e9f6e-498d-4ac3-949d-0568d7864314",
+      "ConcordiaCourseId": "028577"
+    },
+    {
+      "Id": "f2f02fb5-8184-47bf-8eda-0cd62f6c9f1d",
+      "ConcordiaCourseId": "028582"
+    },
+    {
+      "Id": "dc4f1a33-5849-49ad-93de-dbb1b6987902",
+      "ConcordiaCourseId": "028584"
+    },
+    {
+      "Id": "ede5bd8e-0b40-46ec-9a7b-4c004c8425c4",
+      "ConcordiaCourseId": "028586"
+    },
+    {
+      "Id": "dc142fdc-4a21-43b4-8d12-7f0d30f178a7",
+      "ConcordiaCourseId": "028587"
+    },
+    {
+      "Id": "10990fd5-970b-43cc-a79e-0e8f12d52983",
+      "ConcordiaCourseId": "028611"
+    },
+    {
+      "Id": "63bde534-2db7-4e24-a319-47e78ea893fd",
+      "ConcordiaCourseId": "028613"
+    },
+    {
+      "Id": "14bc4e8d-1f26-4d6e-86d0-467cdc925b03",
+      "ConcordiaCourseId": "028614"
+    },
+    {
+      "Id": "3d78e994-5974-42d1-bb8a-fc62ddf89489",
+      "ConcordiaCourseId": "028615"
+    },
+    {
+      "Id": "002347f3-74f1-45c8-97ab-466e7dd00bde",
+      "ConcordiaCourseId": "028616"
+    },
+    {
+      "Id": "12caffda-abf9-4460-bb07-e280cb1981dc",
+      "ConcordiaCourseId": "028617"
+    },
+    {
+      "Id": "86a64ea3-5e3a-4fc0-ae79-500a405a78e8",
+      "ConcordiaCourseId": "028634"
+    },
+    {
+      "Id": "e7958541-9bb3-43cd-82e9-f1f1596f09ec",
+      "ConcordiaCourseId": "028636"
+    },
+    {
+      "Id": "25e5e881-fba2-4473-981b-2f6c08339a01",
+      "ConcordiaCourseId": "028638"
+    },
+    {
+      "Id": "acf72fcd-5f3c-4812-83c9-c8511d324b4d",
+      "ConcordiaCourseId": "028639"
+    },
+    {
+      "Id": "2420b1cf-aa61-4382-a15d-30bc00e812dd",
+      "ConcordiaCourseId": "042304"
+    },
+    {
+      "Id": "b5fb6048-3cd8-4d8a-9da4-0578d18135d3",
+      "ConcordiaCourseId": "042306"
+    },
+    {
+      "Id": "10979044-86a1-456f-9130-bddebc4bbd64",
+      "ConcordiaCourseId": "042308"
+    },
+    {
+      "Id": "8f02161f-3272-4e26-868c-ae92f2e70081",
+      "ConcordiaCourseId": "047013"
+    },
+    {
+      "Id": "a0469724-eb95-46e1-b35f-337a2bc11769",
+      "ConcordiaCourseId": "047014"
+    },
+    {
+      "Id": "2ce8d930-090d-4a1b-8386-d9fc9ef54a6b",
+      "ConcordiaCourseId": "047015"
+    },
+    {
+      "Id": "3442c410-3bbd-4a7c-87b2-140391824160",
+      "ConcordiaCourseId": "047016"
+    },
+    {
+      "Id": "db1881f2-5072-48ae-bf29-587cb45a622a",
+      "ConcordiaCourseId": "047017"
+    },
+    {
+      "Id": "7cf5d0ce-8448-4e36-b6e6-899165516f0d",
+      "ConcordiaCourseId": "047389"
+    },
+    {
+      "Id": "20029151-ac2a-43c0-bed1-b8bd4e0c939b",
+      "ConcordiaCourseId": "047390"
+    },
+    {
+      "Id": "299171e1-ed26-4641-afa6-4297f700dd34",
+      "ConcordiaCourseId": "047391"
+    },
+    {
+      "Id": "93d5b27b-95f2-431f-8ec3-5ab792b5f14a",
+      "ConcordiaCourseId": "047392"
+    },
+    {
+      "Id": "eac1c0e2-895e-42db-8a73-17ba650b6162",
+      "ConcordiaCourseId": "047393"
+    },
+    {
+      "Id": "0f36d0f1-279a-44df-8f6f-410230e8b740",
+      "ConcordiaCourseId": "047394"
+    },
+    {
+      "Id": "b2333ad0-ab9e-40a7-8b81-0aa1fe707cef",
+      "ConcordiaCourseId": "049733"
+    },
+    {
+      "Id": "6621e66c-1998-4c02-8f2f-4122c6ff464d",
+      "ConcordiaCourseId": "028659"
+    },
+    {
+      "Id": "1342ae4e-ec66-44bf-9ffb-602022f223fe",
+      "ConcordiaCourseId": "028668"
+    },
+    {
+      "Id": "ba2e86d2-9df2-4951-af59-b7f5976190e0",
+      "ConcordiaCourseId": "028674"
+    },
+    {
+      "Id": "4913af1f-4845-44d3-9ad5-523a149b89bf",
+      "ConcordiaCourseId": "028675"
+    },
+    {
+      "Id": "7408f9b8-e8f1-4c1c-b3fe-a04a54d8c0c5",
+      "ConcordiaCourseId": "028681"
+    },
+    {
+      "Id": "934b101c-f542-4f10-b283-552cd8d8691f",
+      "ConcordiaCourseId": "028682"
+    },
+    {
+      "Id": "905658ef-ac0a-4636-9bee-aee53734721d",
+      "ConcordiaCourseId": "028683"
+    },
+    {
+      "Id": "a921360c-93c9-4f7f-8ff8-f6620e58a4d2",
+      "ConcordiaCourseId": "028684"
+    },
+    {
+      "Id": "ae907f5e-ffc5-4abc-8313-ace3730f7d82",
+      "ConcordiaCourseId": "028685"
+    },
+    {
+      "Id": "a5bcad7c-24c8-4d01-95b1-978ef200c82d",
+      "ConcordiaCourseId": "028686"
+    },
+    {
+      "Id": "8400110a-c416-41b1-8e68-4f878c7ffacc",
+      "ConcordiaCourseId": "028687"
+    },
+    {
+      "Id": "ed699d25-5dbc-4648-a2e8-57ec175b94a1",
+      "ConcordiaCourseId": "047018"
+    },
+    {
+      "Id": "ace2b4d8-eba0-4f3c-aea4-464c707fcf7e",
+      "ConcordiaCourseId": "047019"
+    },
+    {
+      "Id": "fcde17ce-b691-4080-afcf-5279413eb10f",
+      "ConcordiaCourseId": "047020"
+    },
+    {
+      "Id": "01da874c-6711-4258-9e6b-47bd52f27ce7",
+      "ConcordiaCourseId": "047021"
+    },
+    {
+      "Id": "98e37600-5bb0-491b-bf1c-a8d7a4b53eb9",
+      "ConcordiaCourseId": "047022"
+    },
+    {
+      "Id": "2939189f-1155-4cf5-94a5-dae691ae205c",
+      "ConcordiaCourseId": "047023"
+    },
+    {
+      "Id": "2a2f04c1-b972-4f21-86b1-0e0d77c1a52c",
+      "ConcordiaCourseId": "028706"
+    },
+    {
+      "Id": "7940b6fb-07bb-4748-b696-5c289eb2b6ba",
+      "ConcordiaCourseId": "028707"
+    },
+    {
+      "Id": "f3936a4d-298e-4be0-8df2-0305933999e9",
+      "ConcordiaCourseId": "047285"
+    },
+    {
+      "Id": "91b615dd-5a32-4983-86b1-24ba40459ee9",
+      "ConcordiaCourseId": "047286"
+    },
+    {
+      "Id": "44a8d0ed-98ee-4777-945d-849ca056797d",
+      "ConcordiaCourseId": "047294"
+    },
+    {
+      "Id": "4c36fc5e-c105-4a08-a205-c4281ffd63ae",
+      "ConcordiaCourseId": "047295"
+    },
+    {
+      "Id": "556ba445-97af-4c1d-ba68-7bb10eb84956",
+      "ConcordiaCourseId": "047288"
+    },
+    {
+      "Id": "5195344a-2297-444b-870c-9a575e978121",
+      "ConcordiaCourseId": "047289"
+    },
+    {
+      "Id": "0497c3b3-3f9a-490b-85c0-ab71d8db99e0",
+      "ConcordiaCourseId": "028726"
+    },
+    {
+      "Id": "6af1f243-653d-4ca1-848a-11bd761e360c",
+      "ConcordiaCourseId": "028730"
+    },
+    {
+      "Id": "b0d4c3d6-553f-43ec-a062-6a27e8bd1bc9",
+      "ConcordiaCourseId": "028743"
+    },
+    {
+      "Id": "fe28233b-f09c-4770-98ec-f6136c1be0c2",
+      "ConcordiaCourseId": "028744"
+    },
+    {
+      "Id": "0bfc2441-0c97-49e4-b609-c130c7643dde",
+      "ConcordiaCourseId": "028745"
+    },
+    {
+      "Id": "f2561825-b2af-4188-a762-9486ad8e7640",
+      "ConcordiaCourseId": "028746"
+    },
+    {
+      "Id": "189c02ef-dc65-48de-9ee7-153bad9f00fa",
+      "ConcordiaCourseId": "028747"
+    },
+    {
+      "Id": "3f7c52fa-553b-4a80-8874-dfa3f9088ac1",
+      "ConcordiaCourseId": "028748"
+    },
+    {
+      "Id": "5a371214-5755-4918-adb1-7ae02f1d8a3c",
+      "ConcordiaCourseId": "028749"
+    },
+    {
+      "Id": "f1aa88e4-c43b-41c7-bd50-697f19369a42",
+      "ConcordiaCourseId": "028750"
+    },
+    {
+      "Id": "5c2c0f0f-4569-46c9-a2d7-6ef92d63a50d",
+      "ConcordiaCourseId": "028751"
+    },
+    {
+      "Id": "df9b0f53-1956-461d-ba52-f518a8255929",
+      "ConcordiaCourseId": "028752"
+    },
+    {
+      "Id": "bb20d181-1ac3-45a0-83c9-d4bbcf588480",
+      "ConcordiaCourseId": "028753"
+    },
+    {
+      "Id": "09f66f2c-0840-4212-93de-aede7ab13103",
+      "ConcordiaCourseId": "028754"
+    },
+    {
+      "Id": "247d8a7c-e2fe-4b7f-8717-e874c80a8887",
+      "ConcordiaCourseId": "028756"
+    },
+    {
+      "Id": "5cc054f5-fb7a-47fb-bb70-df106affb564",
+      "ConcordiaCourseId": "028759"
+    },
+    {
+      "Id": "b4408bbc-05c7-476f-bbd2-312f829f7a67",
+      "ConcordiaCourseId": "028809"
+    },
+    {
+      "Id": "080da425-ad60-4d6a-9f98-e4ddb292963b",
+      "ConcordiaCourseId": "028820"
+    },
+    {
+      "Id": "9768e672-9a45-4e94-b800-2ad6c6201493",
+      "ConcordiaCourseId": "028822"
+    },
+    {
+      "Id": "cdba0970-4a61-4829-88fb-59f6170afc5a",
+      "ConcordiaCourseId": "028827"
+    },
+    {
+      "Id": "835a5ae0-5212-4bcd-9771-48c6430632de",
+      "ConcordiaCourseId": "028830"
+    },
+    {
+      "Id": "1bee8197-4ad5-4dd0-a447-b7e7a97b5532",
+      "ConcordiaCourseId": "028835"
+    },
+    {
+      "Id": "81e22fd9-abc2-4b88-bafc-b862d9ecd5b0",
+      "ConcordiaCourseId": "028842"
+    },
+    {
+      "Id": "eaf20c60-adc7-494f-85b4-e9d3a23da5e5",
+      "ConcordiaCourseId": "028849"
+    },
+    {
+      "Id": "31c7cd36-a516-424c-8937-da4a7313e3ff",
+      "ConcordiaCourseId": "028854"
+    },
+    {
+      "Id": "b52e09e4-1dde-4942-9093-2eaabd3b43e7",
+      "ConcordiaCourseId": "028855"
+    },
+    {
+      "Id": "9c172af5-7fcd-4fd5-84ee-1d5c8a1956d8",
+      "ConcordiaCourseId": "028856"
+    },
+    {
+      "Id": "458ef2f2-481d-4601-997e-dfe14b49f54e",
+      "ConcordiaCourseId": "028865"
+    },
+    {
+      "Id": "6452dc1a-7a85-4c43-a99c-508dbc9e506a",
+      "ConcordiaCourseId": "028868"
+    },
+    {
+      "Id": "196afcd0-7a0d-4f2b-88b6-018fb165eb37",
+      "ConcordiaCourseId": "028869"
+    },
+    {
+      "Id": "9787db67-0c5e-4121-9b01-520ae9e9b63d",
+      "ConcordiaCourseId": "028876"
+    },
+    {
+      "Id": "82995603-485c-4124-b4fc-6121a763b142",
+      "ConcordiaCourseId": "028877"
+    },
+    {
+      "Id": "c75f4c4d-2b0f-4e67-8c37-c88e7d522019",
+      "ConcordiaCourseId": "028885"
+    },
+    {
+      "Id": "c64982fb-310e-49d5-bdb7-61436df49ddc",
+      "ConcordiaCourseId": "028887"
+    },
+    {
+      "Id": "ab9c5e14-cbb3-4210-aa4d-dbcf81cbbbb8",
+      "ConcordiaCourseId": "028888"
+    },
+    {
+      "Id": "6232b0fc-5328-4769-a0db-27d4dcb8bdc7",
+      "ConcordiaCourseId": "028896"
+    },
+    {
+      "Id": "7ca384f1-cbdb-4ad1-b8ea-e9edb064ac4e",
+      "ConcordiaCourseId": "028958"
+    },
+    {
+      "Id": "532e7560-588e-4afc-9aff-463debc4ca51",
+      "ConcordiaCourseId": "028962"
+    },
+    {
+      "Id": "883179c7-b35c-4834-a4ad-fe8cee7563e0",
+      "ConcordiaCourseId": "028963"
+    },
+    {
+      "Id": "bf73876f-27ef-44c4-a529-94781f3269fe",
+      "ConcordiaCourseId": "028964"
+    },
+    {
+      "Id": "211139f7-4c30-48b8-ae90-1637a3dc1390",
+      "ConcordiaCourseId": "028965"
+    },
+    {
+      "Id": "bb994c70-cc8a-446e-878c-e5fbc9aabed7",
+      "ConcordiaCourseId": "028966"
+    },
+    {
+      "Id": "5c833106-fe54-4b54-932f-3227c455b378",
+      "ConcordiaCourseId": "028967"
+    },
+    {
+      "Id": "046ea8cd-f2f5-4386-8079-7b9acf87e926",
+      "ConcordiaCourseId": "028971"
+    },
+    {
+      "Id": "fdbba4de-324d-428d-9fb4-6957cb9ac0ec",
+      "ConcordiaCourseId": "028972"
+    },
+    {
+      "Id": "04d595c7-fe36-44e0-9d48-2400f551b88f",
+      "ConcordiaCourseId": "028973"
+    },
+    {
+      "Id": "1beed2e2-22ae-4c35-80e4-9000c7a104f3",
+      "ConcordiaCourseId": "028974"
+    },
+    {
+      "Id": "39437349-10b7-48ba-a306-57d60c49f603",
+      "ConcordiaCourseId": "028975"
+    },
+    {
+      "Id": "604f29f2-22de-4f65-a328-8a79466128f6",
+      "ConcordiaCourseId": "028978"
+    },
+    {
+      "Id": "28e66511-8f16-49e9-bf34-9d83f618854f",
+      "ConcordiaCourseId": "028981"
+    },
+    {
+      "Id": "afffed02-a78c-4f4c-90aa-0816b0f4d7d8",
+      "ConcordiaCourseId": "028982"
+    },
+    {
+      "Id": "f51b0db4-6eaa-4e16-bc8b-c3260710e355",
+      "ConcordiaCourseId": "028983"
+    },
+    {
+      "Id": "33aef580-ceb3-48d1-8004-f6b4835ee607",
+      "ConcordiaCourseId": "028984"
+    },
+    {
+      "Id": "711f9e0b-1ee6-4382-98ab-51b071bc3f08",
+      "ConcordiaCourseId": "028985"
+    },
+    {
+      "Id": "961a1be0-1e9c-40fc-93fd-6feaa50e503b",
+      "ConcordiaCourseId": "028986"
+    },
+    {
+      "Id": "6b358523-1b42-4abf-91a4-2b44396e65a8",
+      "ConcordiaCourseId": "028987"
+    },
+    {
+      "Id": "7439068f-fa15-438c-b7fb-f1e11015e93a",
+      "ConcordiaCourseId": "028988"
+    },
+    {
+      "Id": "3d08b65e-2f57-4c7d-b6b0-bcdf5ce92fbe",
+      "ConcordiaCourseId": "028989"
+    },
+    {
+      "Id": "44c9f307-4e45-4a43-97c9-f87553494b0e",
+      "ConcordiaCourseId": "028993"
+    },
+    {
+      "Id": "e1855edb-5e56-4528-8a43-bbe5408cfea0",
+      "ConcordiaCourseId": "028994"
+    },
+    {
+      "Id": "8eeddd9c-26c6-4524-9d3e-80858cbbdafe",
+      "ConcordiaCourseId": "028995"
+    },
+    {
+      "Id": "7038673c-bf82-4713-992c-974037b40dd9",
+      "ConcordiaCourseId": "028996"
+    },
+    {
+      "Id": "6dce8aa3-7865-47e3-a2b8-9f45c4a57a73",
+      "ConcordiaCourseId": "028997"
+    },
+    {
+      "Id": "f015abe6-d839-44aa-b63e-286a3c67af5e",
+      "ConcordiaCourseId": "028998"
+    },
+    {
+      "Id": "8a6f92e6-b098-4a63-b452-c54f2c9d44f0",
+      "ConcordiaCourseId": "028999"
+    },
+    {
+      "Id": "dc770716-aecd-477c-83a3-d641051ce612",
+      "ConcordiaCourseId": "029000"
+    },
+    {
+      "Id": "b180252c-bd40-430e-829a-c817cc6877fa",
+      "ConcordiaCourseId": "029001"
+    },
+    {
+      "Id": "7fff1df4-a308-429b-868b-a11f118257c7",
+      "ConcordiaCourseId": "029003"
+    },
+    {
+      "Id": "704bce56-01d5-43a3-8268-4a29224f62e7",
+      "ConcordiaCourseId": "029004"
+    },
+    {
+      "Id": "c694cb75-e02b-4972-9185-a6eebbeff0c4",
+      "ConcordiaCourseId": "029005"
+    },
+    {
+      "Id": "12942a0a-507d-4d2d-b389-0aeb957a704a",
+      "ConcordiaCourseId": "029006"
+    },
+    {
+      "Id": "ce09f9a3-47d7-49b0-b47d-f9080b4b1b72",
+      "ConcordiaCourseId": "029007"
+    },
+    {
+      "Id": "2534414c-14a3-41a3-bac9-773820a7bd75",
+      "ConcordiaCourseId": "029014"
+    },
+    {
+      "Id": "5cfa8a49-f938-4543-a587-a34c05b79a4a",
+      "ConcordiaCourseId": "029015"
+    },
+    {
+      "Id": "65a85db1-7950-46d3-a66d-421fe2d3783e",
+      "ConcordiaCourseId": "029016"
+    },
+    {
+      "Id": "af12fc84-b767-4ebd-aee8-6bf5f285c10e",
+      "ConcordiaCourseId": "029017"
+    },
+    {
+      "Id": "680e588b-70ae-48b4-92d1-81b138c0955c",
+      "ConcordiaCourseId": "029018"
+    },
+    {
+      "Id": "ba7a7097-312e-4154-83fc-3e4949d992d7",
+      "ConcordiaCourseId": "029019"
+    },
+    {
+      "Id": "8eb981ba-43a7-4008-a04c-a9861ecc5da4",
+      "ConcordiaCourseId": "029028"
+    },
+    {
+      "Id": "2cd8336f-0bb9-46c9-b951-be6db83c99fc",
+      "ConcordiaCourseId": "029030"
+    },
+    {
+      "Id": "7660de24-8cb3-4b8f-9f12-43d3de69b164",
+      "ConcordiaCourseId": "029056"
+    },
+    {
+      "Id": "48104b29-e519-41fb-9902-d471d362d32e",
+      "ConcordiaCourseId": "029093"
+    },
+    {
+      "Id": "55f2489b-3655-40c9-ac82-c2cc1117753b",
+      "ConcordiaCourseId": "029095"
+    },
+    {
+      "Id": "ee9e119c-d8d1-4bca-b121-fb30ed59e70f",
+      "ConcordiaCourseId": "029097"
+    },
+    {
+      "Id": "7d031741-aceb-46ac-a3d0-e425b9564aaf",
+      "ConcordiaCourseId": "029099"
+    },
+    {
+      "Id": "845b18a6-d972-4fb6-8e30-4e27a485bfb1",
+      "ConcordiaCourseId": "029116"
+    },
+    {
+      "Id": "d6a7346f-16d0-465b-a1be-8daebaa802da",
+      "ConcordiaCourseId": "029117"
+    },
+    {
+      "Id": "6355b34c-7600-4e63-8711-53decbe262f3",
+      "ConcordiaCourseId": "029118"
+    },
+    {
+      "Id": "6d4f490d-6392-4616-92ae-2d2d8be3339e",
+      "ConcordiaCourseId": "029119"
+    },
+    {
+      "Id": "0662e38c-6230-4c8d-b62d-2cc575a99cd1",
+      "ConcordiaCourseId": "029120"
+    },
+    {
+      "Id": "df63325b-4433-4eb2-858d-ddfa8e038376",
+      "ConcordiaCourseId": "029121"
+    },
+    {
+      "Id": "bbca7c07-f280-4ce2-826b-164471bca45c",
+      "ConcordiaCourseId": "029122"
+    },
+    {
+      "Id": "910c8092-43b8-4298-a6d7-f73021de85d7",
+      "ConcordiaCourseId": "029123"
+    },
+    {
+      "Id": "ca0101ad-bdc9-4743-b104-3449e511f76f",
+      "ConcordiaCourseId": "029124"
+    },
+    {
+      "Id": "61b5efbf-0511-4e7a-a0a5-f20da743462c",
+      "ConcordiaCourseId": "029125"
+    },
+    {
+      "Id": "0a3b789f-5b6c-4f6d-8092-389f98ee5a51",
+      "ConcordiaCourseId": "029126"
+    },
+    {
+      "Id": "ed748bad-6886-42f9-8656-d2f89f385bd7",
+      "ConcordiaCourseId": "029127"
+    },
+    {
+      "Id": "c66f7635-166a-47ad-a4e7-da8d37f710db",
+      "ConcordiaCourseId": "029128"
+    },
+    {
+      "Id": "fa4b01d4-2050-4394-b0f9-bafc763ad927",
+      "ConcordiaCourseId": "029129"
+    },
+    {
+      "Id": "6274bc00-db87-4690-b13b-af0089e38c42",
+      "ConcordiaCourseId": "029130"
+    },
+    {
+      "Id": "629a0770-bd17-4a87-ab15-7938827fe9c4",
+      "ConcordiaCourseId": "029131"
+    },
+    {
+      "Id": "312f5ea9-b370-4496-b1c9-0e630c2fdad9",
+      "ConcordiaCourseId": "029132"
+    },
+    {
+      "Id": "2f7eb60f-3491-4c3a-a138-ef45bc8cdf6e",
+      "ConcordiaCourseId": "029133"
+    },
+    {
+      "Id": "61586fe0-11af-480b-955f-3487e24350de",
+      "ConcordiaCourseId": "029134"
+    },
+    {
+      "Id": "52f770bd-f0f8-456e-a680-a720b51c279f",
+      "ConcordiaCourseId": "029135"
+    },
+    {
+      "Id": "ef904403-084f-47f3-b5bc-d40f466b95d8",
+      "ConcordiaCourseId": "029136"
+    },
+    {
+      "Id": "df6d8f9b-58b2-45bc-9af6-56b3c5dc5d1c",
+      "ConcordiaCourseId": "029141"
+    },
+    {
+      "Id": "ad81815f-6ab1-4237-a322-8d3b8a9a9144",
+      "ConcordiaCourseId": "029155"
+    },
+    {
+      "Id": "c86fa925-1e32-4a72-9a3c-1542c39a1a4a",
+      "ConcordiaCourseId": "029201"
+    },
+    {
+      "Id": "d08d535e-402a-48b5-897f-7837da4fafd0",
+      "ConcordiaCourseId": "029202"
+    },
+    {
+      "Id": "ca88ec6a-4c79-4a1f-92c4-a08597d84e9b",
+      "ConcordiaCourseId": "029205"
+    },
+    {
+      "Id": "0ad01a19-aeaf-45f2-aaf7-eee886daffde",
+      "ConcordiaCourseId": "029207"
+    },
+    {
+      "Id": "59ca01ec-ade8-4ec6-b1e3-4ed047a77659",
+      "ConcordiaCourseId": "029225"
+    },
+    {
+      "Id": "9f73e48d-10c1-4edd-ad3d-ed464f354ccb",
+      "ConcordiaCourseId": "029243"
+    },
+    {
+      "Id": "96ed0c10-0bc8-493a-8abd-64deafcf2dc3",
+      "ConcordiaCourseId": "029268"
+    },
+    {
+      "Id": "b0cb5afb-07f2-44ca-afcd-bc29867ff158",
+      "ConcordiaCourseId": "029330"
+    },
+    {
+      "Id": "1b1a8587-fcb7-44d8-b6df-3211ae783b77",
+      "ConcordiaCourseId": "029331"
+    },
+    {
+      "Id": "f0615aed-afde-40bd-a1fa-fe23682add82",
+      "ConcordiaCourseId": "029332"
+    },
+    {
+      "Id": "808760d7-05e2-4d48-b3ea-b72c409b4ee0",
+      "ConcordiaCourseId": "029333"
+    },
+    {
+      "Id": "6fbc826f-9496-4ea4-a3fd-3101a47cdef3",
+      "ConcordiaCourseId": "029334"
+    },
+    {
+      "Id": "e75e73bb-54eb-4577-bf6e-c47e5b58eb47",
+      "ConcordiaCourseId": "029335"
+    },
+    {
+      "Id": "d63339a4-5426-4922-a47e-25f8b46916e7",
+      "ConcordiaCourseId": "029338"
+    },
+    {
+      "Id": "2007b15c-e39e-4b26-9214-d52665211e94",
+      "ConcordiaCourseId": "029339"
+    },
+    {
+      "Id": "d4d41ae4-5e56-4798-a76b-61e3f0a1f597",
+      "ConcordiaCourseId": "029340"
+    },
+    {
+      "Id": "4257de13-a487-4f44-9b27-b2381c6fe085",
+      "ConcordiaCourseId": "029341"
+    },
+    {
+      "Id": "675302b7-6f21-438b-86db-d4e679b5c62f",
+      "ConcordiaCourseId": "029342"
+    },
+    {
+      "Id": "929b36c3-0fb3-4577-9b66-b50e7ae17662",
+      "ConcordiaCourseId": "029343"
+    },
+    {
+      "Id": "af2586a8-30bd-4254-8fec-134a84e5e68b",
+      "ConcordiaCourseId": "029344"
+    },
+    {
+      "Id": "10fca50a-70e3-4229-aaf2-b976de0cc9db",
+      "ConcordiaCourseId": "029345"
+    },
+    {
+      "Id": "6b1ef50c-a13e-4e3d-bbd8-c5c1d2c0bba0",
+      "ConcordiaCourseId": "029346"
+    },
+    {
+      "Id": "19add599-1faf-4248-bb09-c98a0eb89690",
+      "ConcordiaCourseId": "029347"
+    },
+    {
+      "Id": "a0305697-1ad2-431f-a9c9-a4acba9f8d25",
+      "ConcordiaCourseId": "029348"
+    },
+    {
+      "Id": "1d5fa9ae-8293-48b4-a4df-6bc6688fc1b5",
+      "ConcordiaCourseId": "029350"
+    },
+    {
+      "Id": "9b579a11-50ad-49f7-9f80-255164366717",
+      "ConcordiaCourseId": "029351"
+    },
+    {
+      "Id": "7a0e62a6-d9fe-4574-81b4-aa85693a3cf8",
+      "ConcordiaCourseId": "029353"
+    },
+    {
+      "Id": "365514a3-c9ca-47ac-94ca-93d028288f7b",
+      "ConcordiaCourseId": "029354"
+    },
+    {
+      "Id": "5a6e0652-3413-4e75-89fc-fe6924dbf34e",
+      "ConcordiaCourseId": "029356"
+    },
+    {
+      "Id": "a4bdd6c5-7faa-49f2-a737-da6ec0fa5dba",
+      "ConcordiaCourseId": "029357"
+    },
+    {
+      "Id": "57b243a2-8e13-4974-849b-e8304dbfdc4c",
+      "ConcordiaCourseId": "029359"
+    },
+    {
+      "Id": "306a05d1-8271-48e8-b5fc-3c6bfe56ac61",
+      "ConcordiaCourseId": "029363"
+    },
+    {
+      "Id": "1495cc92-bb66-4d49-b9c2-65de2005665c",
+      "ConcordiaCourseId": "029364"
+    },
+    {
+      "Id": "a76e910d-ba64-49c1-ba19-8cf5de7316db",
+      "ConcordiaCourseId": "029368"
+    },
+    {
+      "Id": "f2c2ef7d-5895-4d70-85c7-a915f7f32082",
+      "ConcordiaCourseId": "029372"
+    },
+    {
+      "Id": "1579044e-7859-483b-be32-3447a379a570",
+      "ConcordiaCourseId": "029373"
+    },
+    {
+      "Id": "e68eec5f-3228-4232-afb3-41c10ab81714",
+      "ConcordiaCourseId": "042334"
+    },
+    {
+      "Id": "2f7487f4-2002-4457-b95b-7cb800e834a5",
+      "ConcordiaCourseId": "042344"
+    },
+    {
+      "Id": "f1d94a79-7dc8-4438-a955-939b2da1ad70",
+      "ConcordiaCourseId": "042368"
+    },
+    {
+      "Id": "989b0dd6-ff76-4f1a-b458-12078f0a42c3",
+      "ConcordiaCourseId": "044208"
+    },
+    {
+      "Id": "9628c460-9277-4491-b5df-e1b5ab427b1e",
+      "ConcordiaCourseId": "044209"
+    },
+    {
+      "Id": "2489ad76-40f5-4203-a9ce-227ff13b0fd2",
+      "ConcordiaCourseId": "044210"
+    },
+    {
+      "Id": "851144f5-f465-4cac-842e-aaa8c6e43c95",
+      "ConcordiaCourseId": "044211"
+    },
+    {
+      "Id": "88dc1eef-249f-44e6-9416-9dd0a861b7b2",
+      "ConcordiaCourseId": "044212"
+    },
+    {
+      "Id": "eed89d79-0cea-4aeb-84c7-5804d424bb5b",
+      "ConcordiaCourseId": "045730"
+    },
+    {
+      "Id": "cd9a169c-7c91-4e1e-8809-eb3e5114bafa",
+      "ConcordiaCourseId": "047024"
+    },
+    {
+      "Id": "00eeac74-bfb3-425c-b15b-10a73a944f80",
+      "ConcordiaCourseId": "047025"
+    },
+    {
+      "Id": "3f41836e-ea09-4334-9048-529223df0536",
+      "ConcordiaCourseId": "047026"
+    },
+    {
+      "Id": "f57bcff8-6f3a-4884-912a-7b598240217d",
+      "ConcordiaCourseId": "047027"
+    },
+    {
+      "Id": "c28f37e2-7faf-47b2-a307-7838d711eb33",
+      "ConcordiaCourseId": "047028"
+    },
+    {
+      "Id": "72852fd8-30d7-4bbd-89d4-869450474457",
+      "ConcordiaCourseId": "047029"
+    },
+    {
+      "Id": "6cb82ec0-3c2b-44aa-943a-bd500f539a60",
+      "ConcordiaCourseId": "047030"
+    },
+    {
+      "Id": "6c7a583d-a692-427c-b0fd-6c50ad3ebf2d",
+      "ConcordiaCourseId": "047031"
+    },
+    {
+      "Id": "35a0274a-0985-462a-8a64-a9b0b845a36b",
+      "ConcordiaCourseId": "047032"
+    },
+    {
+      "Id": "ad1cc191-161b-4642-8b81-bbda6f6f928f",
+      "ConcordiaCourseId": "047033"
+    },
+    {
+      "Id": "57c23745-1b99-4aeb-8994-ca64fdba7723",
+      "ConcordiaCourseId": "047034"
+    },
+    {
+      "Id": "28138b9c-02e5-4f67-a1e6-36626631e463",
+      "ConcordiaCourseId": "047035"
+    },
+    {
+      "Id": "2d310970-4070-4914-9117-ff979b5ffea2",
+      "ConcordiaCourseId": "047036"
+    },
+    {
+      "Id": "a2e4edec-7a67-4697-8903-85b9797b57c9",
+      "ConcordiaCourseId": "047037"
+    },
+    {
+      "Id": "977625d1-552a-4ffd-a91a-fde68b518d24",
+      "ConcordiaCourseId": "047038"
+    },
+    {
+      "Id": "4e857eb8-6d8e-4666-8a40-2e984e907da4",
+      "ConcordiaCourseId": "047039"
+    },
+    {
+      "Id": "f59d62b4-662d-4ab2-8f25-7cb2661c492b",
+      "ConcordiaCourseId": "047040"
+    },
+    {
+      "Id": "5378a410-40e2-4748-aa1d-613b3dc50e19",
+      "ConcordiaCourseId": "047041"
+    },
+    {
+      "Id": "1b2c929d-97ca-4265-b4a3-854fee199fb3",
+      "ConcordiaCourseId": "047042"
+    },
+    {
+      "Id": "9f2ab4a3-eda8-434b-ad11-7ed4e589350a",
+      "ConcordiaCourseId": "047043"
+    },
+    {
+      "Id": "22a6c86a-4ed9-4d23-9860-5828bf51a96a",
+      "ConcordiaCourseId": "047044"
+    },
+    {
+      "Id": "9d4379eb-7d8e-414f-83ef-56533a07c0df",
+      "ConcordiaCourseId": "047045"
+    },
+    {
+      "Id": "493ea7f7-88f3-4a7c-99b9-e78ecccf04ba",
+      "ConcordiaCourseId": "047046"
+    },
+    {
+      "Id": "1e840924-3e7c-42b9-8cc2-cc1fe2a514ca",
+      "ConcordiaCourseId": "047173"
+    },
+    {
+      "Id": "11075857-5d41-4d9a-b4f6-232a565de521",
+      "ConcordiaCourseId": "047174"
+    },
+    {
+      "Id": "46648960-a729-49e3-934f-403fca55a8dd",
+      "ConcordiaCourseId": "047175"
+    },
+    {
+      "Id": "1daed0f1-f1b2-444a-95cf-e17c71d4b02c",
+      "ConcordiaCourseId": "047314"
+    },
+    {
+      "Id": "9f35234e-26b9-4480-923f-97e768930b2b",
+      "ConcordiaCourseId": "048661"
+    },
+    {
+      "Id": "26b62608-8822-48ab-9a4e-31c69a5c9fc9",
+      "ConcordiaCourseId": "050373"
+    },
+    {
+      "Id": "386fc8b0-6b98-4b1b-8bcf-61a9c600a590",
+      "ConcordiaCourseId": "050374"
+    },
+    {
+      "Id": "e8260eaa-4382-4d28-99c4-f7ea0466172e",
+      "ConcordiaCourseId": "050375"
+    },
+    {
+      "Id": "56e6c30d-a04c-4dda-9536-a66cf2e903d7",
+      "ConcordiaCourseId": "050376"
+    },
+    {
+      "Id": "bfd029c3-1a52-43b2-8cd3-aa666136f54e",
+      "ConcordiaCourseId": "029563"
+    },
+    {
+      "Id": "b1ed2cff-c0ba-4910-9904-274a32d3f75b",
+      "ConcordiaCourseId": "029566"
+    },
+    {
+      "Id": "b06d4572-1405-4aaa-906b-fdb7e31e0db0",
+      "ConcordiaCourseId": "029574"
+    },
+    {
+      "Id": "0b4a1d73-22ce-444c-9d4c-f17ac56e355e",
+      "ConcordiaCourseId": "029578"
+    },
+    {
+      "Id": "0124cf84-5e9f-48d6-9e8a-020fd39fc47b",
+      "ConcordiaCourseId": "029579"
+    },
+    {
+      "Id": "ca9bfcf6-372c-494c-8822-48943647ec33",
+      "ConcordiaCourseId": "029580"
+    },
+    {
+      "Id": "df48ac36-e380-4491-9ee3-b97dd9092384",
+      "ConcordiaCourseId": "029581"
+    },
+    {
+      "Id": "d0a96f8e-135d-4113-adf9-4241db777eae",
+      "ConcordiaCourseId": "029582"
+    },
+    {
+      "Id": "52ac47b2-1b8b-4872-9b8c-1ead429fbae0",
+      "ConcordiaCourseId": "029583"
+    },
+    {
+      "Id": "3c70d671-f4e2-46ac-90fe-c3b9078194ce",
+      "ConcordiaCourseId": "029592"
+    },
+    {
+      "Id": "982b2ad8-4fd4-4e8a-95e8-2bb0d0aed779",
+      "ConcordiaCourseId": "029594"
+    },
+    {
+      "Id": "431f9dec-8c51-4b85-b8a2-e46af7e0dd8e",
+      "ConcordiaCourseId": "029596"
+    },
+    {
+      "Id": "ae1abae0-4209-4e83-ae83-d784c7c4097a",
+      "ConcordiaCourseId": "029597"
+    },
+    {
+      "Id": "4f8eee97-fd81-4f1b-a735-1377dab9aa60",
+      "ConcordiaCourseId": "047047"
+    },
+    {
+      "Id": "b218a5aa-f6c7-45b0-ae4f-c3fe91a5d057",
+      "ConcordiaCourseId": "047048"
+    },
+    {
+      "Id": "35cee4a0-19a7-4473-b5ea-948d4338091e",
+      "ConcordiaCourseId": "047516"
+    },
+    {
+      "Id": "25fd4ad7-5610-4a25-8a71-9541eea84484",
+      "ConcordiaCourseId": "047517"
+    },
+    {
+      "Id": "3c5e2884-975f-4e54-b70f-e0139a652a90",
+      "ConcordiaCourseId": "047518"
+    },
+    {
+      "Id": "bc952907-4e13-4059-be9f-463d2efaee5a",
+      "ConcordiaCourseId": "047519"
+    },
+    {
+      "Id": "c2459a2c-b7bf-426d-a4be-32dd5dfdd639",
+      "ConcordiaCourseId": "047520"
+    },
+    {
+      "Id": "78388497-7125-4c91-9fb2-687a9b0f97d4",
+      "ConcordiaCourseId": "047521"
+    },
+    {
+      "Id": "b44b777e-2db2-46d9-ae3d-ef4790514c2d",
+      "ConcordiaCourseId": "050793"
+    },
+    {
+      "Id": "170b18fb-7288-4c20-811e-d09aa0d9d7b7",
+      "ConcordiaCourseId": "050794"
+    },
+    {
+      "Id": "504bc9fb-9033-45db-9c72-ea2402a447b9",
+      "ConcordiaCourseId": "029669"
+    },
+    {
+      "Id": "a51bc0eb-75b0-4f9a-bd5f-c908bd01c797",
+      "ConcordiaCourseId": "029759"
+    },
+    {
+      "Id": "d3179635-9a36-4d9c-9f58-e8de10002063",
+      "ConcordiaCourseId": "029760"
+    },
+    {
+      "Id": "88d84e1f-6bdd-40db-904f-4f87b6cc08eb",
+      "ConcordiaCourseId": "029764"
+    },
+    {
+      "Id": "21c985cb-424e-419f-9b13-747bb26807cf",
+      "ConcordiaCourseId": "029765"
+    },
+    {
+      "Id": "a0ecc5db-94de-4220-b9ef-39ae15741ecb",
+      "ConcordiaCourseId": "029766"
+    },
+    {
+      "Id": "fbb1b140-aa4a-48ec-a63a-8fc173fb488c",
+      "ConcordiaCourseId": "029769"
+    },
+    {
+      "Id": "434dac8b-92ef-41da-b2f8-02ae535276ab",
+      "ConcordiaCourseId": "029772"
+    },
+    {
+      "Id": "42935e43-1a6c-4ece-b3cc-fa640fb390df",
+      "ConcordiaCourseId": "029773"
+    },
+    {
+      "Id": "292b23d8-e9fd-42a2-9fde-22e9e3829194",
+      "ConcordiaCourseId": "029774"
+    },
+    {
+      "Id": "cba6049b-8548-4ffc-9cf7-f618fc274a4a",
+      "ConcordiaCourseId": "029775"
+    },
+    {
+      "Id": "15393b73-9e18-4706-bbf6-41242845f926",
+      "ConcordiaCourseId": "029776"
+    },
+    {
+      "Id": "0814c89e-8b55-44b9-8643-069aefa0bec3",
+      "ConcordiaCourseId": "029777"
+    },
+    {
+      "Id": "4b874f76-b47a-46af-9329-3ed490d09bb3",
+      "ConcordiaCourseId": "029804"
+    },
+    {
+      "Id": "acae4a44-3e3f-4eb9-b90e-79797cfa8c48",
+      "ConcordiaCourseId": "029805"
+    },
+    {
+      "Id": "392de31b-ade6-4ac3-9b5d-bfa9e97d4bb1",
+      "ConcordiaCourseId": "029806"
+    },
+    {
+      "Id": "b75bdd2e-4dcc-411d-b171-8d82fb7e40f2",
+      "ConcordiaCourseId": "029810"
+    },
+    {
+      "Id": "111bbf80-b3c9-4b1f-a97b-cc9516f39597",
+      "ConcordiaCourseId": "029811"
+    },
+    {
+      "Id": "2fcca0bc-bb8e-4ae1-b34a-7d17e5fa903a",
+      "ConcordiaCourseId": "029812"
+    },
+    {
+      "Id": "57fad6e6-8c06-462a-96bc-f5936c0088b6",
+      "ConcordiaCourseId": "029814"
+    },
+    {
+      "Id": "d7b1928e-cf91-4a9f-9493-b2b308ce891a",
+      "ConcordiaCourseId": "029815"
+    },
+    {
+      "Id": "47010e0c-48fb-46df-96ad-266c29a56a44",
+      "ConcordiaCourseId": "029816"
+    },
+    {
+      "Id": "d81be72f-3212-4cde-8d7b-83f07ced32ed",
+      "ConcordiaCourseId": "029817"
+    },
+    {
+      "Id": "0343d1cc-a87b-4866-bf72-648b523ffd7e",
+      "ConcordiaCourseId": "029819"
+    },
+    {
+      "Id": "a34eb4e8-5667-499f-968e-64a89f523f06",
+      "ConcordiaCourseId": "029820"
+    },
+    {
+      "Id": "afc77e3e-606c-49be-b696-9efbc0dfc550",
+      "ConcordiaCourseId": "029821"
+    },
+    {
+      "Id": "66415ee1-03db-425c-a377-63864c092784",
+      "ConcordiaCourseId": "029822"
+    },
+    {
+      "Id": "96ed6dc9-a64a-4fec-8e1a-57262fec79cc",
+      "ConcordiaCourseId": "029823"
+    },
+    {
+      "Id": "4f3bcc99-1a52-4f78-8ac2-b7deac8ebc39",
+      "ConcordiaCourseId": "029824"
+    },
+    {
+      "Id": "ef5ecb56-0342-438d-a82e-29eda4bd5ee7",
+      "ConcordiaCourseId": "029825"
+    },
+    {
+      "Id": "fbd49e8a-8598-468f-892d-84ca727b5fd7",
+      "ConcordiaCourseId": "029826"
+    },
+    {
+      "Id": "883fe8ab-ae78-4d28-bff1-9875f669df98",
+      "ConcordiaCourseId": "029828"
+    },
+    {
+      "Id": "6f7bc86c-e9d9-4026-a494-0529fe2ee932",
+      "ConcordiaCourseId": "029829"
+    },
+    {
+      "Id": "91aa9f3c-98be-4d36-9f9a-6b1a2618d0da",
+      "ConcordiaCourseId": "029832"
+    },
+    {
+      "Id": "6152246e-5bfc-4f78-8e9d-2dcb3314ee1c",
+      "ConcordiaCourseId": "029833"
+    },
+    {
+      "Id": "9808ffcf-784a-4a5f-8ae2-67991b82727c",
+      "ConcordiaCourseId": "029834"
+    },
+    {
+      "Id": "1f00d19e-b3d4-409e-9949-7caba910c4ae",
+      "ConcordiaCourseId": "029835"
+    },
+    {
+      "Id": "975bf00c-18e3-4b4f-876b-9ca312c02377",
+      "ConcordiaCourseId": "029837"
+    },
+    {
+      "Id": "44fd36e6-cefc-4f6b-88b7-729ef7aaa810",
+      "ConcordiaCourseId": "029838"
+    },
+    {
+      "Id": "29709bbf-5958-4401-9aac-42c6222e2c80",
+      "ConcordiaCourseId": "029839"
+    },
+    {
+      "Id": "3fb28ac7-50c0-44c9-a8a6-cbdf7d03800a",
+      "ConcordiaCourseId": "029841"
+    },
+    {
+      "Id": "7ba8f542-9176-47e4-88f5-ec99a17d79e8",
+      "ConcordiaCourseId": "029844"
+    },
+    {
+      "Id": "0ee83ee0-b733-4bc8-91cd-534b16a7e921",
+      "ConcordiaCourseId": "029845"
+    },
+    {
+      "Id": "59d1207f-b2c0-4e3b-969b-440e5c573466",
+      "ConcordiaCourseId": "029846"
+    },
+    {
+      "Id": "0aac957d-52bd-4dc8-a83e-0c403dd7354e",
+      "ConcordiaCourseId": "029847"
+    },
+    {
+      "Id": "bbccd8eb-e24f-40fb-924a-338ce81bfc54",
+      "ConcordiaCourseId": "029848"
+    },
+    {
+      "Id": "49b2de4c-d668-4bcb-a087-b74ed6d72075",
+      "ConcordiaCourseId": "029851"
+    },
+    {
+      "Id": "18ef0ad5-d0b7-4310-8413-346c4e2ac648",
+      "ConcordiaCourseId": "029852"
+    },
+    {
+      "Id": "786bde78-8b31-4019-b707-359c35664c7a",
+      "ConcordiaCourseId": "029854"
+    },
+    {
+      "Id": "c0296377-2e51-45e9-b207-8d21a3e95f3f",
+      "ConcordiaCourseId": "029855"
+    },
+    {
+      "Id": "a808ee5d-3f31-466f-853c-9638d0d0f90e",
+      "ConcordiaCourseId": "029856"
+    },
+    {
+      "Id": "0bc02e5e-dbbc-45ec-893d-fbd0ae3342f7",
+      "ConcordiaCourseId": "029858"
+    },
+    {
+      "Id": "62ca91d6-5c7a-438f-889d-b4ac3a44ec47",
+      "ConcordiaCourseId": "029859"
+    },
+    {
+      "Id": "6f4cd7cd-40bf-495b-9194-5bdab7b5237f",
+      "ConcordiaCourseId": "029860"
+    },
+    {
+      "Id": "49e1eec2-33ad-4acf-8d3e-80ea10263a1b",
+      "ConcordiaCourseId": "029863"
+    },
+    {
+      "Id": "3d43a73c-4e24-4ba3-baa3-a6c0df77ec0f",
+      "ConcordiaCourseId": "029864"
+    },
+    {
+      "Id": "2b46ed33-762b-4591-82c1-05e8aa6e8170",
+      "ConcordiaCourseId": "029865"
+    },
+    {
+      "Id": "99382fcd-ce98-4798-8af2-4a25ce5016be",
+      "ConcordiaCourseId": "029867"
+    },
+    {
+      "Id": "080cfd8c-c846-4f5d-a2cf-13b9a0f11507",
+      "ConcordiaCourseId": "029868"
+    },
+    {
+      "Id": "c5d05a32-4da5-4423-8392-84ffae48806e",
+      "ConcordiaCourseId": "029869"
+    },
+    {
+      "Id": "c666cd99-6d5a-4539-bc02-37dae688d8cd",
+      "ConcordiaCourseId": "029870"
+    },
+    {
+      "Id": "df817947-9ebe-4e25-876a-2ad7fc68f3dc",
+      "ConcordiaCourseId": "029871"
+    },
+    {
+      "Id": "5ac030f8-4260-4309-ae4c-a62544319da4",
+      "ConcordiaCourseId": "029872"
+    },
+    {
+      "Id": "5b29b59f-8687-46ab-b5ac-1fbd2bd37857",
+      "ConcordiaCourseId": "029873"
+    },
+    {
+      "Id": "db83a09b-be2c-4a96-a235-030231c97914",
+      "ConcordiaCourseId": "029874"
+    },
+    {
+      "Id": "7db8dcea-d1b0-4951-a6b0-4168ad9d0d07",
+      "ConcordiaCourseId": "029875"
+    },
+    {
+      "Id": "f2fa4ee0-12a8-4107-80cc-174a2da7f5b4",
+      "ConcordiaCourseId": "029877"
+    },
+    {
+      "Id": "913524dd-ea4d-41ca-a6b3-1efef4a03376",
+      "ConcordiaCourseId": "029879"
+    },
+    {
+      "Id": "a3c7fe85-b774-4a26-99db-086cdd7877ec",
+      "ConcordiaCourseId": "029883"
+    },
+    {
+      "Id": "600dfb1b-693e-4c6c-b52a-ae53fbf51547",
+      "ConcordiaCourseId": "029884"
+    },
+    {
+      "Id": "47604ce9-e426-48bc-a41e-3c9ee28dc0d4",
+      "ConcordiaCourseId": "029885"
+    },
+    {
+      "Id": "75c3659b-fa27-45aa-9632-60c9fa3b5bd4",
+      "ConcordiaCourseId": "029886"
+    },
+    {
+      "Id": "c2977754-2c9d-4eb0-930f-c432b1546fd3",
+      "ConcordiaCourseId": "029888"
+    },
+    {
+      "Id": "8d24f6a0-2aac-479a-a65e-10f10d9079ca",
+      "ConcordiaCourseId": "029889"
+    },
+    {
+      "Id": "1b02ef57-1bd8-4199-9e6e-aedf1df9cbba",
+      "ConcordiaCourseId": "029890"
+    },
+    {
+      "Id": "506cbaa3-0060-4030-8971-e105b3ab797e",
+      "ConcordiaCourseId": "029892"
+    },
+    {
+      "Id": "0729bb0a-e5c5-44fc-956d-eadef4e26eed",
+      "ConcordiaCourseId": "029893"
+    },
+    {
+      "Id": "bec1986c-c0c6-4141-b45e-a6fc892658d2",
+      "ConcordiaCourseId": "029899"
+    },
+    {
+      "Id": "b47b4c21-1afc-4046-bf4f-9abcb041e390",
+      "ConcordiaCourseId": "029900"
+    },
+    {
+      "Id": "7fa9c032-363f-47ea-9e05-85c2474bbf35",
+      "ConcordiaCourseId": "029901"
+    },
+    {
+      "Id": "877b70a0-0b40-409e-8251-ffca80299543",
+      "ConcordiaCourseId": "029902"
+    },
+    {
+      "Id": "fd6e2f4f-10c0-451a-93fd-45d54dfba378",
+      "ConcordiaCourseId": "029903"
+    },
+    {
+      "Id": "311cfd7c-415c-46fe-b32d-f4cff49ef17c",
+      "ConcordiaCourseId": "029904"
+    },
+    {
+      "Id": "530d2a56-e1ed-49d7-ab04-47df46554fb6",
+      "ConcordiaCourseId": "029905"
+    },
+    {
+      "Id": "f4c5884f-49bf-4bf3-8b39-f1c5fdd76f8b",
+      "ConcordiaCourseId": "029906"
+    },
+    {
+      "Id": "790f50c8-eb87-493a-a186-74c8dec1f4c6",
+      "ConcordiaCourseId": "029907"
+    },
+    {
+      "Id": "2371edc0-dda5-4795-8526-c08b7b48c607",
+      "ConcordiaCourseId": "029908"
+    },
+    {
+      "Id": "7ae6cad0-d603-4519-9ae6-9a09c1296667",
+      "ConcordiaCourseId": "029909"
+    },
+    {
+      "Id": "1aa225dd-3818-4a0c-ae3a-a3d24a2ada74",
+      "ConcordiaCourseId": "029910"
+    },
+    {
+      "Id": "92ccf0cd-0e68-4830-be28-da805a0e5005",
+      "ConcordiaCourseId": "029911"
+    },
+    {
+      "Id": "4d5c38d3-32e7-47b4-9e63-247aedd140a8",
+      "ConcordiaCourseId": "029916"
+    },
+    {
+      "Id": "68d92dec-6b47-4486-af09-d4943f6be332",
+      "ConcordiaCourseId": "029920"
+    },
+    {
+      "Id": "d6e2e94a-d320-4114-b158-7ad8a988a72b",
+      "ConcordiaCourseId": "029921"
+    },
+    {
+      "Id": "f5360771-2d6f-4bba-abfe-de1d981bc023",
+      "ConcordiaCourseId": "029923"
+    },
+    {
+      "Id": "1b99c66c-1829-428a-acaa-3ce4267cbb14",
+      "ConcordiaCourseId": "029957"
+    },
+    {
+      "Id": "e3f5c98d-b93f-4fac-8679-a5f33cc60294",
+      "ConcordiaCourseId": "029963"
+    },
+    {
+      "Id": "58933992-0acd-4a04-a57f-1da2a3c92495",
+      "ConcordiaCourseId": "029970"
+    },
+    {
+      "Id": "9b717304-fc97-4c5a-8d2f-a8d7eedd8fbd",
+      "ConcordiaCourseId": "029971"
+    },
+    {
+      "Id": "f94b9c48-3068-4c55-bf52-beb69b92a042",
+      "ConcordiaCourseId": "029977"
+    },
+    {
+      "Id": "ecb5a4f9-930d-43da-bfa6-7d5537e79480",
+      "ConcordiaCourseId": "029990"
+    },
+    {
+      "Id": "e3598ee7-576d-424c-8184-1e9e89929b41",
+      "ConcordiaCourseId": "029993"
+    },
+    {
+      "Id": "19e925ce-c966-450d-9ca2-d8ddf8fabb26",
+      "ConcordiaCourseId": "029996"
+    },
+    {
+      "Id": "6083fda1-c5c5-43c4-9277-89919de6811e",
+      "ConcordiaCourseId": "030019"
+    },
+    {
+      "Id": "2d4d0eb0-0fef-487c-8dd6-063e9504e08c",
+      "ConcordiaCourseId": "030020"
+    },
+    {
+      "Id": "4da8d37b-db31-4b1a-bb2b-c6c76bbc1eb4",
+      "ConcordiaCourseId": "030021"
+    },
+    {
+      "Id": "c5a7b4bf-d6e9-4d98-ad7d-18ac357e1374",
+      "ConcordiaCourseId": "030022"
+    },
+    {
+      "Id": "3d4c16a3-b181-4aee-875c-3aeff67644a8",
+      "ConcordiaCourseId": "030051"
+    },
+    {
+      "Id": "36bfaa53-2986-43ae-b9cf-43b9e05eb392",
+      "ConcordiaCourseId": "030058"
+    },
+    {
+      "Id": "1846263b-c213-4edd-87a6-deaf2411d9df",
+      "ConcordiaCourseId": "030066"
+    },
+    {
+      "Id": "fdb5a29d-137b-48b0-a964-f3ee325df5b7",
+      "ConcordiaCourseId": "030068"
+    },
+    {
+      "Id": "cd77735d-14f1-40e1-b4bc-9a981c990877",
+      "ConcordiaCourseId": "030069"
+    },
+    {
+      "Id": "dc027277-5001-477d-a94d-f244da94b227",
+      "ConcordiaCourseId": "030071"
+    },
+    {
+      "Id": "29dcd7ba-4267-4e26-8a72-3a5e9cc405b0",
+      "ConcordiaCourseId": "030079"
+    },
+    {
+      "Id": "b7284d32-9fc0-4eaf-8a14-2465c84e01b8",
+      "ConcordiaCourseId": "030094"
+    },
+    {
+      "Id": "94836015-475a-4012-9305-d700e57b9265",
+      "ConcordiaCourseId": "030109"
+    },
+    {
+      "Id": "bc6bd982-8ad3-4df4-8248-6259e6123ab3",
+      "ConcordiaCourseId": "030113"
+    },
+    {
+      "Id": "6438f9d8-2d59-42c0-bc3b-56b020dfc731",
+      "ConcordiaCourseId": "030120"
+    },
+    {
+      "Id": "8a54189d-fa8f-4953-aa7e-d9ba4fb5664f",
+      "ConcordiaCourseId": "030142"
+    },
+    {
+      "Id": "f686887f-b137-4028-ae20-2ba0767111b6",
+      "ConcordiaCourseId": "030144"
+    },
+    {
+      "Id": "c13a6d7c-7bcf-4f40-a8bc-3fc9c8467a73",
+      "ConcordiaCourseId": "030147"
+    },
+    {
+      "Id": "86d7b0cf-8546-4081-b814-3020cd967bef",
+      "ConcordiaCourseId": "030179"
+    },
+    {
+      "Id": "b088271d-08c2-4c08-ab00-430133519070",
+      "ConcordiaCourseId": "030181"
+    },
+    {
+      "Id": "4e7a2f04-43d8-43a1-a852-9f3a43f4bb91",
+      "ConcordiaCourseId": "030186"
+    },
+    {
+      "Id": "62e14f32-9182-4d06-ae59-07e4aea5ea5e",
+      "ConcordiaCourseId": "030189"
+    },
+    {
+      "Id": "244d3243-142d-467b-8a6a-a5925be0ab55",
+      "ConcordiaCourseId": "030192"
+    },
+    {
+      "Id": "3c6658e2-e7fe-44a3-a83b-e7b3a1ddaf3a",
+      "ConcordiaCourseId": "030194"
+    },
+    {
+      "Id": "3344815b-0777-4ea6-a063-2a850371e44d",
+      "ConcordiaCourseId": "030198"
+    },
+    {
+      "Id": "acc84675-1455-4706-8e30-bc73e21214a3",
+      "ConcordiaCourseId": "030203"
+    },
+    {
+      "Id": "ef78ebe4-e49e-4030-89a7-ad61b25966c8",
+      "ConcordiaCourseId": "030212"
+    },
+    {
+      "Id": "060f617c-c193-45ed-a483-f233a4961cab",
+      "ConcordiaCourseId": "030225"
+    },
+    {
+      "Id": "79ab430f-08b1-4cc2-bb0f-d6716bd4c3fe",
+      "ConcordiaCourseId": "030239"
+    },
+    {
+      "Id": "a6ba7b8b-3723-4aea-839e-73f9f988acb7",
+      "ConcordiaCourseId": "030245"
+    },
+    {
+      "Id": "32655fe9-7ab5-4f09-bbcc-9d847818b2dd",
+      "ConcordiaCourseId": "030248"
+    },
+    {
+      "Id": "91feb4ec-22c5-41f9-82a3-9e3b409ab988",
+      "ConcordiaCourseId": "030252"
+    },
+    {
+      "Id": "13f8f3ba-6318-413a-b2e8-83931b618014",
+      "ConcordiaCourseId": "030263"
+    },
+    {
+      "Id": "9ca910a5-96fe-4038-90de-4b53dc873613",
+      "ConcordiaCourseId": "030266"
+    },
+    {
+      "Id": "793bdc98-a4b3-45e1-91a4-3ac0f12c5753",
+      "ConcordiaCourseId": "030285"
+    },
+    {
+      "Id": "38fea709-eb9c-4e90-a078-8985dd5d9014",
+      "ConcordiaCourseId": "030292"
+    },
+    {
+      "Id": "9fe08842-fef7-47f4-8db0-035aa0620586",
+      "ConcordiaCourseId": "030309"
+    },
+    {
+      "Id": "e62ea604-f192-45cb-8128-51bd7e6b3704",
+      "ConcordiaCourseId": "030312"
+    },
+    {
+      "Id": "91c13fd9-1aca-414c-9e65-040e396c5e5d",
+      "ConcordiaCourseId": "030315"
+    },
+    {
+      "Id": "79926553-854e-46f2-bb22-afccc1a9e77d",
+      "ConcordiaCourseId": "030318"
+    },
+    {
+      "Id": "37b6da1b-dc46-4d0a-b404-1ad974fc3d70",
+      "ConcordiaCourseId": "030329"
+    },
+    {
+      "Id": "cde5ce3b-7656-4973-9d82-f8193f2f8bc0",
+      "ConcordiaCourseId": "030338"
+    },
+    {
+      "Id": "a3b01c0a-af18-4ba7-a0fb-7ff9c7c5d7b2",
+      "ConcordiaCourseId": "030342"
+    },
+    {
+      "Id": "6d40d280-d2fb-497c-ac35-2e723730a1d8",
+      "ConcordiaCourseId": "030345"
+    },
+    {
+      "Id": "20e2e1bd-2283-4e30-84b3-73eea99bcf6f",
+      "ConcordiaCourseId": "030346"
+    },
+    {
+      "Id": "ff7f0294-cd17-46db-80ee-5b396315cb4d",
+      "ConcordiaCourseId": "030347"
+    },
+    {
+      "Id": "3bbb0931-d42b-4b5b-a429-7d1644500ff5",
+      "ConcordiaCourseId": "030350"
+    },
+    {
+      "Id": "3e083d9f-a33d-4951-ba01-ee6cc0177cca",
+      "ConcordiaCourseId": "030358"
+    },
+    {
+      "Id": "259d3c8a-71cc-49f2-9a0f-4d2b8dd210f4",
+      "ConcordiaCourseId": "030370"
+    },
+    {
+      "Id": "846b894f-6fa9-4906-b72b-218ae5c260ef",
+      "ConcordiaCourseId": "030373"
+    },
+    {
+      "Id": "db3ffe56-38a5-4ffe-a32d-7037d196998d",
+      "ConcordiaCourseId": "030378"
+    },
+    {
+      "Id": "bee83271-5b06-4d80-9ae8-ea50c3d2ad65",
+      "ConcordiaCourseId": "030381"
+    },
+    {
+      "Id": "2ea41548-2225-46d9-980f-8ed3d58c5f90",
+      "ConcordiaCourseId": "030385"
+    },
+    {
+      "Id": "2f0ad986-e281-4364-b299-0759a1635675",
+      "ConcordiaCourseId": "030388"
+    },
+    {
+      "Id": "5970e60c-2043-4021-b1dd-b0def195ad60",
+      "ConcordiaCourseId": "030400"
+    },
+    {
+      "Id": "18d5597a-5a1c-447d-8547-60ca661b6c04",
+      "ConcordiaCourseId": "030405"
+    },
+    {
+      "Id": "c0817590-a48b-4eea-8ece-196414d24e9c",
+      "ConcordiaCourseId": "030410"
+    },
+    {
+      "Id": "5e757147-8cc7-4011-a478-dbe0c5de743f",
+      "ConcordiaCourseId": "030412"
+    },
+    {
+      "Id": "3314618f-a5d4-42e4-834c-0013cebbb932",
+      "ConcordiaCourseId": "030428"
+    },
+    {
+      "Id": "8e6b037d-7d26-4762-864c-d2f5da8de4e9",
+      "ConcordiaCourseId": "030429"
+    },
+    {
+      "Id": "177ce604-a610-4dc2-8af1-94b7fe94d8af",
+      "ConcordiaCourseId": "030441"
+    },
+    {
+      "Id": "4629ff29-6a3e-4791-9487-490af6a77d17",
+      "ConcordiaCourseId": "030456"
+    },
+    {
+      "Id": "2a1bce6d-9b70-4b2b-a065-aa30f6269723",
+      "ConcordiaCourseId": "030458"
+    },
+    {
+      "Id": "04a62fb4-749c-43c1-b4f6-7f3323368d14",
+      "ConcordiaCourseId": "030469"
+    },
+    {
+      "Id": "41f6bf3d-8900-4e4e-a65b-33265b83af0b",
+      "ConcordiaCourseId": "030475"
+    },
+    {
+      "Id": "2a61fd05-4732-4f09-ab9e-e9926ebc9958",
+      "ConcordiaCourseId": "030480"
+    },
+    {
+      "Id": "87d8a0ca-b9d4-4075-8e3a-8d1fad5755bc",
+      "ConcordiaCourseId": "030490"
+    },
+    {
+      "Id": "f6dcfd2e-9d01-4806-a58b-50e6190ee404",
+      "ConcordiaCourseId": "030498"
+    },
+    {
+      "Id": "2f9cf2ac-3f64-4ff9-adc3-2ef1ae2b1409",
+      "ConcordiaCourseId": "030507"
+    },
+    {
+      "Id": "2ded6275-53da-4897-a770-ffa3ff95fc34",
+      "ConcordiaCourseId": "030518"
+    },
+    {
+      "Id": "55fc44b5-bc6d-4c72-a5e4-f1bce130ca26",
+      "ConcordiaCourseId": "030547"
+    },
+    {
+      "Id": "8cde319f-7b99-41de-887e-b38a32ef1db7",
+      "ConcordiaCourseId": "030565"
+    },
+    {
+      "Id": "ea2845ad-9b8a-41cf-81c3-e58eedaf3e9c",
+      "ConcordiaCourseId": "030578"
+    },
+    {
+      "Id": "27e1a3d0-ecfd-4a30-b3a4-ce7740326dba",
+      "ConcordiaCourseId": "030590"
+    },
+    {
+      "Id": "c80d49e3-6470-440d-be9d-ea8d5806f4bf",
+      "ConcordiaCourseId": "030607"
+    },
+    {
+      "Id": "1c10aefc-18be-4d03-93c0-742880182f3a",
+      "ConcordiaCourseId": "030630"
+    },
+    {
+      "Id": "c9092fdc-8ff3-4a49-8646-75d57d42a57b",
+      "ConcordiaCourseId": "030647"
+    },
+    {
+      "Id": "fb6fb7f1-d2a1-4a46-8356-77d42a3624de",
+      "ConcordiaCourseId": "030655"
+    },
+    {
+      "Id": "e5174f4b-292d-475e-82aa-4836d41a7cf2",
+      "ConcordiaCourseId": "030660"
+    },
+    {
+      "Id": "89206bca-7cfb-4a82-9bee-3dffbfc3d312",
+      "ConcordiaCourseId": "030679"
+    },
+    {
+      "Id": "8b6f73b4-dd39-4935-88f4-39161b114980",
+      "ConcordiaCourseId": "030683"
+    },
+    {
+      "Id": "34d71a0e-fa19-4352-9e62-6970f0c604d8",
+      "ConcordiaCourseId": "030692"
+    },
+    {
+      "Id": "61e0dc65-467e-4b9e-b1e7-9378e3fd4fae",
+      "ConcordiaCourseId": "030696"
+    },
+    {
+      "Id": "82fceec2-a7af-4d2e-8c30-e82b3ca40ec9",
+      "ConcordiaCourseId": "030701"
+    },
+    {
+      "Id": "e195fa83-5f64-439d-b068-45c9f7483608",
+      "ConcordiaCourseId": "030710"
+    },
+    {
+      "Id": "7c97d281-e59e-44a0-8bd3-becf7745a782",
+      "ConcordiaCourseId": "030724"
+    },
+    {
+      "Id": "2b3e79e9-5473-4597-9cd7-6f6825f7880d",
+      "ConcordiaCourseId": "030738"
+    },
+    {
+      "Id": "bcfe3070-380b-44d0-adc5-ab7a12009478",
+      "ConcordiaCourseId": "030750"
+    },
+    {
+      "Id": "31542554-bec6-4da3-89e4-01a1eefb010d",
+      "ConcordiaCourseId": "030757"
+    },
+    {
+      "Id": "eca6632b-0ddf-431a-9a64-56658ead6a0e",
+      "ConcordiaCourseId": "030762"
+    },
+    {
+      "Id": "30af5a00-052a-4be2-b993-c81e72962725",
+      "ConcordiaCourseId": "030773"
+    },
+    {
+      "Id": "0ff5a537-6834-4acd-9c82-55c66593fe34",
+      "ConcordiaCourseId": "030774"
+    },
+    {
+      "Id": "861299fc-f177-4abd-83a6-c13a9c6252b0",
+      "ConcordiaCourseId": "030776"
+    },
+    {
+      "Id": "df38d7a7-e449-423b-9e3d-45c90e666ac6",
+      "ConcordiaCourseId": "030779"
+    },
+    {
+      "Id": "2a2e3eff-ffa3-4b5b-8136-f6fec09602bc",
+      "ConcordiaCourseId": "042403"
+    },
+    {
+      "Id": "d345bbd9-012c-41fd-9c89-cff657fa4dda",
+      "ConcordiaCourseId": "042408"
+    },
+    {
+      "Id": "ed039859-37e1-4bc2-9294-7456b306b903",
+      "ConcordiaCourseId": "042409"
+    },
+    {
+      "Id": "32e78d58-951c-4c2f-bf0b-c7f23083e75f",
+      "ConcordiaCourseId": "045742"
+    },
+    {
+      "Id": "4cfaea9f-d77f-4dfc-a4ec-aa57f4c20b70",
+      "ConcordiaCourseId": "047049"
+    },
+    {
+      "Id": "5ad5f758-fe21-489f-a0c1-e2d99f5c36e5",
+      "ConcordiaCourseId": "047050"
+    },
+    {
+      "Id": "f446b57e-3485-4877-a67b-3027fac0d5da",
+      "ConcordiaCourseId": "047051"
+    },
+    {
+      "Id": "7a7159be-e5ad-4f5d-9d98-7822df8a5a0d",
+      "ConcordiaCourseId": "047052"
+    },
+    {
+      "Id": "7f09924a-3464-4a25-aa80-6d036f7e668c",
+      "ConcordiaCourseId": "047053"
+    },
+    {
+      "Id": "ba1f681e-1bb6-4c7e-b975-00d201f98335",
+      "ConcordiaCourseId": "047054"
+    },
+    {
+      "Id": "c8cdb9a6-bde2-4112-a9c2-c3003be2d1a1",
+      "ConcordiaCourseId": "047055"
+    },
+    {
+      "Id": "19d859c2-6b44-4ef4-8f0f-cdf14d01f32a",
+      "ConcordiaCourseId": "047056"
+    },
+    {
+      "Id": "45dca84a-0c74-44e2-ad57-819b2c6a29db",
+      "ConcordiaCourseId": "047057"
+    },
+    {
+      "Id": "71a1c51c-d022-4b89-afe5-14362b18b756",
+      "ConcordiaCourseId": "047058"
+    },
+    {
+      "Id": "0c05f2e5-a1b2-4cf9-84f5-65c16ef1dd95",
+      "ConcordiaCourseId": "047059"
+    },
+    {
+      "Id": "e473a3d6-20d4-4084-b6f4-f9078514cb02",
+      "ConcordiaCourseId": "047060"
+    },
+    {
+      "Id": "405343e7-3906-4b27-853a-3bf28b6ab510",
+      "ConcordiaCourseId": "047061"
+    },
+    {
+      "Id": "0b6b3a03-4e3e-454a-b568-e4289edd95d6",
+      "ConcordiaCourseId": "047062"
+    },
+    {
+      "Id": "c88a4ebf-b593-467c-9353-b37234dbbfd5",
+      "ConcordiaCourseId": "047063"
+    },
+    {
+      "Id": "c0c4adf6-c74a-441f-8a98-3a14f7d4ad35",
+      "ConcordiaCourseId": "047064"
+    },
+    {
+      "Id": "d9249d80-cb72-4f94-aedb-92612027e84e",
+      "ConcordiaCourseId": "047065"
+    },
+    {
+      "Id": "59dfdf98-4244-4fa6-a2fe-a3bc1f490de6",
+      "ConcordiaCourseId": "047066"
+    },
+    {
+      "Id": "e6bed6ce-7477-4258-adb9-4ca050422c8b",
+      "ConcordiaCourseId": "047176"
+    },
+    {
+      "Id": "8db0351a-50c1-4ed5-9f5d-4a57acc10aa0",
+      "ConcordiaCourseId": "047205"
+    },
+    {
+      "Id": "f8625079-1200-4bbe-983b-203309c69909",
+      "ConcordiaCourseId": "047206"
+    },
+    {
+      "Id": "dd3ff4f8-7152-4bb0-8f1c-00cfc2b393d8",
+      "ConcordiaCourseId": "047207"
+    },
+    {
+      "Id": "07b7aac0-6971-4f2e-98ec-6ec11500c9d9",
+      "ConcordiaCourseId": "047208"
+    },
+    {
+      "Id": "82cd9220-924f-4b54-8c5f-d2464797c56e",
+      "ConcordiaCourseId": "047348"
+    },
+    {
+      "Id": "d8a9dc4a-44b6-4cd2-a35f-e288a1c4d166",
+      "ConcordiaCourseId": "047420"
+    },
+    {
+      "Id": "20cd1979-9277-47b8-966f-75caa719417d",
+      "ConcordiaCourseId": "047819"
+    },
+    {
+      "Id": "c72577cf-70d2-4ab8-b0f5-7826565a780b",
+      "ConcordiaCourseId": "048370"
+    },
+    {
+      "Id": "31247dce-bcd3-457d-99f3-2a95bea5f589",
+      "ConcordiaCourseId": "048371"
+    },
+    {
+      "Id": "3f8a61d0-5895-4365-a58a-e353e6a934b6",
+      "ConcordiaCourseId": "048400"
+    },
+    {
+      "Id": "6b5945e1-103b-4f02-a759-58f0c46718f9",
+      "ConcordiaCourseId": "049372"
+    },
+    {
+      "Id": "988db8f6-a04a-45b0-8f1f-71ad33d40144",
+      "ConcordiaCourseId": "049373"
+    },
+    {
+      "Id": "02693349-8bae-459d-a2ee-6fd2b8f6b214",
+      "ConcordiaCourseId": "049374"
+    },
+    {
+      "Id": "fd727963-4470-4693-ab2d-bf7babb40c00",
+      "ConcordiaCourseId": "049375"
+    },
+    {
+      "Id": "87a85ada-db9a-4781-bdff-d8a8fdf74b57",
+      "ConcordiaCourseId": "049376"
+    },
+    {
+      "Id": "1484b665-5e3a-481f-8648-4323ed62c6fe",
+      "ConcordiaCourseId": "049377"
+    },
+    {
+      "Id": "eeece4fd-8518-4391-9077-18984198f0de",
+      "ConcordiaCourseId": "049378"
+    },
+    {
+      "Id": "713e819f-5ae7-4485-968d-66e76a0ea8ba",
+      "ConcordiaCourseId": "049404"
+    },
+    {
+      "Id": "5ed39f7d-066f-4a5e-ad30-ef778074cbcf",
+      "ConcordiaCourseId": "049579"
+    },
+    {
+      "Id": "09504174-946c-41d2-9fcf-5fd6cf813f9c",
+      "ConcordiaCourseId": "049585"
+    },
+    {
+      "Id": "5a0a7075-30df-4a25-854c-657431f0c251",
+      "ConcordiaCourseId": "049592"
+    },
+    {
+      "Id": "ab037ff3-fcb4-447c-98f6-189a24800f1a",
+      "ConcordiaCourseId": "049854"
+    },
+    {
+      "Id": "7177960a-1ef9-4b9c-ae2c-32a38b9efe2e",
+      "ConcordiaCourseId": "049855"
+    },
+    {
+      "Id": "20069ecf-4a04-4cd9-9868-a23c43f94305",
+      "ConcordiaCourseId": "049866"
+    },
+    {
+      "Id": "cb725f50-243d-4eca-9bd7-f8ce1dfd27a4",
+      "ConcordiaCourseId": "049867"
+    },
+    {
+      "Id": "fdb5ece1-fffb-4066-bcd6-7775088c0672",
+      "ConcordiaCourseId": "050013"
+    },
+    {
+      "Id": "b0a930cc-1a46-4315-809e-36ff34ac8235",
+      "ConcordiaCourseId": "050359"
+    },
+    {
+      "Id": "201c4976-dc59-4fe4-aed1-9b9db6718c08",
+      "ConcordiaCourseId": "050435"
+    },
+    {
+      "Id": "aeefbba5-63ab-4b32-8b3e-0b9afad481ca",
+      "ConcordiaCourseId": "050436"
+    },
+    {
+      "Id": "e9ce5248-643f-4755-9a24-47ae12baf2ba",
+      "ConcordiaCourseId": "050485"
+    },
+    {
+      "Id": "907a964f-d4e5-4a46-a530-0a331276a0bd",
+      "ConcordiaCourseId": "050491"
+    },
+    {
+      "Id": "2ac7a0a3-e961-41f7-ac13-7592bf2c497b",
+      "ConcordiaCourseId": "050492"
+    },
+    {
+      "Id": "56d2f30c-de46-4bb5-9416-52547fecba2c",
+      "ConcordiaCourseId": "050493"
+    },
+    {
+      "Id": "09450135-e299-4022-82fd-3b3aed2e9b38",
+      "ConcordiaCourseId": "050500"
+    },
+    {
+      "Id": "e5aabe0f-ebc3-4922-a2c0-2d61c0251f5f",
+      "ConcordiaCourseId": "050501"
+    },
+    {
+      "Id": "2343985c-fcf3-4a74-8ebb-e3a246109b93",
+      "ConcordiaCourseId": "050502"
+    },
+    {
+      "Id": "851d2dc9-35ce-495c-a345-42b9a9c65a59",
+      "ConcordiaCourseId": "050503"
+    },
+    {
+      "Id": "7280209b-eb17-44da-ba10-d4a709988669",
+      "ConcordiaCourseId": "050504"
+    },
+    {
+      "Id": "4e3e7bce-bffe-4192-ac8e-b0e9e9bab22a",
+      "ConcordiaCourseId": "050505"
+    },
+    {
+      "Id": "0e84f215-9e76-4315-8964-8c28ab505145",
+      "ConcordiaCourseId": "050507"
+    },
+    {
+      "Id": "d62a8702-5441-4a70-993a-76f715db433d",
+      "ConcordiaCourseId": "050508"
+    },
+    {
+      "Id": "9a5614de-22d3-4719-812e-8eb97f1c4a2b",
+      "ConcordiaCourseId": "050600"
+    },
+    {
+      "Id": "837f4335-fefd-426c-94f8-dba1a867c550",
+      "ConcordiaCourseId": "047067"
+    },
+    {
+      "Id": "89cd9ee6-6e9e-4f75-9b4f-7e34a6923a20",
+      "ConcordiaCourseId": "031014"
+    },
+    {
+      "Id": "93ce72cc-8611-41a4-948c-a7d6ee795e83",
+      "ConcordiaCourseId": "031020"
+    },
+    {
+      "Id": "660c0dfd-a959-4d9f-8a6d-311ecc43fc51",
+      "ConcordiaCourseId": "047068"
+    },
+    {
+      "Id": "222fc8ea-bb0a-4353-b01d-fcbd007677f8",
+      "ConcordiaCourseId": "047069"
+    },
+    {
+      "Id": "0339b486-6881-42ec-bf14-4c186a4f66f1",
+      "ConcordiaCourseId": "050416"
+    },
+    {
+      "Id": "8e69363b-e127-4978-b5cc-8c9bec7c62ce",
+      "ConcordiaCourseId": "050417"
+    },
+    {
+      "Id": "313a5252-f0d7-45cb-bc49-22f6bae5867a",
+      "ConcordiaCourseId": "050419"
+    },
+    {
+      "Id": "5a777b50-c661-4a19-a4a0-4c265b6c1877",
+      "ConcordiaCourseId": "050727"
+    },
+    {
+      "Id": "f54db98e-e799-4e5d-acf8-eef1dff57905",
+      "ConcordiaCourseId": "050728"
+    },
+    {
+      "Id": "dd0b6316-078b-4785-afb6-0e7cdfc74278",
+      "ConcordiaCourseId": "050732"
+    },
+    {
+      "Id": "1f04878c-b3ac-43d6-9d1e-cac1cb69c1e9",
+      "ConcordiaCourseId": "050733"
+    },
+    {
+      "Id": "d1bd7a71-f06e-4312-bb7e-5096cf68273e",
+      "ConcordiaCourseId": "050734"
+    },
+    {
+      "Id": "28e65a71-269e-4470-ad07-412bcd347059",
+      "ConcordiaCourseId": "050735"
+    },
+    {
+      "Id": "187fa5b1-19d6-44f4-8a36-5719d891ca60",
+      "ConcordiaCourseId": "050736"
+    },
+    {
+      "Id": "74a19834-1683-43cd-8349-9f350b3503d5",
+      "ConcordiaCourseId": "050737"
+    },
+    {
+      "Id": "abd666e7-ab8e-448f-aefa-e67f489f0311",
+      "ConcordiaCourseId": "050738"
+    },
+    {
+      "Id": "7f2cfa1c-e86c-4d66-964e-874fb10d2db6",
+      "ConcordiaCourseId": "050739"
+    },
+    {
+      "Id": "419f518d-83f7-416d-91d5-2b949beba922",
+      "ConcordiaCourseId": "050740"
+    },
+    {
+      "Id": "58487975-6048-4dd5-9d8d-125a6e894076",
+      "ConcordiaCourseId": "050743"
+    },
+    {
+      "Id": "50537069-8848-43b9-8439-bca925fe7bf3",
+      "ConcordiaCourseId": "050744"
+    },
+    {
+      "Id": "4d2db06f-2bf7-43ef-a412-fca8cc8bff72",
+      "ConcordiaCourseId": "050745"
+    },
+    {
+      "Id": "7c56dd77-5a65-47f6-8897-cf6086076a06",
+      "ConcordiaCourseId": "050746"
+    },
+    {
+      "Id": "b0d5c3be-5ec1-4616-93ba-4e0d33407d71",
+      "ConcordiaCourseId": "050747"
+    },
+    {
+      "Id": "09ea9194-927c-457d-9d71-d62c66667765",
+      "ConcordiaCourseId": "050748"
+    },
+    {
+      "Id": "d756a8ea-8491-41b1-acc8-870f0f6858bb",
+      "ConcordiaCourseId": "050749"
+    },
+    {
+      "Id": "307d37be-1e2c-449c-b306-835c89465416",
+      "ConcordiaCourseId": "050750"
+    },
+    {
+      "Id": "7fd32485-d536-4a9b-b23e-63e4420e7a7d",
+      "ConcordiaCourseId": "050751"
+    },
+    {
+      "Id": "07caba21-67f4-4b5b-8ca1-a4405473322b",
+      "ConcordiaCourseId": "050752"
+    },
+    {
+      "Id": "b028b611-462c-4644-98d0-ce4b10f4b117",
+      "ConcordiaCourseId": "050753"
+    },
+    {
+      "Id": "2feb5f34-8834-46c8-9666-6656ff7ff2b2",
+      "ConcordiaCourseId": "050754"
+    },
+    {
+      "Id": "08f0a5ca-eefd-4326-a8d5-74d8b164a2f8",
+      "ConcordiaCourseId": "050755"
+    },
+    {
+      "Id": "76423733-0567-4161-a007-3aa1e3147af7",
+      "ConcordiaCourseId": "050756"
+    },
+    {
+      "Id": "7d9aa499-6ed1-416e-abd1-e838cc60686a",
+      "ConcordiaCourseId": "050757"
+    },
+    {
+      "Id": "935bc5e9-db9f-4297-a6ae-0b04958d63f3",
+      "ConcordiaCourseId": "050758"
+    },
+    {
+      "Id": "f72d65cb-79b4-4869-a6fa-2ef8ce0ca575",
+      "ConcordiaCourseId": "050759"
+    },
+    {
+      "Id": "b00747be-998c-41a6-9d67-2329988c555e",
+      "ConcordiaCourseId": "050760"
+    },
+    {
+      "Id": "e6afa1a7-aa91-46bd-9eb5-bdba4cd9265d",
+      "ConcordiaCourseId": "050761"
+    },
+    {
+      "Id": "53470bf2-013d-4533-977f-f345e6baea98",
+      "ConcordiaCourseId": "050762"
+    },
+    {
+      "Id": "cd4c38d4-a75f-4b1d-b3bd-8fe0471ed924",
+      "ConcordiaCourseId": "050763"
+    },
+    {
+      "Id": "dcc4764f-0a6d-4b8a-a9f8-13ee02949583",
+      "ConcordiaCourseId": "050764"
+    },
+    {
+      "Id": "8523b4e2-353f-4d92-ab26-f56926bd18af",
+      "ConcordiaCourseId": "050765"
+    },
+    {
+      "Id": "c8b5c8f3-02ed-45a3-8578-4fae90c67652",
+      "ConcordiaCourseId": "050766"
+    },
+    {
+      "Id": "8d8acc8f-e079-4548-be5e-3d762f8b45e3",
+      "ConcordiaCourseId": "034707"
+    },
+    {
+      "Id": "97d93859-1a24-4a23-83cd-7cf20759485b",
+      "ConcordiaCourseId": "047070"
+    },
+    {
+      "Id": "ac4a6932-690e-406d-850e-d86785dadfb7",
+      "ConcordiaCourseId": "047071"
+    },
+    {
+      "Id": "02134884-7f44-43ba-8467-1fe201e54a14",
+      "ConcordiaCourseId": "047072"
+    },
+    {
+      "Id": "de22d75b-022f-4511-8516-5a47b9523d4c",
+      "ConcordiaCourseId": "031127"
+    },
+    {
+      "Id": "bac34b33-5781-49a5-8999-297c265ab457",
+      "ConcordiaCourseId": "031128"
+    },
+    {
+      "Id": "918c6995-74de-4430-86ae-0e2fd32b56d5",
+      "ConcordiaCourseId": "031144"
+    },
+    {
+      "Id": "16d915bb-feb0-4f0a-9b49-ad8f2d1e6594",
+      "ConcordiaCourseId": "031151"
+    },
+    {
+      "Id": "47a5344c-436d-4a6a-84cc-b1eb80aa214f",
+      "ConcordiaCourseId": "031178"
+    },
+    {
+      "Id": "7f75ba85-4abb-4145-8290-d4de7963d0af",
+      "ConcordiaCourseId": "031199"
+    },
+    {
+      "Id": "a80dfe55-284e-4acb-b9cd-b8b196a7a5fa",
+      "ConcordiaCourseId": "047073"
+    },
+    {
+      "Id": "a55c00dd-f474-44ab-83f3-fdc323585627",
+      "ConcordiaCourseId": "047074"
+    },
+    {
+      "Id": "1050c2f4-8474-45c5-bff3-cf58007e16ab",
+      "ConcordiaCourseId": "047075"
+    },
+    {
+      "Id": "7ec2a321-d2c5-4ad7-b564-0451d28984db",
+      "ConcordiaCourseId": "047076"
+    },
+    {
+      "Id": "e6fd2b5a-3cba-4efb-b20d-e733aacd5381",
+      "ConcordiaCourseId": "047077"
+    },
+    {
+      "Id": "d5fcac9d-1087-41e9-a09e-28685580cf7c",
+      "ConcordiaCourseId": "048299"
+    },
+    {
+      "Id": "ddb050f5-6886-4ad3-88a8-db28496a86c9",
+      "ConcordiaCourseId": "031210"
+    },
+    {
+      "Id": "1de7794b-de30-48ab-9fe7-fc3d3899e8a9",
+      "ConcordiaCourseId": "031211"
+    },
+    {
+      "Id": "255861ca-7fad-4157-bf75-c4773ee13201",
+      "ConcordiaCourseId": "031212"
+    },
+    {
+      "Id": "18b080f7-739d-4aeb-8073-c073d907f863",
+      "ConcordiaCourseId": "031213"
+    },
+    {
+      "Id": "0ba93e35-1e9b-4b3a-868b-e74590fc3a8e",
+      "ConcordiaCourseId": "031214"
+    },
+    {
+      "Id": "5cde7e86-96cc-4ac3-925b-61ec0c26548b",
+      "ConcordiaCourseId": "031215"
+    },
+    {
+      "Id": "003328a8-d4c3-4929-bc34-8ab310000bb9",
+      "ConcordiaCourseId": "031216"
+    },
+    {
+      "Id": "091870c1-847a-4915-9751-6ebcd1e30900",
+      "ConcordiaCourseId": "048079"
+    },
+    {
+      "Id": "e7df294f-6e32-4552-88b4-12311a43de4f",
+      "ConcordiaCourseId": "050069"
+    },
+    {
+      "Id": "81f8cdd6-e2ea-4c5a-8d67-388155ce8162",
+      "ConcordiaCourseId": "031217"
+    },
+    {
+      "Id": "ca7c7945-456f-49e8-b062-31dfdb328242",
+      "ConcordiaCourseId": "031218"
+    },
+    {
+      "Id": "73403e4b-da50-46a8-9d04-ed65a662f0b1",
+      "ConcordiaCourseId": "031221"
+    },
+    {
+      "Id": "626b6a0c-ad0d-43dd-b37a-297cd3f8e953",
+      "ConcordiaCourseId": "031226"
+    },
+    {
+      "Id": "acc88d11-b89e-48fb-a3ee-1382ab9bd2ce",
+      "ConcordiaCourseId": "031227"
+    },
+    {
+      "Id": "f8fcc785-6141-4838-9b38-507f40758a41",
+      "ConcordiaCourseId": "031228"
+    },
+    {
+      "Id": "745376eb-e9ec-4b50-ac4d-bb70b9c1030e",
+      "ConcordiaCourseId": "031230"
+    },
+    {
+      "Id": "2ef49f45-9d7f-4111-9847-7258d6d914a5",
+      "ConcordiaCourseId": "031232"
+    },
+    {
+      "Id": "974a7487-daff-4117-9c61-98cada2a3457",
+      "ConcordiaCourseId": "031233"
+    },
+    {
+      "Id": "cd5f756f-27fd-44bd-af60-96bbb6db1869",
+      "ConcordiaCourseId": "031234"
+    },
+    {
+      "Id": "baebbd12-6915-44d1-b06f-c4fcb0a47cf0",
+      "ConcordiaCourseId": "031235"
+    },
+    {
+      "Id": "fb45c971-52b2-4d7c-8336-d80b66f56df2",
+      "ConcordiaCourseId": "031237"
+    },
+    {
+      "Id": "4e151e8f-60e1-4e92-a4e6-d4d08a8b17d9",
+      "ConcordiaCourseId": "031252"
+    },
+    {
+      "Id": "15a89853-74c0-491b-98de-026ece31617c",
+      "ConcordiaCourseId": "031253"
+    },
+    {
+      "Id": "6bf42096-9928-4394-9fcc-7ed42894774f",
+      "ConcordiaCourseId": "031254"
+    },
+    {
+      "Id": "1f3a821b-2895-4685-b63c-ff2967ecebc0",
+      "ConcordiaCourseId": "031255"
+    },
+    {
+      "Id": "c62c0465-60c3-46ff-ab6d-afb0230741d3",
+      "ConcordiaCourseId": "031256"
+    },
+    {
+      "Id": "f5c0ec9f-bc9d-4cb6-92f8-c34bbf87d478",
+      "ConcordiaCourseId": "031258"
+    },
+    {
+      "Id": "0efc037c-5641-4056-a207-dd1c7db57697",
+      "ConcordiaCourseId": "031259"
+    },
+    {
+      "Id": "42691f33-f564-43b7-9453-48e877fcf91d",
+      "ConcordiaCourseId": "031260"
+    },
+    {
+      "Id": "e5b62f4a-e069-4d5b-8c11-f39cff792daf",
+      "ConcordiaCourseId": "031261"
+    },
+    {
+      "Id": "2d60ffeb-0fcc-45ba-9269-68a811098e5b",
+      "ConcordiaCourseId": "031262"
+    },
+    {
+      "Id": "6e99e463-e3c9-4c1d-871e-b6baee1f6562",
+      "ConcordiaCourseId": "031265"
+    },
+    {
+      "Id": "29d14211-e433-4872-88eb-725ae31d34c3",
+      "ConcordiaCourseId": "031267"
+    },
+    {
+      "Id": "d1dac22b-d776-4548-a5d6-3337aae6f66a",
+      "ConcordiaCourseId": "031269"
+    },
+    {
+      "Id": "f7a5fe31-f926-4f16-bb74-1f0832caea53",
+      "ConcordiaCourseId": "031495"
+    },
+    {
+      "Id": "bbc4ae29-ced1-41ff-ba80-2c39b61481f7",
+      "ConcordiaCourseId": "044219"
+    },
+    {
+      "Id": "3c52f4e0-1b77-43c7-acf8-c5789ce14d02",
+      "ConcordiaCourseId": "047078"
+    },
+    {
+      "Id": "6f59cfcf-02b0-4426-b558-b21c2351d439",
+      "ConcordiaCourseId": "047079"
+    },
+    {
+      "Id": "c1649c32-ae79-46c4-97c2-2a694182acf4",
+      "ConcordiaCourseId": "048820"
+    },
+    {
+      "Id": "ecfa2012-0682-4854-a546-ac4f53e4baba",
+      "ConcordiaCourseId": "048821"
+    },
+    {
+      "Id": "226239a1-fc22-4e7f-85dd-dfc9c7b666f9",
+      "ConcordiaCourseId": "048822"
+    },
+    {
+      "Id": "8a11de07-98f7-4c0e-89a5-fe45f14f0fd4",
+      "ConcordiaCourseId": "048823"
+    },
+    {
+      "Id": "8518c44b-650e-4743-9f46-79699573fe55",
+      "ConcordiaCourseId": "049278"
+    },
+    {
+      "Id": "5b4e367b-977c-4dbd-b39c-e48167e32f60",
+      "ConcordiaCourseId": "031291"
+    },
+    {
+      "Id": "8c7c31e7-fee0-42a3-84af-8977e6d533d1",
+      "ConcordiaCourseId": "031292"
+    },
+    {
+      "Id": "d55591e0-955a-4c51-b37a-9d7a072e9124",
+      "ConcordiaCourseId": "031295"
+    },
+    {
+      "Id": "e15e5f73-167e-49ed-b6a2-ecec8a7203ec",
+      "ConcordiaCourseId": "031296"
+    },
+    {
+      "Id": "ac756429-e853-457c-abdb-f29f8be48f20",
+      "ConcordiaCourseId": "031304"
+    },
+    {
+      "Id": "d2cf0a10-6fb7-48e7-af96-92cfe13fd58d",
+      "ConcordiaCourseId": "031305"
+    },
+    {
+      "Id": "a03af1c7-d668-46a4-8360-720d97432ea3",
+      "ConcordiaCourseId": "031306"
+    },
+    {
+      "Id": "37dc797e-a102-4ad1-a052-44a5d0719b95",
+      "ConcordiaCourseId": "031307"
+    },
+    {
+      "Id": "b3a6c4c8-0056-4a90-b9df-0a397c69b02c",
+      "ConcordiaCourseId": "031309"
+    },
+    {
+      "Id": "77d72771-afef-4709-b5ea-d6d6c75a3495",
+      "ConcordiaCourseId": "031314"
+    },
+    {
+      "Id": "bbc245eb-e579-48c9-b0cc-32e2d56795db",
+      "ConcordiaCourseId": "031316"
+    },
+    {
+      "Id": "7bcdc462-1aaa-4b8d-bf69-dfc7bafa8c61",
+      "ConcordiaCourseId": "031318"
+    },
+    {
+      "Id": "f74db9b4-9a5d-460e-9ff3-4c7b74728e31",
+      "ConcordiaCourseId": "031319"
+    },
+    {
+      "Id": "25bb69c3-9d00-4172-850a-8bf756e415bb",
+      "ConcordiaCourseId": "047080"
+    },
+    {
+      "Id": "ec431470-b5e2-4f88-8f95-d3dc619bfa36",
+      "ConcordiaCourseId": "047081"
+    },
+    {
+      "Id": "fb8c717a-0c2b-4dd2-bb0e-9eb897d46313",
+      "ConcordiaCourseId": "049685"
+    },
+    {
+      "Id": "148e6d20-0f68-4cff-81e1-64a63595b3ab",
+      "ConcordiaCourseId": "049686"
+    },
+    {
+      "Id": "1c28d8d5-3df8-4009-a18d-7984ad8e8392",
+      "ConcordiaCourseId": "049687"
+    },
+    {
+      "Id": "9cab0c87-19f0-49ac-876a-724811d86456",
+      "ConcordiaCourseId": "050409"
+    },
+    {
+      "Id": "3ff3a691-f8c5-4962-ab76-5b672542f6fc",
+      "ConcordiaCourseId": "050700"
+    },
+    {
+      "Id": "a896ea02-3186-4f79-919e-c31190235a91",
+      "ConcordiaCourseId": "050701"
+    },
+    {
+      "Id": "51dbfaac-7015-498b-a218-e266f32499b3",
+      "ConcordiaCourseId": "050702"
+    },
+    {
+      "Id": "8b7ece68-38ee-42a1-90d4-fa683144a71f",
+      "ConcordiaCourseId": "050703"
+    },
+    {
+      "Id": "93142afa-348d-4405-ae0d-a4ae376a1354",
+      "ConcordiaCourseId": "050704"
+    },
+    {
+      "Id": "2ce9e271-3fa2-490e-aa34-951992b65638",
+      "ConcordiaCourseId": "050705"
+    },
+    {
+      "Id": "8fcf1d02-9aa3-448f-9533-947e146e9e31",
+      "ConcordiaCourseId": "050706"
+    },
+    {
+      "Id": "f1f7b90b-a356-4692-a70e-778d3f69588b",
+      "ConcordiaCourseId": "050708"
+    },
+    {
+      "Id": "e485170b-7749-4888-8f75-5493a97d3383",
+      "ConcordiaCourseId": "050709"
+    },
+    {
+      "Id": "83d1e490-8945-4320-8521-9483017746d1",
+      "ConcordiaCourseId": "050710"
+    },
+    {
+      "Id": "2e19edd5-2a8f-4e98-88f5-624a429b3ec5",
+      "ConcordiaCourseId": "050711"
+    },
+    {
+      "Id": "004995f0-d804-4923-9ca0-7129ade09b0d",
+      "ConcordiaCourseId": "050712"
+    },
+    {
+      "Id": "dbad4343-05dc-400f-9f03-2599361031ee",
+      "ConcordiaCourseId": "050713"
+    },
+    {
+      "Id": "d0a9a3fb-3bd5-46e4-9afd-c7efdce21506",
+      "ConcordiaCourseId": "050714"
+    },
+    {
+      "Id": "2c57b4fd-1d5e-4f53-b8b4-19bb9652b0c3",
+      "ConcordiaCourseId": "050715"
+    },
+    {
+      "Id": "6d31e613-408d-43af-9a1b-20f0da055579",
+      "ConcordiaCourseId": "050716"
+    },
+    {
+      "Id": "e0a090f1-7b0d-4c6f-80c4-36e9bf1299d2",
+      "ConcordiaCourseId": "047082"
+    },
+    {
+      "Id": "f8c7a203-3ac3-47a3-9e0e-b99e31272d07",
+      "ConcordiaCourseId": "031374"
+    },
+    {
+      "Id": "854b0581-c473-4726-a4ec-b98687401976",
+      "ConcordiaCourseId": "031375"
+    },
+    {
+      "Id": "2fcc51d1-c3e9-4f1e-bd4d-e5516ed3dfef",
+      "ConcordiaCourseId": "042528"
+    },
+    {
+      "Id": "88b0280b-6a1d-4ddb-8aaf-2391ed2aa326",
+      "ConcordiaCourseId": "042529"
+    },
+    {
+      "Id": "0d0f4f0b-bc20-4449-8f92-c5f7ba83927c",
+      "ConcordiaCourseId": "042530"
+    },
+    {
+      "Id": "538aa3b5-f2c5-46a4-aed7-1b6248fc7c1b",
+      "ConcordiaCourseId": "042531"
+    },
+    {
+      "Id": "b358ed20-0595-4d92-bc06-1bb668e9ac15",
+      "ConcordiaCourseId": "042532"
+    },
+    {
+      "Id": "e9758837-5ef0-4164-b633-545c349b5da2",
+      "ConcordiaCourseId": "031408"
+    },
+    {
+      "Id": "7b0ef6d9-91ba-48fe-819f-12b6750bb903",
+      "ConcordiaCourseId": "031418"
+    },
+    {
+      "Id": "0868923d-43c4-4ef5-9509-c3c54b23fa1b",
+      "ConcordiaCourseId": "031419"
+    },
+    {
+      "Id": "8068a7ab-8fbd-4a31-b65b-b906a9a597c1",
+      "ConcordiaCourseId": "031421"
+    },
+    {
+      "Id": "863ec0b8-c191-42b9-a7f5-e871f33d0958",
+      "ConcordiaCourseId": "031423"
+    },
+    {
+      "Id": "8557ee1e-ff30-44cf-9d24-3e63dd9f3af2",
+      "ConcordiaCourseId": "031424"
+    },
+    {
+      "Id": "5ee8c977-cb55-47f1-8f15-667fedf83e96",
+      "ConcordiaCourseId": "031429"
+    },
+    {
+      "Id": "c0f2bfe1-4a3c-4cba-87dc-09ceb9176a0b",
+      "ConcordiaCourseId": "031430"
+    },
+    {
+      "Id": "a0d9613c-675d-4a90-9381-cdce00fb1386",
+      "ConcordiaCourseId": "031432"
+    },
+    {
+      "Id": "9c613758-ff2f-414e-b983-0af78e4e94f9",
+      "ConcordiaCourseId": "031433"
+    },
+    {
+      "Id": "c9b7e848-aff7-4a87-90a4-603697bd3d36",
+      "ConcordiaCourseId": "031434"
+    },
+    {
+      "Id": "e5bfd1d2-131d-43a0-a9c8-cd8326a892b0",
+      "ConcordiaCourseId": "031435"
+    },
+    {
+      "Id": "3334f973-dabe-4249-9eb1-fd1f2a417b9b",
+      "ConcordiaCourseId": "031436"
+    },
+    {
+      "Id": "821fe097-c7e4-4171-a002-2b7069bbd3be",
+      "ConcordiaCourseId": "031438"
+    },
+    {
+      "Id": "29b9de17-1c6a-4117-950a-b57f5d586d71",
+      "ConcordiaCourseId": "031439"
+    },
+    {
+      "Id": "b8b69fc9-e9a8-4663-b4da-40a0716a3124",
+      "ConcordiaCourseId": "031441"
+    },
+    {
+      "Id": "a0ff5ebb-2145-4c8e-9342-226c7716e5b5",
+      "ConcordiaCourseId": "031442"
+    },
+    {
+      "Id": "c89c20ab-f589-4380-b1ab-a8cee8c4eca3",
+      "ConcordiaCourseId": "031450"
+    },
+    {
+      "Id": "d20e3b7a-1daf-4b8d-bc16-c72e18928f0b",
+      "ConcordiaCourseId": "031474"
+    },
+    {
+      "Id": "ff9d8bb2-3356-4008-ae63-e8b1091af4de",
+      "ConcordiaCourseId": "031487"
+    },
+    {
+      "Id": "7db48cc1-daa0-44aa-8546-6164f18ba33f",
+      "ConcordiaCourseId": "031488"
+    },
+    {
+      "Id": "4c7e5a87-351e-4110-8203-ecc83c69ed38",
+      "ConcordiaCourseId": "031489"
+    },
+    {
+      "Id": "051f119f-2988-4ab1-99d3-0a625c500706",
+      "ConcordiaCourseId": "031491"
+    },
+    {
+      "Id": "5e2dbfb2-b54e-419a-8b8b-0c7ce606c0f0",
+      "ConcordiaCourseId": "031492"
+    },
+    {
+      "Id": "8784cfc0-558a-43a3-9daf-a510b3195a0b",
+      "ConcordiaCourseId": "031494"
+    },
+    {
+      "Id": "46637bc9-70c6-4818-a613-0ee16acc230b",
+      "ConcordiaCourseId": "031496"
+    },
+    {
+      "Id": "382d5e9f-36f3-473b-8c66-d72a51fe5135",
+      "ConcordiaCourseId": "031497"
+    },
+    {
+      "Id": "3e21ba5b-1ffc-48f4-bdf7-dbacbbc78a27",
+      "ConcordiaCourseId": "031499"
+    },
+    {
+      "Id": "72db5a97-9b74-49f5-ae12-df759f8749d5",
+      "ConcordiaCourseId": "031500"
+    },
+    {
+      "Id": "311cf892-b74c-4a24-8248-2c4f1e9d7e3e",
+      "ConcordiaCourseId": "031501"
+    },
+    {
+      "Id": "0a49b976-0fa0-4df5-9782-8ddffd1ffc83",
+      "ConcordiaCourseId": "031504"
+    },
+    {
+      "Id": "cd0afcc3-629f-44b5-a9a4-4354771acd54",
+      "ConcordiaCourseId": "031514"
+    },
+    {
+      "Id": "4ff26fe8-f5bb-4bb4-a97b-042ac2a09176",
+      "ConcordiaCourseId": "031516"
+    },
+    {
+      "Id": "bd242501-69b7-49b6-bf0d-af3679926358",
+      "ConcordiaCourseId": "031520"
+    },
+    {
+      "Id": "6a274156-2be8-4fa2-8faf-b4fb68dc9182",
+      "ConcordiaCourseId": "031521"
+    },
+    {
+      "Id": "0995c689-d885-4e22-9443-034dc1887d01",
+      "ConcordiaCourseId": "031564"
+    },
+    {
+      "Id": "12ff89c7-ec42-45de-9519-f7172fc45e21",
+      "ConcordiaCourseId": "031567"
+    },
+    {
+      "Id": "eb2091ab-6e2c-439f-a0c4-02ea99dfbda4",
+      "ConcordiaCourseId": "031569"
+    },
+    {
+      "Id": "07f7642d-7744-4308-928e-272b11a7195b",
+      "ConcordiaCourseId": "031572"
+    },
+    {
+      "Id": "db1b8b36-e251-4c44-8ef4-96deb40edcbe",
+      "ConcordiaCourseId": "031574"
+    },
+    {
+      "Id": "0fadd540-2aa0-442d-a008-59506df6ab5a",
+      "ConcordiaCourseId": "031580"
+    },
+    {
+      "Id": "5704b336-e357-431f-b70f-c0ddb6f08828",
+      "ConcordiaCourseId": "031581"
+    },
+    {
+      "Id": "2fce2a54-0e07-4013-8e46-9e7e035f3808",
+      "ConcordiaCourseId": "031586"
+    },
+    {
+      "Id": "d8a953df-b2bd-40f7-9730-5df9ba07b547",
+      "ConcordiaCourseId": "031591"
+    },
+    {
+      "Id": "6f44f5b6-d211-49cc-a988-d42df12da48c",
+      "ConcordiaCourseId": "031596"
+    },
+    {
+      "Id": "c4d7b0d6-ba95-468a-bad3-d7e0e4c6859f",
+      "ConcordiaCourseId": "031600"
+    },
+    {
+      "Id": "15a98b42-3107-432c-b3e5-c723acc9ccbd",
+      "ConcordiaCourseId": "031601"
+    },
+    {
+      "Id": "cd3af150-4518-4f01-ad8f-70a4c26ca8ce",
+      "ConcordiaCourseId": "031605"
+    },
+    {
+      "Id": "055e5ee3-c721-4f5e-8875-ead309caaa93",
+      "ConcordiaCourseId": "031606"
+    },
+    {
+      "Id": "676aca38-c100-43c0-b5e5-8a37f76c28e7",
+      "ConcordiaCourseId": "031611"
+    },
+    {
+      "Id": "808e67ec-3f8c-49b0-b7ee-4e0bff8ecf7d",
+      "ConcordiaCourseId": "031618"
+    },
+    {
+      "Id": "ca35742e-efce-4a64-9e63-e899469fbf70",
+      "ConcordiaCourseId": "031619"
+    },
+    {
+      "Id": "a2a89c62-de3b-42c4-a151-6b4e6899e7e2",
+      "ConcordiaCourseId": "031623"
+    },
+    {
+      "Id": "1e3cdc67-a5c7-4f51-a9c5-6feb7ef2e1d9",
+      "ConcordiaCourseId": "031624"
+    },
+    {
+      "Id": "22321e1b-2d29-4386-80cb-691b23d60250",
+      "ConcordiaCourseId": "031628"
+    },
+    {
+      "Id": "15225264-6a10-4555-9021-928e5e806cf1",
+      "ConcordiaCourseId": "031629"
+    },
+    {
+      "Id": "ec400ee6-d46d-40ef-8ca1-ca4b87d2fe8b",
+      "ConcordiaCourseId": "031634"
+    },
+    {
+      "Id": "aa9c16a2-d3e5-48d0-9d38-ed3ada911d87",
+      "ConcordiaCourseId": "031636"
+    },
+    {
+      "Id": "1a10c3a9-429e-4bc3-8171-e140ebec2898",
+      "ConcordiaCourseId": "031637"
+    },
+    {
+      "Id": "80aca2af-2569-47bb-a084-2a968547608f",
+      "ConcordiaCourseId": "031638"
+    },
+    {
+      "Id": "7ec4d98d-ca0e-4142-95d9-ec6e59986929",
+      "ConcordiaCourseId": "031693"
+    },
+    {
+      "Id": "4486267e-741e-4e1d-bca1-358ae4a97f18",
+      "ConcordiaCourseId": "031699"
+    },
+    {
+      "Id": "63f56c95-4baa-4779-81ed-3655bc997d2e",
+      "ConcordiaCourseId": "031700"
+    },
+    {
+      "Id": "09faccd2-95ae-447c-a258-0795a73856cf",
+      "ConcordiaCourseId": "031702"
+    },
+    {
+      "Id": "1e0d3f1a-df0e-4e02-914e-138ed992a9b0",
+      "ConcordiaCourseId": "031704"
+    },
+    {
+      "Id": "ed801822-e5a6-4c5c-9226-e08b6d01562e",
+      "ConcordiaCourseId": "031705"
+    },
+    {
+      "Id": "dc8cfda3-7a56-4d59-8d7c-3fd4bb9c038e",
+      "ConcordiaCourseId": "031710"
+    },
+    {
+      "Id": "29da915f-3131-4fd5-af28-9d9753809704",
+      "ConcordiaCourseId": "031713"
+    },
+    {
+      "Id": "64926abc-8325-4182-b131-b68d705f0d89",
+      "ConcordiaCourseId": "031715"
+    },
+    {
+      "Id": "cc67473d-85bb-414a-9f91-5e6dcadfb336",
+      "ConcordiaCourseId": "031720"
+    },
+    {
+      "Id": "1ccb6d7e-a293-4a8e-94ec-78683d9c15b7",
+      "ConcordiaCourseId": "031724"
+    },
+    {
+      "Id": "ff1d9df0-ee74-42e3-8e35-9cc17bd31f8e",
+      "ConcordiaCourseId": "031731"
+    },
+    {
+      "Id": "461d5d04-bb99-44a0-92d2-7542a42a41bc",
+      "ConcordiaCourseId": "031732"
+    },
+    {
+      "Id": "d83f4e7e-3d78-480f-8f8a-11b22c8ba848",
+      "ConcordiaCourseId": "031734"
+    },
+    {
+      "Id": "37ce34e9-c39b-4699-b55b-22519f95fd30",
+      "ConcordiaCourseId": "031736"
+    },
+    {
+      "Id": "0c04a518-126f-4eee-a424-16ac7bba26c7",
+      "ConcordiaCourseId": "031737"
+    },
+    {
+      "Id": "37a1111f-f9d8-4907-95fd-9cd63a78fbbe",
+      "ConcordiaCourseId": "031738"
+    },
+    {
+      "Id": "42369a21-7849-470b-8221-19fee35a350d",
+      "ConcordiaCourseId": "031753"
+    },
+    {
+      "Id": "97d0429f-2f56-47ad-895a-5c8eb458e544",
+      "ConcordiaCourseId": "031758"
+    },
+    {
+      "Id": "fa0a9478-5ed9-49e8-82a9-f183928f8b9d",
+      "ConcordiaCourseId": "031759"
+    },
+    {
+      "Id": "23ed0108-c0fd-46d1-a3b6-b4142fb64f10",
+      "ConcordiaCourseId": "031761"
+    },
+    {
+      "Id": "51b3b48c-6609-45c0-9009-881660f892f1",
+      "ConcordiaCourseId": "031762"
+    },
+    {
+      "Id": "b10637ec-7acc-44e0-be17-ca39bfa425dc",
+      "ConcordiaCourseId": "031763"
+    },
+    {
+      "Id": "5344be78-6a8a-4bd0-881a-e04c73a1a3dd",
+      "ConcordiaCourseId": "031766"
+    },
+    {
+      "Id": "0757d5b0-b373-478e-8537-6f9037cfee7e",
+      "ConcordiaCourseId": "031773"
+    },
+    {
+      "Id": "5d8caae0-9819-4c7e-aa47-3a972a2efe28",
+      "ConcordiaCourseId": "031785"
+    },
+    {
+      "Id": "b5ce2b30-745c-46d4-84ed-e5479d591f17",
+      "ConcordiaCourseId": "031790"
+    },
+    {
+      "Id": "466c6521-7fce-47c9-9ec8-f0d3eafd51ac",
+      "ConcordiaCourseId": "031793"
+    },
+    {
+      "Id": "b671a236-fbb2-43c1-92ff-4412b15b0a95",
+      "ConcordiaCourseId": "031797"
+    },
+    {
+      "Id": "062f1b1f-b5a9-4579-9a48-5d4a6e199cc2",
+      "ConcordiaCourseId": "031802"
+    },
+    {
+      "Id": "0de86abd-f5a4-4fc3-909e-10817fde390b",
+      "ConcordiaCourseId": "031814"
+    },
+    {
+      "Id": "742f70e8-fee5-4e15-94a1-02de3e2cc230",
+      "ConcordiaCourseId": "042537"
+    },
+    {
+      "Id": "b5ec9b39-282e-4012-9430-968b3ae1854b",
+      "ConcordiaCourseId": "042540"
+    },
+    {
+      "Id": "dfd1e90b-fac3-48bc-b17f-fc6e64bd8762",
+      "ConcordiaCourseId": "042541"
+    },
+    {
+      "Id": "f92a3a5e-a726-4041-859c-57b3f277c8c5",
+      "ConcordiaCourseId": "042551"
+    },
+    {
+      "Id": "d2ef2293-f005-4dea-ab47-cb3cd0e9ca4a",
+      "ConcordiaCourseId": "046392"
+    },
+    {
+      "Id": "c3915951-323a-49ae-85c8-1deac968f397",
+      "ConcordiaCourseId": "047083"
+    },
+    {
+      "Id": "7888b6ea-670f-4972-bc47-a5168231af78",
+      "ConcordiaCourseId": "047084"
+    },
+    {
+      "Id": "8371c492-1cd9-46cb-bbb8-bb31085e66dd",
+      "ConcordiaCourseId": "047085"
+    },
+    {
+      "Id": "f6e08fc8-adc2-4996-b3d4-31776f2bc551",
+      "ConcordiaCourseId": "047086"
+    },
+    {
+      "Id": "d0ed27e4-04f9-407b-8ba7-e4f7c8e9dcaf",
+      "ConcordiaCourseId": "047087"
+    },
+    {
+      "Id": "d0bad72f-c235-475c-9599-ebb165d44bf1",
+      "ConcordiaCourseId": "047088"
+    },
+    {
+      "Id": "96fef165-e60d-4bfc-9cef-c53ba0679d9f",
+      "ConcordiaCourseId": "047089"
+    },
+    {
+      "Id": "14088692-5e78-49db-8461-28f89b9471e5",
+      "ConcordiaCourseId": "047090"
+    },
+    {
+      "Id": "63ac2180-2669-4a2d-be43-c154dfa4fc69",
+      "ConcordiaCourseId": "047091"
+    },
+    {
+      "Id": "e321c8fe-6659-4acc-a338-3272be22e4a8",
+      "ConcordiaCourseId": "047092"
+    },
+    {
+      "Id": "88eac25d-5872-4ddc-854d-4d3a306aafb2",
+      "ConcordiaCourseId": "047093"
+    },
+    {
+      "Id": "48f011ee-ee93-4331-a0bc-883a9a15b18b",
+      "ConcordiaCourseId": "047094"
+    },
+    {
+      "Id": "c51933eb-8600-41bf-a5c2-e870b27677df",
+      "ConcordiaCourseId": "047095"
+    },
+    {
+      "Id": "03af1815-84a1-438a-bbf1-c0fccf335d60",
+      "ConcordiaCourseId": "047096"
+    },
+    {
+      "Id": "266e09b6-5469-46c8-b467-ccf482ef7793",
+      "ConcordiaCourseId": "047097"
+    },
+    {
+      "Id": "0c2341b3-d9fe-45b8-a0cd-2cc31dfd71bf",
+      "ConcordiaCourseId": "047098"
+    },
+    {
+      "Id": "7cda3c92-c19d-41f5-8e50-cfe6f7164237",
+      "ConcordiaCourseId": "047099"
+    },
+    {
+      "Id": "4243f7aa-b581-4f60-b104-91882224199e",
+      "ConcordiaCourseId": "047204"
+    },
+    {
+      "Id": "fec11d15-1c6a-4bb8-bd7e-0e11d5ff9147",
+      "ConcordiaCourseId": "047257"
+    },
+    {
+      "Id": "a805c139-ee9e-4ab7-a909-680158eb303d",
+      "ConcordiaCourseId": "047373"
+    },
+    {
+      "Id": "12553e3e-5d0a-4244-bd49-c09300673867",
+      "ConcordiaCourseId": "047496"
+    },
+    {
+      "Id": "61554d6c-9ad3-42c2-a24c-ec88dfcebb59",
+      "ConcordiaCourseId": "047798"
+    },
+    {
+      "Id": "6a97c757-4657-4c9f-a725-d8a61bd77d89",
+      "ConcordiaCourseId": "048301"
+    },
+    {
+      "Id": "1d2bd8c3-8b2b-4cfd-8f52-c3b4cf6ce6a6",
+      "ConcordiaCourseId": "048302"
+    },
+    {
+      "Id": "29c21e30-ed3e-4ae1-a124-61cafa23360f",
+      "ConcordiaCourseId": "048773"
+    },
+    {
+      "Id": "cef15c43-340f-4960-8bad-dd088d4cf5a6",
+      "ConcordiaCourseId": "048832"
+    },
+    {
+      "Id": "a7a22bd3-a0e9-4e1c-ba46-2254e182b3f2",
+      "ConcordiaCourseId": "049184"
+    },
+    {
+      "Id": "779f1fa4-bb38-412b-a808-dc7377fe35cf",
+      "ConcordiaCourseId": "049213"
+    },
+    {
+      "Id": "c8340fab-c567-4186-9ace-5870a5e0ca4f",
+      "ConcordiaCourseId": "050311"
+    },
+    {
+      "Id": "d0e0e9e1-f255-4dc4-a9bf-52ce53bb2368",
+      "ConcordiaCourseId": "050631"
+    },
+    {
+      "Id": "ddf2c912-908d-4baf-9165-1f5e34e0e0fa",
+      "ConcordiaCourseId": "050632"
+    },
+    {
+      "Id": "989133bf-68ff-419b-804b-b5f3c05bf815",
+      "ConcordiaCourseId": "050717"
+    },
+    {
+      "Id": "5b7a0541-74cb-444f-b129-b3aada88ef5e",
+      "ConcordiaCourseId": "032001"
+    },
+    {
+      "Id": "8c2d6a53-1816-42f1-8fd9-5bc192c24f62",
+      "ConcordiaCourseId": "032004"
+    },
+    {
+      "Id": "ca6c37fe-b6ab-469a-ae01-aee5c01e1466",
+      "ConcordiaCourseId": "032005"
+    },
+    {
+      "Id": "4d63cfd9-e897-4ed2-b9d4-ac1995d47f56",
+      "ConcordiaCourseId": "032006"
+    },
+    {
+      "Id": "b7c7c95d-6c3e-4f97-9c9f-00aa82ffca9d",
+      "ConcordiaCourseId": "032008"
+    },
+    {
+      "Id": "886dc3ab-e575-445b-9776-ab7d6490bd42",
+      "ConcordiaCourseId": "032009"
+    },
+    {
+      "Id": "4b59539d-20bf-4e62-9bed-4712fcc9b550",
+      "ConcordiaCourseId": "032010"
+    },
+    {
+      "Id": "2ebac821-97fc-4102-b01c-9bbeaa146dc2",
+      "ConcordiaCourseId": "032011"
+    },
+    {
+      "Id": "a3739990-cd92-4ed2-8da6-de66b304ed0f",
+      "ConcordiaCourseId": "032012"
+    },
+    {
+      "Id": "7d7c58c6-be7b-41ad-8fcb-57b1b5646dbe",
+      "ConcordiaCourseId": "032013"
+    },
+    {
+      "Id": "30a5957a-74db-47c1-bdc6-60c20a79d33f",
+      "ConcordiaCourseId": "032015"
+    },
+    {
+      "Id": "fb3e9856-e0b7-4bc2-81a4-e3fa86d82a37",
+      "ConcordiaCourseId": "032016"
+    },
+    {
+      "Id": "12d33dc3-34d5-4917-9ae5-345648283861",
+      "ConcordiaCourseId": "032017"
+    },
+    {
+      "Id": "f70c85bc-c82e-41c0-892f-907cf28934ef",
+      "ConcordiaCourseId": "032018"
+    },
+    {
+      "Id": "8be69d47-f3e5-446a-a20d-0e6ff93904e7",
+      "ConcordiaCourseId": "032020"
+    },
+    {
+      "Id": "579bc4f9-bfc5-4188-9f41-601033cbd383",
+      "ConcordiaCourseId": "032021"
+    },
+    {
+      "Id": "700bfa3c-33a8-42e2-ad1a-baf738add304",
+      "ConcordiaCourseId": "032026"
+    },
+    {
+      "Id": "9519e39c-a615-41bc-afa0-0c49de4e9af7",
+      "ConcordiaCourseId": "032027"
+    },
+    {
+      "Id": "dbe26030-9293-4497-a95e-9d68c1e6fca5",
+      "ConcordiaCourseId": "032029"
+    },
+    {
+      "Id": "521c61f7-7c25-4570-9e0f-75c4b039ab6e",
+      "ConcordiaCourseId": "032030"
+    },
+    {
+      "Id": "25bbce49-36fd-4384-8151-204692ab1b42",
+      "ConcordiaCourseId": "032031"
+    },
+    {
+      "Id": "622268e6-8bdd-4e96-8b56-c2bafacd9ba9",
+      "ConcordiaCourseId": "032032"
+    },
+    {
+      "Id": "9cfe8a54-8cbd-4d48-a184-193ada61ed7b",
+      "ConcordiaCourseId": "032033"
+    },
+    {
+      "Id": "a0f2229b-72ff-4350-be9e-e175735124ce",
+      "ConcordiaCourseId": "032034"
+    },
+    {
+      "Id": "686afd6d-df17-4ad0-994b-4fe75c132a9e",
+      "ConcordiaCourseId": "032035"
+    },
+    {
+      "Id": "c7a5ae16-f4fd-4f86-905e-a0337f482197",
+      "ConcordiaCourseId": "032036"
+    },
+    {
+      "Id": "39bc2dad-7298-4bdc-a887-4062bece6cee",
+      "ConcordiaCourseId": "032038"
+    },
+    {
+      "Id": "180e532e-fd48-4f23-94de-90769799e153",
+      "ConcordiaCourseId": "032039"
+    },
+    {
+      "Id": "ae36c95f-dfea-43f5-bbd8-9ed667150685",
+      "ConcordiaCourseId": "032043"
+    },
+    {
+      "Id": "ee16e0a2-dc5f-401d-b4cd-bedfd69aa7de",
+      "ConcordiaCourseId": "032044"
+    },
+    {
+      "Id": "106f1021-2c7a-4d50-a886-777c6da90b28",
+      "ConcordiaCourseId": "032045"
+    },
+    {
+      "Id": "a1405edc-44cf-4bf6-aee1-a710e44ee005",
+      "ConcordiaCourseId": "042553"
+    },
+    {
+      "Id": "49c8a4c0-ab43-42f1-acb9-5f6fb355ae82",
+      "ConcordiaCourseId": "044220"
+    },
+    {
+      "Id": "787ef997-5e28-4d64-96c8-8f58f638ceb7",
+      "ConcordiaCourseId": "044221"
+    },
+    {
+      "Id": "38b4d1fc-76fe-4959-b34f-19935a626abc",
+      "ConcordiaCourseId": "047100"
+    },
+    {
+      "Id": "d2e8cdfa-a959-4d39-8ac4-1e1a07acbdac",
+      "ConcordiaCourseId": "047101"
+    },
+    {
+      "Id": "34b26238-c3f8-4a82-8d3c-2c87945d0479",
+      "ConcordiaCourseId": "047209"
+    },
+    {
+      "Id": "f7bcf48a-0257-45ca-8978-0d6e4b9fab80",
+      "ConcordiaCourseId": "047979"
+    },
+    {
+      "Id": "64cdc6b1-63e8-4093-8e4a-c36dba4d63f9",
+      "ConcordiaCourseId": "048218"
+    },
+    {
+      "Id": "fadc48e9-2bce-477f-8ab8-7ee1eb771ba1",
+      "ConcordiaCourseId": "048693"
+    },
+    {
+      "Id": "f97b0493-0efb-4168-8cf9-0f4b3dbff247",
+      "ConcordiaCourseId": "048873"
+    },
+    {
+      "Id": "222324ea-9fcb-45ee-b239-0ac191781517",
+      "ConcordiaCourseId": "048957"
+    },
+    {
+      "Id": "def413b7-69fc-48f0-8c53-2fd9d3929366",
+      "ConcordiaCourseId": "049308"
+    },
+    {
+      "Id": "87515b83-4a42-4d90-a99c-009f5fb32b16",
+      "ConcordiaCourseId": "049507"
+    },
+    {
+      "Id": "2f74051e-b4ad-4544-8196-0a221d64b6b5",
+      "ConcordiaCourseId": "049698"
+    },
+    {
+      "Id": "677d2f99-6f70-40fd-a88e-0a6affd64ff4",
+      "ConcordiaCourseId": "049699"
+    },
+    {
+      "Id": "7931dd2b-180b-4f33-95d0-740d5a3aa47f",
+      "ConcordiaCourseId": "049702"
+    },
+    {
+      "Id": "b5e568f3-7e4f-4a5e-9e5d-d2aa9b88876e",
+      "ConcordiaCourseId": "050886"
+    },
+    {
+      "Id": "c3e86e9e-b742-4b31-a550-0fddb575aaa4",
+      "ConcordiaCourseId": "032070"
+    },
+    {
+      "Id": "60479c24-41a9-415c-9a8f-800f6af07656",
+      "ConcordiaCourseId": "032072"
+    },
+    {
+      "Id": "085f49b2-422d-4ee8-aead-71b22f328bf4",
+      "ConcordiaCourseId": "032073"
+    },
+    {
+      "Id": "07406d2d-8b56-4632-bcbc-11e5e4a809ba",
+      "ConcordiaCourseId": "032080"
+    },
+    {
+      "Id": "b5229a72-6918-4686-a645-c50dbb1be9a0",
+      "ConcordiaCourseId": "032081"
+    },
+    {
+      "Id": "b9d56a41-4078-4378-87f5-7ca557d33b08",
+      "ConcordiaCourseId": "032082"
+    },
+    {
+      "Id": "df3db193-810b-4b53-bf3d-bafb75a0e601",
+      "ConcordiaCourseId": "032097"
+    },
+    {
+      "Id": "6da68406-691b-42bd-a30d-641670a5b4dc",
+      "ConcordiaCourseId": "032098"
+    },
+    {
+      "Id": "af7b8a65-362b-4e84-a0f8-cbef6e320efe",
+      "ConcordiaCourseId": "032101"
+    },
+    {
+      "Id": "f70f15ca-ee2a-481e-aefe-e09c73ea49c3",
+      "ConcordiaCourseId": "032103"
+    },
+    {
+      "Id": "b3fd5780-2d81-43b8-9641-94b38b04bc6c",
+      "ConcordiaCourseId": "032104"
+    },
+    {
+      "Id": "c8ab7a88-8ffc-450d-8147-8abfcc50c853",
+      "ConcordiaCourseId": "032108"
+    },
+    {
+      "Id": "4c1c4713-cb0d-40ab-b306-41daaa81fd10",
+      "ConcordiaCourseId": "032109"
+    },
+    {
+      "Id": "4ed05f20-d5f3-4f9e-b1ab-6e8983e9c81f",
+      "ConcordiaCourseId": "032112"
+    },
+    {
+      "Id": "a95bc273-0524-4bd8-8884-6ed7def526a8",
+      "ConcordiaCourseId": "032113"
+    },
+    {
+      "Id": "da350895-5c9f-4c72-b21c-1ea6d5a08a14",
+      "ConcordiaCourseId": "032117"
+    },
+    {
+      "Id": "860d89ee-ad3d-4e92-913c-a5f292123f96",
+      "ConcordiaCourseId": "032119"
+    },
+    {
+      "Id": "b33f7e8d-741a-4f95-b97a-f8643ea7a160",
+      "ConcordiaCourseId": "032122"
+    },
+    {
+      "Id": "db3845d9-9341-4bb0-aae0-de3fade866d9",
+      "ConcordiaCourseId": "032123"
+    },
+    {
+      "Id": "31fb8723-9f7e-424e-8d9e-9b32b57704c4",
+      "ConcordiaCourseId": "032124"
+    },
+    {
+      "Id": "e28348e4-dfbd-45fb-92d7-1ca710d2ace5",
+      "ConcordiaCourseId": "032139"
+    },
+    {
+      "Id": "1355e2d9-7e57-4b2c-a9bf-b8ee19d7bdea",
+      "ConcordiaCourseId": "032147"
+    },
+    {
+      "Id": "05a32050-946f-4509-baf5-72962925f905",
+      "ConcordiaCourseId": "032151"
+    },
+    {
+      "Id": "da0a7428-20ff-4495-9123-486e9e092b2c",
+      "ConcordiaCourseId": "032152"
+    },
+    {
+      "Id": "cb88447a-bf43-408b-a425-de9cac4d4f9b",
+      "ConcordiaCourseId": "032153"
+    },
+    {
+      "Id": "6b85f1a4-92a9-4477-bf14-31eee51091ad",
+      "ConcordiaCourseId": "032156"
+    },
+    {
+      "Id": "ee65213d-02b3-4dfe-8be9-d4d0c30140f5",
+      "ConcordiaCourseId": "032158"
+    },
+    {
+      "Id": "1fa53b10-fefa-4251-9f25-881512377bd8",
+      "ConcordiaCourseId": "032161"
+    },
+    {
+      "Id": "6c3a13fd-871f-4ce5-a2f7-1c3d8626697c",
+      "ConcordiaCourseId": "032173"
+    },
+    {
+      "Id": "f4bd39be-8062-440b-ae93-eba0586d4d78",
+      "ConcordiaCourseId": "032174"
+    },
+    {
+      "Id": "396a5a7b-5301-4d4a-a42b-dca7751c51fc",
+      "ConcordiaCourseId": "032175"
+    },
+    {
+      "Id": "fe42612b-1807-4f41-b2f7-b181dd25a690",
+      "ConcordiaCourseId": "032177"
+    },
+    {
+      "Id": "fa382c94-5143-4f9c-bde4-8ab064ae7d4b",
+      "ConcordiaCourseId": "032180"
+    },
+    {
+      "Id": "223d33d9-3a42-4e2b-b658-12deea6672ba",
+      "ConcordiaCourseId": "032181"
+    },
+    {
+      "Id": "a8f41f37-d8ae-4e4d-8b33-db89b3ae8309",
+      "ConcordiaCourseId": "032182"
+    },
+    {
+      "Id": "655f5386-b69b-4543-9c66-51ce0788e5d0",
+      "ConcordiaCourseId": "032184"
+    },
+    {
+      "Id": "6297f3f3-12c7-4513-a1f0-7a06e31f9e15",
+      "ConcordiaCourseId": "032185"
+    },
+    {
+      "Id": "ff1cd4b7-5804-4bd0-98af-579b46faee34",
+      "ConcordiaCourseId": "032186"
+    },
+    {
+      "Id": "c105bb5c-0ce7-4d9a-ba03-db34d2337148",
+      "ConcordiaCourseId": "032187"
+    },
+    {
+      "Id": "4fb46a29-bcba-456f-9fe5-1e4065c66627",
+      "ConcordiaCourseId": "032188"
+    },
+    {
+      "Id": "33d113e0-2640-41c9-893c-4ad7a16a288f",
+      "ConcordiaCourseId": "032189"
+    },
+    {
+      "Id": "f0d3cacc-156f-4bb1-a94d-c8f20b8cbc6e",
+      "ConcordiaCourseId": "032190"
+    },
+    {
+      "Id": "b1d13a82-eca1-4af3-ac7c-adf4ec556c6e",
+      "ConcordiaCourseId": "032191"
+    },
+    {
+      "Id": "538c0059-e3ff-46d9-bd57-1a6e0af1a12d",
+      "ConcordiaCourseId": "032192"
+    },
+    {
+      "Id": "cb571e8e-1b03-4124-980e-1bd37efc2255",
+      "ConcordiaCourseId": "032204"
+    },
+    {
+      "Id": "dd3476f3-6768-4679-aca2-2325c55aa876",
+      "ConcordiaCourseId": "032207"
+    },
+    {
+      "Id": "134e95fe-abd4-4e7c-8beb-e6e8479c013e",
+      "ConcordiaCourseId": "032209"
+    },
+    {
+      "Id": "f488dee4-7734-4484-943a-6e846f2eb54a",
+      "ConcordiaCourseId": "032211"
+    },
+    {
+      "Id": "78432fbd-ba22-4b37-a0aa-f2d041060122",
+      "ConcordiaCourseId": "032212"
+    },
+    {
+      "Id": "a6722eea-1877-4e39-a930-780561eb1459",
+      "ConcordiaCourseId": "032243"
+    },
+    {
+      "Id": "43c8671b-05a1-4569-bad0-c201a6b01aaf",
+      "ConcordiaCourseId": "032244"
+    },
+    {
+      "Id": "372d744e-e9b1-45f7-8680-790f0ffadfd8",
+      "ConcordiaCourseId": "032248"
+    },
+    {
+      "Id": "3cb05477-d786-4405-a2be-786752478781",
+      "ConcordiaCourseId": "032250"
+    },
+    {
+      "Id": "e20a57a8-d8cd-4a81-a1b7-1a8393a98dd2",
+      "ConcordiaCourseId": "032253"
+    },
+    {
+      "Id": "a73c73f1-afa2-4d8b-961b-b4af77aafc6c",
+      "ConcordiaCourseId": "032254"
+    },
+    {
+      "Id": "4da6a759-43c1-41ab-b9ae-a570416ab473",
+      "ConcordiaCourseId": "032255"
+    },
+    {
+      "Id": "7ba6173e-38af-4162-93b9-e1c3d0d37aee",
+      "ConcordiaCourseId": "032261"
+    },
+    {
+      "Id": "7624d655-20de-473e-9ded-372e728184e2",
+      "ConcordiaCourseId": "032262"
+    },
+    {
+      "Id": "2f67c362-46f6-4a5a-92ee-298b05a6dbbc",
+      "ConcordiaCourseId": "042560"
+    },
+    {
+      "Id": "2b7ccfbe-63d1-441a-8342-7b7c286b4e0d",
+      "ConcordiaCourseId": "042562"
+    },
+    {
+      "Id": "5e39a003-34b5-468d-9053-2b402621a50c",
+      "ConcordiaCourseId": "042563"
+    },
+    {
+      "Id": "d85f2b72-b784-4d39-8fd1-3294c74d7cdf",
+      "ConcordiaCourseId": "047102"
+    },
+    {
+      "Id": "711dface-5382-40aa-bbbe-7ad8ced96bad",
+      "ConcordiaCourseId": "047103"
+    },
+    {
+      "Id": "f310948f-23c4-480d-9e21-dccec6c30960",
+      "ConcordiaCourseId": "047104"
+    },
+    {
+      "Id": "f575df15-a992-47fb-9f58-16ad3f8a11f3",
+      "ConcordiaCourseId": "047105"
+    },
+    {
+      "Id": "1793b18f-8f8d-44c9-b67f-921035037b90",
+      "ConcordiaCourseId": "047260"
+    },
+    {
+      "Id": "ca36b1fb-8974-476d-8c3f-344bc0d7f914",
+      "ConcordiaCourseId": "047261"
+    },
+    {
+      "Id": "961d4204-bf04-4003-a736-d20423f74d3e",
+      "ConcordiaCourseId": "047404"
+    },
+    {
+      "Id": "693cd7d7-d204-4288-be8e-c3fbe18f128c",
+      "ConcordiaCourseId": "048196"
+    },
+    {
+      "Id": "8d9b6ea9-3f9b-4e30-8717-625535874e62",
+      "ConcordiaCourseId": "048197"
+    },
+    {
+      "Id": "7db6fbb9-7b5d-4283-aed7-66276aa5c559",
+      "ConcordiaCourseId": "048402"
+    },
+    {
+      "Id": "51fe5823-9256-4653-b832-e88124e55ae3",
+      "ConcordiaCourseId": "048403"
+    },
+    {
+      "Id": "ea12a290-1186-4600-bc21-21945d8d5874",
+      "ConcordiaCourseId": "032355"
+    },
+    {
+      "Id": "84fdae34-e058-4c43-b826-b1e57d050304",
+      "ConcordiaCourseId": "032361"
+    },
+    {
+      "Id": "51c5ec6a-7e02-45b0-b221-c73816af8f4b",
+      "ConcordiaCourseId": "032366"
+    },
+    {
+      "Id": "6ec0e010-ac9a-437c-9d78-faabe45eb27b",
+      "ConcordiaCourseId": "032370"
+    },
+    {
+      "Id": "5574bb8e-ac6e-4afb-9d37-a7bcd62e945b",
+      "ConcordiaCourseId": "032376"
+    },
+    {
+      "Id": "fd34e304-9cfa-41a5-8870-616310d3c305",
+      "ConcordiaCourseId": "032382"
+    },
+    {
+      "Id": "68da3ae3-65d6-4cc7-b076-7005d315cb93",
+      "ConcordiaCourseId": "032387"
+    },
+    {
+      "Id": "10a6382b-9359-4f80-9992-7959e0daf131",
+      "ConcordiaCourseId": "032393"
+    },
+    {
+      "Id": "3bf049ae-23ce-42e8-8ba0-33a3c409de13",
+      "ConcordiaCourseId": "032397"
+    },
+    {
+      "Id": "aefe5682-5b10-4138-92cf-437bcea8f0d3",
+      "ConcordiaCourseId": "032401"
+    },
+    {
+      "Id": "77c5b5b0-601c-4f7a-ba9c-c5dca23f6736",
+      "ConcordiaCourseId": "032405"
+    },
+    {
+      "Id": "e2b0606c-72a0-4fd0-b083-a54afd52add1",
+      "ConcordiaCourseId": "032410"
+    },
+    {
+      "Id": "a068d60d-8d57-472c-bc89-9d179a9e4521",
+      "ConcordiaCourseId": "032414"
+    },
+    {
+      "Id": "5f0a4f59-203d-4c0d-abb3-fe780fe47d5f",
+      "ConcordiaCourseId": "032417"
+    },
+    {
+      "Id": "854ade4e-a38e-48da-a7b1-9d5476033818",
+      "ConcordiaCourseId": "032420"
+    },
+    {
+      "Id": "738982a4-9fa3-411f-b97b-5018496106ec",
+      "ConcordiaCourseId": "032425"
+    },
+    {
+      "Id": "98d27ba2-05d4-4193-9ad8-0492487a252b",
+      "ConcordiaCourseId": "032429"
+    },
+    {
+      "Id": "3331a2ba-389a-4a5c-aca4-f41781b6739b",
+      "ConcordiaCourseId": "032434"
+    },
+    {
+      "Id": "5b204654-af3c-4e4f-b634-6428a0757866",
+      "ConcordiaCourseId": "032438"
+    },
+    {
+      "Id": "f1796fea-d69d-478b-97b6-4884922c02fc",
+      "ConcordiaCourseId": "032440"
+    },
+    {
+      "Id": "9d878cd9-a555-4790-995b-ef319a619c37",
+      "ConcordiaCourseId": "032445"
+    },
+    {
+      "Id": "be9edaa6-2a0f-4c19-b2c8-494efc2f47bc",
+      "ConcordiaCourseId": "032468"
+    },
+    {
+      "Id": "71cc7ada-b957-4120-9f06-7249e193d70b",
+      "ConcordiaCourseId": "032494"
+    },
+    {
+      "Id": "3eb07344-d428-4c73-99f0-d827571dacdc",
+      "ConcordiaCourseId": "032521"
+    },
+    {
+      "Id": "4bb3fbcf-3c67-4713-ad94-8e5371a95bb7",
+      "ConcordiaCourseId": "032547"
+    },
+    {
+      "Id": "ccf68801-d6ce-44bf-b157-a13200c3c272",
+      "ConcordiaCourseId": "032573"
+    },
+    {
+      "Id": "308c7813-a1ae-4abe-8272-68c518dcedaf",
+      "ConcordiaCourseId": "032600"
+    },
+    {
+      "Id": "cd16832d-618a-4922-a797-99ce363c9023",
+      "ConcordiaCourseId": "032623"
+    },
+    {
+      "Id": "245fb66e-7cac-4cb3-a611-90e26804e88a",
+      "ConcordiaCourseId": "032648"
+    },
+    {
+      "Id": "838f968e-9374-464e-9440-e4920c305d2c",
+      "ConcordiaCourseId": "032671"
+    },
+    {
+      "Id": "b37282c3-4613-4e81-9753-861467287490",
+      "ConcordiaCourseId": "032695"
+    },
+    {
+      "Id": "5fe90f7b-7c16-4be8-a672-3570c79d7794",
+      "ConcordiaCourseId": "032719"
+    },
+    {
+      "Id": "782fc743-ed5d-4c30-8382-3553f79ebd3e",
+      "ConcordiaCourseId": "032742"
+    },
+    {
+      "Id": "b90d3ec7-ee4e-4d16-bc71-18d779beb9b5",
+      "ConcordiaCourseId": "032761"
+    },
+    {
+      "Id": "b7496296-1423-47bd-a6ea-1a26ec86de9c",
+      "ConcordiaCourseId": "032808"
+    },
+    {
+      "Id": "51859d96-03a1-47fa-b57a-186d4957ef49",
+      "ConcordiaCourseId": "032832"
+    },
+    {
+      "Id": "d4eb35cb-e77b-45b9-b00d-7e7a15711265",
+      "ConcordiaCourseId": "032855"
+    },
+    {
+      "Id": "8903d370-6fcc-46c2-b0c1-cf01c0ce053c",
+      "ConcordiaCourseId": "032878"
+    },
+    {
+      "Id": "a189deb9-4d15-4897-a2f0-185a528fdfd1",
+      "ConcordiaCourseId": "032900"
+    },
+    {
+      "Id": "602dfa88-9bee-43a4-9d81-f85c0d60e934",
+      "ConcordiaCourseId": "032926"
+    },
+    {
+      "Id": "ef7d403c-dace-473b-861c-76317a1c9fc0",
+      "ConcordiaCourseId": "032928"
+    },
+    {
+      "Id": "4dce5cf1-93a4-4fdd-a67d-a2da4877d3ce",
+      "ConcordiaCourseId": "032930"
+    },
+    {
+      "Id": "552d5243-78a1-4f0c-bc04-6aa03da3fa3a",
+      "ConcordiaCourseId": "032932"
+    },
+    {
+      "Id": "f0ee9c1a-bdc0-4363-a93a-4d224e57e165",
+      "ConcordiaCourseId": "032934"
+    },
+    {
+      "Id": "0c9ac60a-87a4-4f47-91ac-ad58ac35b0aa",
+      "ConcordiaCourseId": "032937"
+    },
+    {
+      "Id": "56b404d5-eaa7-4493-9916-2fe8dafb8fbf",
+      "ConcordiaCourseId": "032940"
+    },
+    {
+      "Id": "3134cf18-209a-4fdd-9247-aa9fab2798b2",
+      "ConcordiaCourseId": "032943"
+    },
+    {
+      "Id": "e1762568-a66a-4937-9d08-9c946fce9711",
+      "ConcordiaCourseId": "032947"
+    },
+    {
+      "Id": "68eab0db-d4d2-463f-98e3-ad3bc411d7e4",
+      "ConcordiaCourseId": "032961"
+    },
+    {
+      "Id": "5bb50942-08c1-4521-b630-319870580b1c",
+      "ConcordiaCourseId": "032974"
+    },
+    {
+      "Id": "d4b2253c-4807-44ac-9d98-186a4c9ccd6b",
+      "ConcordiaCourseId": "032975"
+    },
+    {
+      "Id": "4ef3f89a-073a-4a9d-bb0c-be0d7bfe9e26",
+      "ConcordiaCourseId": "032982"
+    },
+    {
+      "Id": "2c22c696-6ad7-404d-b93c-63d56a36ae89",
+      "ConcordiaCourseId": "032986"
+    },
+    {
+      "Id": "31e3da2f-2bea-414c-affb-2f659aa59a0e",
+      "ConcordiaCourseId": "032991"
+    },
+    {
+      "Id": "04b705e4-5450-4eb2-8d78-445add2412e0",
+      "ConcordiaCourseId": "032996"
+    },
+    {
+      "Id": "bd9a1ad8-8a6f-4108-a34c-041802c9c6b4",
+      "ConcordiaCourseId": "033000"
+    },
+    {
+      "Id": "26605a53-b5bb-4b5f-9fcb-e6c5210f1e56",
+      "ConcordiaCourseId": "033006"
+    },
+    {
+      "Id": "97f0fac0-875f-4e7d-a395-056a366e3489",
+      "ConcordiaCourseId": "033014"
+    },
+    {
+      "Id": "f692339d-1680-44c1-ba08-de5991722051",
+      "ConcordiaCourseId": "033019"
+    },
+    {
+      "Id": "246d2944-5dcd-4306-bf6d-df0d5ee0bd51",
+      "ConcordiaCourseId": "033024"
+    },
+    {
+      "Id": "6d82c4f0-9b89-43c8-a86d-7b5990ae5da2",
+      "ConcordiaCourseId": "033027"
+    },
+    {
+      "Id": "faeee099-487f-42a4-b033-e91e12d7cd9f",
+      "ConcordiaCourseId": "033031"
+    },
+    {
+      "Id": "49ecbc70-7e25-4cf4-9825-6b0e1b7c4506",
+      "ConcordiaCourseId": "033036"
+    },
+    {
+      "Id": "f5ae73ab-fe53-45be-a8d4-b0563be94217",
+      "ConcordiaCourseId": "033042"
+    },
+    {
+      "Id": "a97af4f0-9fb4-4fb7-9357-bd46243fe043",
+      "ConcordiaCourseId": "033047"
+    },
+    {
+      "Id": "da86fd73-8afb-401f-8a92-8674234bb649",
+      "ConcordiaCourseId": "033051"
+    },
+    {
+      "Id": "6846b9d9-684d-4e51-969c-778d463239e7",
+      "ConcordiaCourseId": "033055"
+    },
+    {
+      "Id": "2ccec414-c712-495e-b743-e34bc772c082",
+      "ConcordiaCourseId": "033060"
+    },
+    {
+      "Id": "9ce4dfec-3c2f-4003-8581-4685c0be1e76",
+      "ConcordiaCourseId": "033064"
+    },
+    {
+      "Id": "6ac614b0-5661-4342-97bf-086cb85eab19",
+      "ConcordiaCourseId": "033068"
+    },
+    {
+      "Id": "414a6f18-0461-4f15-9a82-bc6c313e0d41",
+      "ConcordiaCourseId": "033091"
+    },
+    {
+      "Id": "f0f44362-d257-4e45-b811-eea8f58bc342",
+      "ConcordiaCourseId": "033113"
+    },
+    {
+      "Id": "2d6544aa-9567-4bb7-be25-bea56bdd2846",
+      "ConcordiaCourseId": "033134"
+    },
+    {
+      "Id": "8a5c6587-3996-4be1-a05f-282718c6f2f3",
+      "ConcordiaCourseId": "033153"
+    },
+    {
+      "Id": "1dfb4f75-24b0-4415-839c-c05955a380e9",
+      "ConcordiaCourseId": "033173"
+    },
+    {
+      "Id": "2fc932dd-eac9-4f07-90c3-ff7badc363b1",
+      "ConcordiaCourseId": "033192"
+    },
+    {
+      "Id": "337f911c-98b7-44f5-a294-6feea0415cd0",
+      "ConcordiaCourseId": "033213"
+    },
+    {
+      "Id": "6246f4e7-5676-47e0-b97a-d2e318183663",
+      "ConcordiaCourseId": "033233"
+    },
+    {
+      "Id": "b5931873-4306-4035-8872-2aa3f1e9f6a8",
+      "ConcordiaCourseId": "033254"
+    },
+    {
+      "Id": "3204738d-8f03-4045-8cd4-59b4f3234c7e",
+      "ConcordiaCourseId": "033276"
+    },
+    {
+      "Id": "25a71d1b-85bf-47e4-996e-dd00bc83e67f",
+      "ConcordiaCourseId": "033298"
+    },
+    {
+      "Id": "542356a3-235e-49ed-97d0-d8c40f2f9d38",
+      "ConcordiaCourseId": "033321"
+    },
+    {
+      "Id": "deb623dd-c975-4e50-9175-15721bc4ebb6",
+      "ConcordiaCourseId": "033339"
+    },
+    {
+      "Id": "88504d14-e22e-4fc1-ad76-b45418795e98",
+      "ConcordiaCourseId": "033359"
+    },
+    {
+      "Id": "0e31898a-9da0-48e0-8303-184be375dfab",
+      "ConcordiaCourseId": "033380"
+    },
+    {
+      "Id": "f1b20ed4-e88a-4d7b-8523-e05e82e57c46",
+      "ConcordiaCourseId": "033416"
+    },
+    {
+      "Id": "e812482b-cd4c-4b50-91a5-0661ac6f8a78",
+      "ConcordiaCourseId": "033467"
+    },
+    {
+      "Id": "ebe2ace2-12c7-48d8-8974-3caa5e673dd1",
+      "ConcordiaCourseId": "033470"
+    },
+    {
+      "Id": "8cb21e65-7157-4e67-bfb4-191fd900962c",
+      "ConcordiaCourseId": "033472"
+    },
+    {
+      "Id": "34743034-378d-4c49-9698-95a9e1da869b",
+      "ConcordiaCourseId": "033475"
+    },
+    {
+      "Id": "443ce112-8460-47b0-a685-157cbeb67a41",
+      "ConcordiaCourseId": "033478"
+    },
+    {
+      "Id": "6c6a5ffb-bbd5-4631-8629-52762863e73a",
+      "ConcordiaCourseId": "033481"
+    },
+    {
+      "Id": "5bbf717e-1e07-47ea-b7b8-0107ac70894c",
+      "ConcordiaCourseId": "033490"
+    },
+    {
+      "Id": "4dc04a5b-530c-493a-ad21-136fd3a409c4",
+      "ConcordiaCourseId": "033495"
+    },
+    {
+      "Id": "7d55c2dd-539a-4d45-bbde-dbb5efd84ff2",
+      "ConcordiaCourseId": "033498"
+    },
+    {
+      "Id": "892f328e-649f-49f0-8d3e-093469a4510f",
+      "ConcordiaCourseId": "033518"
+    },
+    {
+      "Id": "c4eb7e57-46f5-4641-8d59-63e23ccbaf32",
+      "ConcordiaCourseId": "033536"
+    },
+    {
+      "Id": "5fab1b40-764c-4d4c-8d55-7a9b7e6d024a",
+      "ConcordiaCourseId": "042609"
+    },
+    {
+      "Id": "789e366c-fbf8-4760-8503-af8ea5d198e9",
+      "ConcordiaCourseId": "042680"
+    },
+    {
+      "Id": "95e09b2e-c64b-4d16-ad9b-8e22da6adf83",
+      "ConcordiaCourseId": "042681"
+    },
+    {
+      "Id": "54e6aec1-02d5-47c7-b287-dfec0db30380",
+      "ConcordiaCourseId": "045804"
+    },
+    {
+      "Id": "39082596-b3e1-4db5-9b5c-e92604aa64ca",
+      "ConcordiaCourseId": "047106"
+    },
+    {
+      "Id": "798362d8-409c-4e3f-84d8-b9f83769ceda",
+      "ConcordiaCourseId": "047107"
+    },
+    {
+      "Id": "b2dee4bf-0922-4d0e-9d62-7c5d9912ee61",
+      "ConcordiaCourseId": "047108"
+    },
+    {
+      "Id": "8d67838e-2496-4c2b-b951-0bf2c8d8f400",
+      "ConcordiaCourseId": "047109"
+    },
+    {
+      "Id": "3c969f58-5b52-4f92-bc8e-94f9cef5130a",
+      "ConcordiaCourseId": "047110"
+    },
+    {
+      "Id": "23660907-188d-4370-a2c7-518c05f3ef22",
+      "ConcordiaCourseId": "047111"
+    },
+    {
+      "Id": "356d246e-050e-4ef8-bfe0-90a219368bb3",
+      "ConcordiaCourseId": "047112"
+    },
+    {
+      "Id": "a1eaba64-136a-4c21-9727-dcc1a8ba8e4a",
+      "ConcordiaCourseId": "047113"
+    },
+    {
+      "Id": "1c2a4326-198f-445b-ae20-83d37c2f8f7a",
+      "ConcordiaCourseId": "049203"
+    },
+    {
+      "Id": "9537731a-c580-4789-9e97-5932559354a7",
+      "ConcordiaCourseId": "049298"
+    },
+    {
+      "Id": "39e7b356-d519-4ca7-a244-e61d94e52ddc",
+      "ConcordiaCourseId": "049299"
+    },
+    {
+      "Id": "9739456f-85de-4816-895e-f118db8e1d6c",
+      "ConcordiaCourseId": "049300"
+    },
+    {
+      "Id": "5ed577f2-23fe-4e28-b694-ed45fca0d6ca",
+      "ConcordiaCourseId": "049301"
+    },
+    {
+      "Id": "f07407a2-f394-45e3-a1ef-2164671c6901",
+      "ConcordiaCourseId": "049360"
+    },
+    {
+      "Id": "13dd9a00-56ba-42ba-99bf-bb8f323b25c7",
+      "ConcordiaCourseId": "049402"
+    },
+    {
+      "Id": "f50c762b-a9c4-4444-acc3-6f2da44d4e19",
+      "ConcordiaCourseId": "049403"
+    },
+    {
+      "Id": "cedb61a9-b401-4813-9a84-fc2f37c560a1",
+      "ConcordiaCourseId": "050097"
+    },
+    {
+      "Id": "2c9188f2-7bd5-4d9a-a374-881f6b89a697",
+      "ConcordiaCourseId": "050696"
+    },
+    {
+      "Id": "d58924f1-7637-43ab-b726-db6394b00940",
+      "ConcordiaCourseId": "049275"
+    },
+    {
+      "Id": "c72a97d6-1c7d-4d72-822b-3482f45dc703",
+      "ConcordiaCourseId": "049276"
+    },
+    {
+      "Id": "fc4b777f-32e9-46c0-a5d9-532936a37146",
+      "ConcordiaCourseId": "049277"
+    },
+    {
+      "Id": "5c173df8-89bd-457a-aa56-d0dd9f3d363a",
+      "ConcordiaCourseId": "049535"
+    },
+    {
+      "Id": "4aaf2de4-5a18-49d5-90b7-52a1530bb3f2",
+      "ConcordiaCourseId": "049536"
+    },
+    {
+      "Id": "2b33a9e2-768f-49e0-b6c1-30a80bb3393a",
+      "ConcordiaCourseId": "049537"
+    },
+    {
+      "Id": "f47b3b1c-b878-4773-99a3-5d1c48ac871e",
+      "ConcordiaCourseId": "033558"
+    },
+    {
+      "Id": "80b9e40d-3830-4918-b181-3f1d7b2e907e",
+      "ConcordiaCourseId": "033559"
+    },
+    {
+      "Id": "eef14347-3a6d-4bf5-a48f-4a8be93f8148",
+      "ConcordiaCourseId": "033560"
+    },
+    {
+      "Id": "cf256f80-4834-4467-9fec-7cb5ec09cb8f",
+      "ConcordiaCourseId": "033561"
+    },
+    {
+      "Id": "9b091093-a34d-4f5d-a51c-adefdd55d805",
+      "ConcordiaCourseId": "033562"
+    },
+    {
+      "Id": "a4e489aa-52f9-4bb7-ae3e-4665c9ab014d",
+      "ConcordiaCourseId": "033563"
+    },
+    {
+      "Id": "b12863de-c739-47a8-ae72-d3172a3b456e",
+      "ConcordiaCourseId": "033564"
+    },
+    {
+      "Id": "5884c5ee-ccbe-4a78-9cea-be28cf18c67d",
+      "ConcordiaCourseId": "033566"
+    },
+    {
+      "Id": "e1eadc63-9121-4bb6-9aca-d6b4c998be4a",
+      "ConcordiaCourseId": "033567"
+    },
+    {
+      "Id": "2d54269d-8a4f-42e8-8d96-62980165c57e",
+      "ConcordiaCourseId": "033568"
+    },
+    {
+      "Id": "4e9a7311-e217-4871-a634-bf507b3d715f",
+      "ConcordiaCourseId": "033569"
+    },
+    {
+      "Id": "44c35c96-1be9-47d5-910b-dbbe9b654b0a",
+      "ConcordiaCourseId": "033570"
+    },
+    {
+      "Id": "7be82a4a-232f-4a95-acaf-afc616d38a4e",
+      "ConcordiaCourseId": "033571"
+    },
+    {
+      "Id": "414a02c5-d4ee-4841-a202-0694d5d81ebd",
+      "ConcordiaCourseId": "033572"
+    },
+    {
+      "Id": "02f9eea1-d2eb-43dd-a605-355df9d0b7b3",
+      "ConcordiaCourseId": "033573"
+    },
+    {
+      "Id": "982e74e2-9674-4498-9e37-ab321b2b6dd7",
+      "ConcordiaCourseId": "033576"
+    },
+    {
+      "Id": "d7c00e7b-43d1-44bd-8fb0-62c4ade48543",
+      "ConcordiaCourseId": "033580"
+    },
+    {
+      "Id": "acdd5293-248f-4915-a5c6-a3d3c5dc5272",
+      "ConcordiaCourseId": "045809"
+    },
+    {
+      "Id": "f97402e0-a90f-4fec-b971-1fe8824de0d3",
+      "ConcordiaCourseId": "049629"
+    },
+    {
+      "Id": "9ebdfa89-60e9-4cb4-9224-22dde6f11337",
+      "ConcordiaCourseId": "049630"
+    },
+    {
+      "Id": "21a13619-3447-4a60-a93a-dbb734b71c0e",
+      "ConcordiaCourseId": "050510"
+    },
+    {
+      "Id": "2301747e-735f-4d86-afb2-fc307227f099",
+      "ConcordiaCourseId": "033585"
+    },
+    {
+      "Id": "f616f3a1-4e9d-4eda-8ef8-ccad0f7d6e08",
+      "ConcordiaCourseId": "047178"
+    },
+    {
+      "Id": "7e3518f8-fd2f-4de7-9f96-a6847fc458f1",
+      "ConcordiaCourseId": "033613"
+    },
+    {
+      "Id": "fe4a2666-2444-4021-bccc-a9ae93e98f5d",
+      "ConcordiaCourseId": "033614"
+    },
+    {
+      "Id": "07f1e59b-78ef-4ab2-8429-2df77b44e180",
+      "ConcordiaCourseId": "033617"
+    },
+    {
+      "Id": "416d3870-ccc8-494b-91b1-353f4d22e86b",
+      "ConcordiaCourseId": "033618"
+    },
+    {
+      "Id": "1b1eaab5-2233-439e-8701-abbeea64e665",
+      "ConcordiaCourseId": "033627"
+    },
+    {
+      "Id": "57af1a07-c3d9-4a3a-b0bf-8135447f2a0d",
+      "ConcordiaCourseId": "033628"
+    },
+    {
+      "Id": "1c371880-437e-4db5-8c50-f3c4519d14ff",
+      "ConcordiaCourseId": "044226"
+    },
+    {
+      "Id": "c22259af-d242-4c7a-bd96-5bfbd0705b15",
+      "ConcordiaCourseId": "044227"
+    },
+    {
+      "Id": "de86fbf0-66e3-45af-9f89-2686cb9c3d3a",
+      "ConcordiaCourseId": "044228"
+    },
+    {
+      "Id": "33fef5b1-6e1b-44c9-9c1e-bb4f43457a75",
+      "ConcordiaCourseId": "047114"
+    },
+    {
+      "Id": "12e0b127-dfd9-4ff1-82df-285b87e93093",
+      "ConcordiaCourseId": "047115"
+    },
+    {
+      "Id": "93de8946-d96e-4cdd-a61d-00faaa7c98c4",
+      "ConcordiaCourseId": "047116"
+    },
+    {
+      "Id": "f261b424-b09e-41c9-a7a7-b0e3aeac28f3",
+      "ConcordiaCourseId": "050177"
+    },
+    {
+      "Id": "42aad2b7-df5c-4d90-8e9c-f0815763a9c7",
+      "ConcordiaCourseId": "050178"
+    },
+    {
+      "Id": "42df6665-11b9-4e14-b5db-c141884e983a",
+      "ConcordiaCourseId": "050179"
+    },
+    {
+      "Id": "511c6e07-31b3-4b20-a833-8f528375633e",
+      "ConcordiaCourseId": "050180"
+    },
+    {
+      "Id": "926e1477-6a70-4729-a6c4-51d238ffd004",
+      "ConcordiaCourseId": "033644"
+    },
+    {
+      "Id": "9cede327-ec23-4722-a007-a18910c9862f",
+      "ConcordiaCourseId": "033646"
+    },
+    {
+      "Id": "de874cfd-5342-4ab9-8406-4e5118e15c16",
+      "ConcordiaCourseId": "033648"
+    },
+    {
+      "Id": "c2cad040-5fa7-4421-a837-56f1cf7d1283",
+      "ConcordiaCourseId": "033649"
+    },
+    {
+      "Id": "005a7efe-89b1-4e08-be95-c3a6954cdab1",
+      "ConcordiaCourseId": "033653"
+    },
+    {
+      "Id": "8202f4bd-a06b-4bfb-85b6-afc5242150ad",
+      "ConcordiaCourseId": "033654"
+    },
+    {
+      "Id": "f834a964-b8fd-4453-a8bc-c6f7ce277ca6",
+      "ConcordiaCourseId": "033656"
+    },
+    {
+      "Id": "c9db4fbd-d07c-4d73-bd81-a92f0a534aa3",
+      "ConcordiaCourseId": "033657"
+    },
+    {
+      "Id": "794632c0-a32b-4f25-9bc1-04964c74d22a",
+      "ConcordiaCourseId": "033658"
+    },
+    {
+      "Id": "e0523468-3210-4882-af76-a234e258edb0",
+      "ConcordiaCourseId": "033659"
+    },
+    {
+      "Id": "2891e364-9ccb-4d0f-95e7-d20df30f2991",
+      "ConcordiaCourseId": "033665"
+    },
+    {
+      "Id": "2a884b06-c9ff-42b4-9890-f7723b256ef8",
+      "ConcordiaCourseId": "033666"
+    },
+    {
+      "Id": "437cbe9d-110c-4094-b8c5-a17496bfb2f1",
+      "ConcordiaCourseId": "033667"
+    },
+    {
+      "Id": "9de3345f-8ea1-4b02-aa5c-dc7ceada1eb3",
+      "ConcordiaCourseId": "033668"
+    },
+    {
+      "Id": "d0c59179-d275-41ba-906d-4cdb26467aea",
+      "ConcordiaCourseId": "033671"
+    },
+    {
+      "Id": "556deac4-2abd-4a73-aa5e-d992b62d0a9d",
+      "ConcordiaCourseId": "033674"
+    },
+    {
+      "Id": "b0e9b0de-ba21-4255-b921-ec425cbb8002",
+      "ConcordiaCourseId": "033675"
+    },
+    {
+      "Id": "820058c4-3fe0-4558-8745-b3baceafe2ba",
+      "ConcordiaCourseId": "033676"
+    },
+    {
+      "Id": "3421b3b6-14ff-4583-b2cf-ef17fa0620f3",
+      "ConcordiaCourseId": "033678"
+    },
+    {
+      "Id": "b1c6cb10-3645-42d6-b018-694a5f71570f",
+      "ConcordiaCourseId": "033679"
+    },
+    {
+      "Id": "467d0412-1e05-45ec-93a4-a6740cab1170",
+      "ConcordiaCourseId": "033680"
+    },
+    {
+      "Id": "8857aa0f-7d0c-471a-8a6f-81b6ace3f446",
+      "ConcordiaCourseId": "033681"
+    },
+    {
+      "Id": "dbfce114-c32e-49fc-864d-00e69629fda1",
+      "ConcordiaCourseId": "033682"
+    },
+    {
+      "Id": "a0e973ab-4f3f-4135-a107-d73779597e61",
+      "ConcordiaCourseId": "047117"
+    },
+    {
+      "Id": "b29783dd-a9c6-4751-9e55-0ce0f42c4f9d",
+      "ConcordiaCourseId": "047118"
+    },
+    {
+      "Id": "15854f9c-1ce0-475d-be5d-17c8d58a0652",
+      "ConcordiaCourseId": "047119"
+    },
+    {
+      "Id": "28d75064-2dfd-4afd-9e98-d2d76f10577d",
+      "ConcordiaCourseId": "047120"
+    },
+    {
+      "Id": "062d8513-486e-46ad-8040-89501b5e1797",
+      "ConcordiaCourseId": "050064"
+    },
+    {
+      "Id": "32dea79b-3633-45f1-aa44-73cbcd7fc0fb",
+      "ConcordiaCourseId": "033780"
+    },
+    {
+      "Id": "2696cf32-52fe-48e7-bbf3-b236e2fc9ea3",
+      "ConcordiaCourseId": "033783"
+    },
+    {
+      "Id": "a3494df3-48bf-432b-bb41-f715854d9069",
+      "ConcordiaCourseId": "033788"
+    },
+    {
+      "Id": "072cd0b7-ea4f-4b07-88ed-c502d30e75d0",
+      "ConcordiaCourseId": "033791"
+    },
+    {
+      "Id": "e6a69039-c2ab-4d41-be86-b8b3961f5c5b",
+      "ConcordiaCourseId": "033795"
+    },
+    {
+      "Id": "5664edb5-e039-4dd7-98cd-ab78d6e14ea4",
+      "ConcordiaCourseId": "033796"
+    },
+    {
+      "Id": "b6fabb5b-553b-4369-9398-ab68cc26a33a",
+      "ConcordiaCourseId": "033804"
+    },
+    {
+      "Id": "02f32cab-0cb4-4c51-9849-e7ae48f48fe3",
+      "ConcordiaCourseId": "033805"
+    },
+    {
+      "Id": "f48d39a8-5739-450d-9711-fda4aa00e38a",
+      "ConcordiaCourseId": "033807"
+    },
+    {
+      "Id": "c74d8444-a72c-4a4d-b6f7-99a760f7e223",
+      "ConcordiaCourseId": "033809"
+    },
+    {
+      "Id": "af4565a8-aafb-4d2c-8752-3b3a99cae7bc",
+      "ConcordiaCourseId": "044229"
+    },
+    {
+      "Id": "1f2f2935-5307-4dc8-bd1b-f700b01a1ce1",
+      "ConcordiaCourseId": "044230"
+    },
+    {
+      "Id": "4d136654-48b1-46a2-b829-fd04782c426a",
+      "ConcordiaCourseId": "047121"
+    },
+    {
+      "Id": "881b1726-d386-4dec-9fcf-bac28f26a538",
+      "ConcordiaCourseId": "047122"
+    },
+    {
+      "Id": "88505cb6-e96e-4d2c-b958-12c897fc3fb6",
+      "ConcordiaCourseId": "047123"
+    },
+    {
+      "Id": "d5a0ee78-046d-46bb-8efd-2cfc88ef1c02",
+      "ConcordiaCourseId": "033869"
+    },
+    {
+      "Id": "cf1277fb-5927-4666-bd6a-e2a6aaedc5ca",
+      "ConcordiaCourseId": "033870"
+    },
+    {
+      "Id": "6f29fe17-bbac-4e52-8d07-7a2132454653",
+      "ConcordiaCourseId": "033872"
+    },
+    {
+      "Id": "928fc204-3e21-46a1-9955-915297c7c474",
+      "ConcordiaCourseId": "033874"
+    },
+    {
+      "Id": "91c00557-b029-4be9-87e8-af9a8f7c1da8",
+      "ConcordiaCourseId": "033876"
+    },
+    {
+      "Id": "afa9b437-cf6e-4287-8241-2ded6fea17e5",
+      "ConcordiaCourseId": "033878"
+    },
+    {
+      "Id": "97393366-b0aa-4ea1-904b-347037da9437",
+      "ConcordiaCourseId": "033884"
+    },
+    {
+      "Id": "217376de-71ff-4e44-a878-24962e164f50",
+      "ConcordiaCourseId": "033886"
+    },
+    {
+      "Id": "2642b959-ddf1-4ace-ac02-50887a2695d1",
+      "ConcordiaCourseId": "033897"
+    },
+    {
+      "Id": "827bf2c1-3b29-40b3-b292-7711e1a04a7f",
+      "ConcordiaCourseId": "033901"
+    },
+    {
+      "Id": "f1b14ae3-0589-42c2-81ae-35724c2c6217",
+      "ConcordiaCourseId": "033903"
+    },
+    {
+      "Id": "0bebf6cd-cbe3-43eb-8629-05d5cf53312a",
+      "ConcordiaCourseId": "033905"
+    },
+    {
+      "Id": "089816e8-8171-4e62-b0f1-521ed74c08e6",
+      "ConcordiaCourseId": "033908"
+    },
+    {
+      "Id": "3c0f184b-5c9b-42fa-ab8b-1d019ea6f15e",
+      "ConcordiaCourseId": "033910"
+    },
+    {
+      "Id": "e851dcaf-3f56-48bc-bda2-d295d2070e30",
+      "ConcordiaCourseId": "033914"
+    },
+    {
+      "Id": "918e99cd-0fb0-4942-8d2f-54a30ee85d65",
+      "ConcordiaCourseId": "033916"
+    },
+    {
+      "Id": "9ee46b13-3d25-4a1e-93ca-45ef8e21c577",
+      "ConcordiaCourseId": "033935"
+    },
+    {
+      "Id": "48c6ad4f-ba12-4427-8ef7-fa58d0b397c1",
+      "ConcordiaCourseId": "033937"
+    },
+    {
+      "Id": "4faa899f-6115-409e-84a3-372585ee367a",
+      "ConcordiaCourseId": "033964"
+    },
+    {
+      "Id": "b71e871a-4b70-4c35-8fbe-be02d94d407c",
+      "ConcordiaCourseId": "033967"
+    },
+    {
+      "Id": "c27a5787-91e3-4883-acf1-c9871b3f9c2d",
+      "ConcordiaCourseId": "033970"
+    },
+    {
+      "Id": "5595d5ed-64de-44ee-83cb-617dde5344b1",
+      "ConcordiaCourseId": "033972"
+    },
+    {
+      "Id": "863cdcc6-f46a-4cb1-8d18-538ee4887a53",
+      "ConcordiaCourseId": "033981"
+    },
+    {
+      "Id": "faf29dac-2b41-4836-b727-9e89fbbce5c7",
+      "ConcordiaCourseId": "033986"
+    },
+    {
+      "Id": "b843edc3-24f1-405d-8605-1be94a59efc4",
+      "ConcordiaCourseId": "033993"
+    },
+    {
+      "Id": "f63115fc-45eb-492c-8274-1c0b86849bb3",
+      "ConcordiaCourseId": "033999"
+    },
+    {
+      "Id": "edf32058-97a7-48a1-8f9e-cff057777f45",
+      "ConcordiaCourseId": "034001"
+    },
+    {
+      "Id": "644378cd-4c3a-4ee2-8fe2-15a352df5032",
+      "ConcordiaCourseId": "034005"
+    },
+    {
+      "Id": "31ac5826-d8c2-4631-bb4e-ead6cd1ee796",
+      "ConcordiaCourseId": "034008"
+    },
+    {
+      "Id": "514c18ae-9831-4e4b-87b0-3679e080849a",
+      "ConcordiaCourseId": "034016"
+    },
+    {
+      "Id": "f2cc73fb-84b9-4808-8787-9961fa508870",
+      "ConcordiaCourseId": "034020"
+    },
+    {
+      "Id": "2f4f3382-471e-45b6-8608-15c85bd7c987",
+      "ConcordiaCourseId": "034028"
+    },
+    {
+      "Id": "e1d66399-f206-4ebd-a91a-524321f507ef",
+      "ConcordiaCourseId": "034036"
+    },
+    {
+      "Id": "b2da94a2-68c8-4af5-86d3-519aa2cc1ce0",
+      "ConcordiaCourseId": "034040"
+    },
+    {
+      "Id": "67909338-085a-42c8-8c0f-42bc57d09da0",
+      "ConcordiaCourseId": "034044"
+    },
+    {
+      "Id": "788c5f62-19c4-45bc-9233-6e4d4b291000",
+      "ConcordiaCourseId": "034045"
+    },
+    {
+      "Id": "611fde11-3e8e-45e7-90e9-cace4f9d8a96",
+      "ConcordiaCourseId": "034088"
+    },
+    {
+      "Id": "f0af5cab-3f46-487e-be2d-a0037002ec44",
+      "ConcordiaCourseId": "034126"
+    },
+    {
+      "Id": "31cff912-2409-4cc1-a3eb-3e7c03b12e85",
+      "ConcordiaCourseId": "034127"
+    },
+    {
+      "Id": "14680bd1-4160-432c-9128-a043ad768a6c",
+      "ConcordiaCourseId": "034129"
+    },
+    {
+      "Id": "8c6bd8c4-a6fc-42fb-b622-6ea579a1ded3",
+      "ConcordiaCourseId": "034132"
+    },
+    {
+      "Id": "07a03eca-0f16-4404-a36d-d7a7a7bdc031",
+      "ConcordiaCourseId": "034133"
+    },
+    {
+      "Id": "daab317c-ad98-4afd-9452-63a9956dfcfc",
+      "ConcordiaCourseId": "034167"
+    },
+    {
+      "Id": "f183b781-7b36-42a4-82df-6fedaca9c9bc",
+      "ConcordiaCourseId": "034176"
+    },
+    {
+      "Id": "b2516988-a09f-4bfa-b9c9-cd721c3c1316",
+      "ConcordiaCourseId": "034177"
+    },
+    {
+      "Id": "7f0c2bbd-b904-4b86-b392-1c1ef23c02fc",
+      "ConcordiaCourseId": "034180"
+    },
+    {
+      "Id": "8cb9a6e7-1ca5-44b4-9efb-4489962bdc00",
+      "ConcordiaCourseId": "034182"
+    },
+    {
+      "Id": "fa684cd3-0555-4edb-9c9a-131e45bd47d9",
+      "ConcordiaCourseId": "034183"
+    },
+    {
+      "Id": "f3b82ff1-0890-442f-bd09-580127e13d76",
+      "ConcordiaCourseId": "034188"
+    },
+    {
+      "Id": "a6a31146-a927-41ba-9bfc-6bb3b222e1a7",
+      "ConcordiaCourseId": "034194"
+    },
+    {
+      "Id": "e4950914-991b-435d-8c56-24e3da7dc714",
+      "ConcordiaCourseId": "034195"
+    },
+    {
+      "Id": "c5758564-95e0-4f39-aab6-f231361fde7c",
+      "ConcordiaCourseId": "034209"
+    },
+    {
+      "Id": "7fb61816-0b51-41e2-b388-1eb423f764a7",
+      "ConcordiaCourseId": "034244"
+    },
+    {
+      "Id": "bf9d06c0-0226-4f3d-a5e2-b0e873f07025",
+      "ConcordiaCourseId": "034245"
+    },
+    {
+      "Id": "43a4fe79-46f7-4d44-94f6-315866afa342",
+      "ConcordiaCourseId": "034249"
+    },
+    {
+      "Id": "9b8e8384-48c0-486a-ae5e-0ec5b4526cd7",
+      "ConcordiaCourseId": "034252"
+    },
+    {
+      "Id": "b8f85306-4700-4a46-a910-67e57116329e",
+      "ConcordiaCourseId": "034256"
+    },
+    {
+      "Id": "a1ddc103-e3e7-4fbe-8ea3-4eba73b13b32",
+      "ConcordiaCourseId": "034261"
+    },
+    {
+      "Id": "ac4271da-851a-4f4a-a264-a963bed211f7",
+      "ConcordiaCourseId": "034266"
+    },
+    {
+      "Id": "9a4ca20d-20fd-40f5-b07e-e5a30fe03de6",
+      "ConcordiaCourseId": "034270"
+    },
+    {
+      "Id": "9b1c54ac-1516-4c1f-b4aa-6678b9d7915a",
+      "ConcordiaCourseId": "034271"
+    },
+    {
+      "Id": "6214aba8-6283-4e34-a79a-e8aca12ad9c2",
+      "ConcordiaCourseId": "034273"
+    },
+    {
+      "Id": "9cddebe5-6abe-46b2-8713-d90edafd20ac",
+      "ConcordiaCourseId": "034274"
+    },
+    {
+      "Id": "ed73f089-ec5d-4737-8700-de2ef55b8129",
+      "ConcordiaCourseId": "034275"
+    },
+    {
+      "Id": "261a5f8d-f747-4172-ba58-809062fac185",
+      "ConcordiaCourseId": "034283"
+    },
+    {
+      "Id": "f0d9e584-6fc8-45a9-bb40-82961868b2f2",
+      "ConcordiaCourseId": "034287"
+    },
+    {
+      "Id": "58f596f4-03e9-46b3-b367-f18550a87a91",
+      "ConcordiaCourseId": "034292"
+    },
+    {
+      "Id": "8c686a53-5dd5-4b0d-a1bb-de0ad810e2c8",
+      "ConcordiaCourseId": "034294"
+    },
+    {
+      "Id": "a8569ea2-f711-4e55-86c9-d2f86a8cac42",
+      "ConcordiaCourseId": "034298"
+    },
+    {
+      "Id": "9631182c-f41c-4a60-a4f7-b72bb2326c85",
+      "ConcordiaCourseId": "034300"
+    },
+    {
+      "Id": "d159f1de-0578-4ad0-8f8f-10324efbb024",
+      "ConcordiaCourseId": "034309"
+    },
+    {
+      "Id": "aa5764b7-f659-40a5-ab77-3c4cfc51a5a6",
+      "ConcordiaCourseId": "034315"
+    },
+    {
+      "Id": "2dadc880-4ed2-48af-8fd3-e0b2e5467e5f",
+      "ConcordiaCourseId": "034322"
+    },
+    {
+      "Id": "402b1940-728e-4ab7-b321-7546422a4a66",
+      "ConcordiaCourseId": "034326"
+    },
+    {
+      "Id": "29610eea-529f-47e4-90b2-87850e16cb01",
+      "ConcordiaCourseId": "034331"
+    },
+    {
+      "Id": "cdf51569-40c7-4cc4-9de1-3e49b34d9d55",
+      "ConcordiaCourseId": "034336"
+    },
+    {
+      "Id": "1735afd6-b8e7-4707-913d-e03de517fb12",
+      "ConcordiaCourseId": "034340"
+    },
+    {
+      "Id": "085f0a93-6c46-4398-af7e-d205a71be156",
+      "ConcordiaCourseId": "034342"
+    },
+    {
+      "Id": "ce303645-d564-430d-80d9-43d544774705",
+      "ConcordiaCourseId": "034348"
+    },
+    {
+      "Id": "e255a615-163e-4837-b265-ddca61011308",
+      "ConcordiaCourseId": "042698"
+    },
+    {
+      "Id": "e16d0d84-d380-4eb0-b01c-a49a10b55f8d",
+      "ConcordiaCourseId": "042703"
+    },
+    {
+      "Id": "dcdaf8ce-873c-4087-bbc9-d22d8cea2b3e",
+      "ConcordiaCourseId": "042704"
+    },
+    {
+      "Id": "394ec0ea-34d5-42f4-8832-6d602dd4a91f",
+      "ConcordiaCourseId": "042706"
+    },
+    {
+      "Id": "d5569152-23b1-4699-91ca-43b94668a246",
+      "ConcordiaCourseId": "042707"
+    },
+    {
+      "Id": "3a3174f5-82dd-4a1f-9e29-57f22a4e1d72",
+      "ConcordiaCourseId": "045821"
+    },
+    {
+      "Id": "0d3abd57-2742-493a-a8ca-808567e95261",
+      "ConcordiaCourseId": "045824"
+    },
+    {
+      "Id": "cf98c49e-1caa-4c26-876a-4ab78870f917",
+      "ConcordiaCourseId": "047124"
+    },
+    {
+      "Id": "5551027b-8a01-40e3-9c94-a62f2bd633d9",
+      "ConcordiaCourseId": "047125"
+    },
+    {
+      "Id": "b197d3cc-8bd2-4268-a569-34e034f8e869",
+      "ConcordiaCourseId": "047126"
+    },
+    {
+      "Id": "b87ee376-5c1b-4d60-b8ce-a9a7c55dfa5f",
+      "ConcordiaCourseId": "047127"
+    },
+    {
+      "Id": "82854883-2688-4821-94e8-b25a925be149",
+      "ConcordiaCourseId": "047128"
+    },
+    {
+      "Id": "de9562c2-5e8e-4521-adcc-904d00fc37ab",
+      "ConcordiaCourseId": "047129"
+    },
+    {
+      "Id": "2473384f-4ec5-4629-b01e-8bf3ea2edbe7",
+      "ConcordiaCourseId": "047130"
+    },
+    {
+      "Id": "f88ac7c0-6b8f-41c5-af5e-b966ea9b3809",
+      "ConcordiaCourseId": "047202"
+    },
+    {
+      "Id": "1af7782e-8fa6-4da1-af2a-bbda814a4552",
+      "ConcordiaCourseId": "047445"
+    },
+    {
+      "Id": "c5eea8e9-0241-4bab-be0e-89e1aef5f105",
+      "ConcordiaCourseId": "047446"
+    },
+    {
+      "Id": "520a7843-0e53-4b19-b74a-b98dd4e06066",
+      "ConcordiaCourseId": "047822"
+    },
+    {
+      "Id": "b72ba060-fddb-47d0-8f28-731552206035",
+      "ConcordiaCourseId": "048860"
+    },
+    {
+      "Id": "f5d38c2e-457e-4d8e-a2c3-002378053366",
+      "ConcordiaCourseId": "050637"
+    },
+    {
+      "Id": "ddbf3b71-6fe6-4c50-9208-13fe866b9b76",
+      "ConcordiaCourseId": "050768"
+    },
+    {
+      "Id": "466bae35-f55b-4f2e-9177-6d4428406e1d",
+      "ConcordiaCourseId": "050769"
+    },
+    {
+      "Id": "ce821800-cada-4118-974f-401e0fc4a982",
+      "ConcordiaCourseId": "050770"
+    },
+    {
+      "Id": "6cbfba24-128c-4b18-ac98-12001d6b5033",
+      "ConcordiaCourseId": "050771"
+    },
+    {
+      "Id": "f9e888ea-2870-4aa9-8af5-ce61d88c600d",
+      "ConcordiaCourseId": "047131"
+    },
+    {
+      "Id": "90154c73-4370-48c8-b4b8-2328fa78396b",
+      "ConcordiaCourseId": "034467"
+    },
+    {
+      "Id": "d2ad7e36-c961-4549-9983-ebeee0af0b99",
+      "ConcordiaCourseId": "034471"
+    },
+    {
+      "Id": "d23b90ba-2e07-4dc2-9966-cb55d7c62206",
+      "ConcordiaCourseId": "034472"
+    },
+    {
+      "Id": "8fbc87c9-e33d-4795-be98-4e0ed45a8306",
+      "ConcordiaCourseId": "034493"
+    },
+    {
+      "Id": "240444e8-4340-43e3-8d41-3821cbfce022",
+      "ConcordiaCourseId": "034501"
+    },
+    {
+      "Id": "4e76ed6b-78f1-4ed1-9552-214eecb3c10b",
+      "ConcordiaCourseId": "034502"
+    },
+    {
+      "Id": "c7e387e6-56d5-4769-8e1a-1612ecc4d0db",
+      "ConcordiaCourseId": "034503"
+    },
+    {
+      "Id": "9acd5836-a042-4c9f-bfaa-a4b307cd3bed",
+      "ConcordiaCourseId": "034504"
+    },
+    {
+      "Id": "c188d33d-85a3-44fb-9115-be313c6e61a0",
+      "ConcordiaCourseId": "034521"
+    },
+    {
+      "Id": "0d564401-6ac2-4feb-a49a-fb908474e5f1",
+      "ConcordiaCourseId": "047132"
+    },
+    {
+      "Id": "f6d93177-284a-4192-9366-91d93c2d209a",
+      "ConcordiaCourseId": "047133"
+    },
+    {
+      "Id": "fa58377f-52e5-4431-b7e9-74d8a27db5c4",
+      "ConcordiaCourseId": "047134"
+    },
+    {
+      "Id": "c5ea982d-783b-4887-9088-34a522b44d98",
+      "ConcordiaCourseId": "047135"
+    },
+    {
+      "Id": "2bfa8d3e-cc4b-4679-b202-ac769cb32086",
+      "ConcordiaCourseId": "047136"
+    },
+    {
+      "Id": "1bbadab3-e6f8-489d-aad5-f9189de4c397",
+      "ConcordiaCourseId": "034622"
+    },
+    {
+      "Id": "2ab83ac6-dd0b-4478-9d74-663d263f14ea",
+      "ConcordiaCourseId": "034623"
+    },
+    {
+      "Id": "86532be1-57c5-4288-a171-736e5f6fbd3e",
+      "ConcordiaCourseId": "034624"
+    },
+    {
+      "Id": "1d3f6b02-f00f-4a97-8646-2df4716eb31d",
+      "ConcordiaCourseId": "034625"
+    },
+    {
+      "Id": "71e7d1ca-a854-4a8f-908d-be2cc0a6b970",
+      "ConcordiaCourseId": "034626"
+    },
+    {
+      "Id": "4881d12d-43a8-4f8d-b4fa-4211e1dd410f",
+      "ConcordiaCourseId": "034627"
+    },
+    {
+      "Id": "eaaebd31-bce5-4331-ac0c-c100f3b1927b",
+      "ConcordiaCourseId": "034628"
+    },
+    {
+      "Id": "52108211-5226-4e41-be0e-c58978c810b4",
+      "ConcordiaCourseId": "034629"
+    },
+    {
+      "Id": "296349f7-1c54-427f-9409-bf8bfc0b0bdc",
+      "ConcordiaCourseId": "034632"
+    },
+    {
+      "Id": "0440bdb5-ea6d-481c-a960-9e1cf1279487",
+      "ConcordiaCourseId": "034633"
+    },
+    {
+      "Id": "02db9c18-3f62-4d7b-ab6d-bd1df033afbe",
+      "ConcordiaCourseId": "034635"
+    },
+    {
+      "Id": "0ae44a0f-450b-489c-999c-056cd280183b",
+      "ConcordiaCourseId": "034636"
+    },
+    {
+      "Id": "b82ac4f3-f3b3-4d47-9ba4-b62232b88a8b",
+      "ConcordiaCourseId": "034637"
+    },
+    {
+      "Id": "c013a68c-c40a-4d07-b380-9bdd3a3a16d2",
+      "ConcordiaCourseId": "034638"
+    },
+    {
+      "Id": "0d868989-5f59-4f12-b1c3-d143941ada5f",
+      "ConcordiaCourseId": "034639"
+    },
+    {
+      "Id": "24e65e09-9990-4ab1-b12c-05db4d5eafe0",
+      "ConcordiaCourseId": "034640"
+    },
+    {
+      "Id": "d766a9fd-0ac9-4262-b7f5-b4535bb6d3bd",
+      "ConcordiaCourseId": "034641"
+    },
+    {
+      "Id": "79c68b9a-6564-415e-98ff-7a2bb293466d",
+      "ConcordiaCourseId": "034644"
+    },
+    {
+      "Id": "20e04ed7-5af2-43d2-b04d-23bf6a26576b",
+      "ConcordiaCourseId": "034645"
+    },
+    {
+      "Id": "844716f4-5d99-44b2-a761-804493be605b",
+      "ConcordiaCourseId": "034646"
+    },
+    {
+      "Id": "2b189912-5b87-40c2-9415-c590c661b89e",
+      "ConcordiaCourseId": "034647"
+    },
+    {
+      "Id": "b161ce6f-d0f6-48fe-bf19-bc953b1e7007",
+      "ConcordiaCourseId": "034651"
+    },
+    {
+      "Id": "7808c5a6-c4bc-4521-81bc-5354f5d4afe0",
+      "ConcordiaCourseId": "034652"
+    },
+    {
+      "Id": "87d77823-7446-48a4-a934-9ae52f0ddcdf",
+      "ConcordiaCourseId": "034653"
+    },
+    {
+      "Id": "955a2e8c-cdb2-499d-ad20-4711ed7d0810",
+      "ConcordiaCourseId": "034654"
+    },
+    {
+      "Id": "50206bc0-2578-4aa8-bf8d-51492c828866",
+      "ConcordiaCourseId": "034660"
+    },
+    {
+      "Id": "4cf5825b-e68a-4e74-b3ea-927202f36825",
+      "ConcordiaCourseId": "034662"
+    },
+    {
+      "Id": "77cdc1f1-d753-4c16-9d64-4dcf83451d6c",
+      "ConcordiaCourseId": "034663"
+    },
+    {
+      "Id": "c86f0b94-42a5-4c47-b809-3309089c61c1",
+      "ConcordiaCourseId": "034667"
+    },
+    {
+      "Id": "f1a67475-fe66-4003-ac28-f43c53837a0e",
+      "ConcordiaCourseId": "034671"
+    },
+    {
+      "Id": "42b6b77a-c9ee-4823-b39c-423e6456c32d",
+      "ConcordiaCourseId": "034672"
+    },
+    {
+      "Id": "bea494db-21d1-4420-80dc-0dda1fd7b354",
+      "ConcordiaCourseId": "034673"
+    },
+    {
+      "Id": "7d91edd2-0139-4cd3-ac28-a7ebeccf9d47",
+      "ConcordiaCourseId": "034674"
+    },
+    {
+      "Id": "6cd44497-4c82-4caf-93fe-897a16e43727",
+      "ConcordiaCourseId": "034675"
+    },
+    {
+      "Id": "b35deb21-d0aa-4803-a667-e6ebf21a2055",
+      "ConcordiaCourseId": "034677"
+    },
+    {
+      "Id": "5926f8e6-3936-4e07-aa41-9c58a99dc366",
+      "ConcordiaCourseId": "034678"
+    },
+    {
+      "Id": "06c6ae40-da4e-4f3e-bc1f-5bc601ce2eb5",
+      "ConcordiaCourseId": "034680"
+    },
+    {
+      "Id": "a1c25a0d-7e29-4e97-ae61-bea985396ff8",
+      "ConcordiaCourseId": "034681"
+    },
+    {
+      "Id": "91baf1f1-bf3f-4e12-8240-63ccec577472",
+      "ConcordiaCourseId": "034684"
+    },
+    {
+      "Id": "dc5f0300-0028-402e-b0b8-1654b3a6f62d",
+      "ConcordiaCourseId": "034686"
+    },
+    {
+      "Id": "a55a2bd1-c0f7-4dc6-b437-e0daa3dfdfd1",
+      "ConcordiaCourseId": "034694"
+    },
+    {
+      "Id": "729e7109-e3c6-4997-a3cc-df99715e3397",
+      "ConcordiaCourseId": "042781"
+    },
+    {
+      "Id": "7e699219-8fb0-43fd-b4ea-8ccdc76d0a49",
+      "ConcordiaCourseId": "047137"
+    },
+    {
+      "Id": "8ff2a982-83a0-4ff1-ba16-db48b706482b",
+      "ConcordiaCourseId": "047138"
+    },
+    {
+      "Id": "c6e54a23-a0c8-41e5-902b-f487621730c1",
+      "ConcordiaCourseId": "034701"
+    },
+    {
+      "Id": "fe5abf7b-9b65-43bb-876e-60f96861c3a7",
+      "ConcordiaCourseId": "044231"
+    },
+    {
+      "Id": "5d9c8b32-5135-4eaa-8752-bb4d9afcafb5",
+      "ConcordiaCourseId": "046424"
+    },
+    {
+      "Id": "af0bed96-81ef-4f93-b886-49d5427cee5b",
+      "ConcordiaCourseId": "047981"
+    },
+    {
+      "Id": "9f477439-c560-4b8e-acae-2f35e374b0f9",
+      "ConcordiaCourseId": "047982"
+    },
+    {
+      "Id": "28e6f58e-a568-4497-b862-e9974c5c715f",
+      "ConcordiaCourseId": "034703"
+    },
+    {
+      "Id": "b1e6f49e-3d7b-45a5-82e9-4d211b6cd0bb",
+      "ConcordiaCourseId": "034704"
+    },
+    {
+      "Id": "ffa7e592-c4ba-47cc-8418-ba9810eb6a07",
+      "ConcordiaCourseId": "034705"
+    },
+    {
+      "Id": "5c087763-afd3-4b5f-88c8-0626ba78d470",
+      "ConcordiaCourseId": "034708"
+    },
+    {
+      "Id": "a9dee7c7-29f2-4822-9d37-282d4d02e436",
+      "ConcordiaCourseId": "034711"
+    },
+    {
+      "Id": "9e4b5fe8-5739-4c95-a2d9-6558e76dde0e",
+      "ConcordiaCourseId": "034715"
+    },
+    {
+      "Id": "cba48554-d8d4-4462-8dee-ce43da84a15c",
+      "ConcordiaCourseId": "034716"
+    },
+    {
+      "Id": "cba86658-9023-428c-b00d-b23d7d447cce",
+      "ConcordiaCourseId": "034717"
+    },
+    {
+      "Id": "e059a531-a765-40d1-856c-daa4355a2fd7",
+      "ConcordiaCourseId": "034719"
+    },
+    {
+      "Id": "4a08d85f-8e6f-489c-a8d1-45430d92cfd7",
+      "ConcordiaCourseId": "034720"
+    },
+    {
+      "Id": "17c63d08-a42c-4513-aecb-917338865a16",
+      "ConcordiaCourseId": "034722"
+    },
+    {
+      "Id": "8e5f4081-46ac-4e10-9009-5ab68a872453",
+      "ConcordiaCourseId": "034723"
+    },
+    {
+      "Id": "cde0e37c-2d5e-4f59-a338-bfe5e4df45ff",
+      "ConcordiaCourseId": "034725"
+    },
+    {
+      "Id": "58294ed4-2dd6-4ec8-906d-3efbf206192a",
+      "ConcordiaCourseId": "034738"
+    },
+    {
+      "Id": "01ab82ee-d955-4ee6-947d-ceae483c8f2d",
+      "ConcordiaCourseId": "034739"
+    },
+    {
+      "Id": "b7a977c6-ac47-4b3a-8287-9f3e3f44a26f",
+      "ConcordiaCourseId": "034742"
+    },
+    {
+      "Id": "dade24df-3979-44ed-b236-b1636f8b5a43",
+      "ConcordiaCourseId": "034743"
+    },
+    {
+      "Id": "3915cd45-4f06-405d-bb35-f0606d1de776",
+      "ConcordiaCourseId": "034744"
+    },
+    {
+      "Id": "b7ecacc0-8034-46de-ae4e-8cb0abeba89c",
+      "ConcordiaCourseId": "034745"
+    },
+    {
+      "Id": "3ea192d0-8b4f-4adf-89fe-ade9b365f0e8",
+      "ConcordiaCourseId": "034746"
+    },
+    {
+      "Id": "4803a901-bb8b-4dd1-90fe-068597c436c7",
+      "ConcordiaCourseId": "034748"
+    },
+    {
+      "Id": "dd0374ae-0528-4d60-b37a-cf2173fcce0b",
+      "ConcordiaCourseId": "034750"
+    },
+    {
+      "Id": "28db3eb1-24c7-4114-92f0-67ff8b0f5d71",
+      "ConcordiaCourseId": "034751"
+    },
+    {
+      "Id": "aaf80f70-e90c-4d62-b2b8-f0c05064ee1c",
+      "ConcordiaCourseId": "042934"
+    },
+    {
+      "Id": "bc002498-a500-4a23-afc2-9b83c232cb88",
+      "ConcordiaCourseId": "047139"
+    },
+    {
+      "Id": "28dce9b5-b041-4297-986f-be0795e781ff",
+      "ConcordiaCourseId": "047140"
+    },
+    {
+      "Id": "971da814-eadc-4d68-9aac-583b263b2a12",
+      "ConcordiaCourseId": "047141"
+    },
+    {
+      "Id": "35a7ca8b-1ed6-4e51-be4e-dfcb1f93dc40",
+      "ConcordiaCourseId": "047280"
+    },
+    {
+      "Id": "3d26775a-aeb1-4ba4-a7f7-5fdaa9474379",
+      "ConcordiaCourseId": "047281"
+    },
+    {
+      "Id": "9ef455b9-6de1-4f8e-866d-55eac82478cb",
+      "ConcordiaCourseId": "047895"
+    },
+    {
+      "Id": "808a5495-c0fa-4108-858c-db9a28cc4689",
+      "ConcordiaCourseId": "050377"
+    },
+    {
+      "Id": "728d8f7a-02da-4a07-94d3-9bec3a821748",
+      "ConcordiaCourseId": "034828"
+    },
+    {
+      "Id": "57fbec8c-44e1-4bb9-8812-dd0d03d326c5",
+      "ConcordiaCourseId": "049959"
+    },
+    {
+      "Id": "bccacd0b-f9ef-4c55-b049-534cde06f87f",
+      "ConcordiaCourseId": "049963"
+    },
+    {
+      "Id": "def15a1f-3909-4aba-8072-3166859d76fa",
+      "ConcordiaCourseId": "049965"
+    },
+    {
+      "Id": "9e7d381b-08fe-493d-878c-3606f30bb72d",
+      "ConcordiaCourseId": "049967"
+    },
+    {
+      "Id": "8cd34667-ff6f-4930-9e52-1c7eaba9b50f",
+      "ConcordiaCourseId": "049969"
+    },
+    {
+      "Id": "3d1e28d8-113d-407a-a424-d1cb7ea932b0",
+      "ConcordiaCourseId": "049971"
+    },
+    {
+      "Id": "c9f88cd3-4cb6-4c33-8fa6-f6cd87d6fddf",
+      "ConcordiaCourseId": "049973"
+    },
+    {
+      "Id": "b70976e6-9516-44d6-a1d1-51027b4cc110",
+      "ConcordiaCourseId": "049975"
+    },
+    {
+      "Id": "632b6853-e6ca-4971-83f6-4e915310a0a0",
+      "ConcordiaCourseId": "049977"
+    },
+    {
+      "Id": "c4b6a120-d14e-4e2e-9dcf-eb3413beb3c0",
+      "ConcordiaCourseId": "049979"
+    },
+    {
+      "Id": "af4680c1-9ace-44dc-a27c-294ecdab04b3",
+      "ConcordiaCourseId": "049981"
+    },
+    {
+      "Id": "8680f48e-a4c8-46ea-95d9-67e276d9113b",
+      "ConcordiaCourseId": "049983"
+    },
+    {
+      "Id": "0f477e65-99c4-41cf-ad7c-4a666853516e",
+      "ConcordiaCourseId": "049985"
+    },
+    {
+      "Id": "a17acce2-c91c-442a-b9a7-cda49166dcd4",
+      "ConcordiaCourseId": "049987"
+    },
+    {
+      "Id": "0d954eef-fdd5-404d-8597-e4cf292df59d",
+      "ConcordiaCourseId": "049989"
+    },
+    {
+      "Id": "d4681791-18fe-43af-ae24-7c0d082ea966",
+      "ConcordiaCourseId": "049991"
+    },
+    {
+      "Id": "d472fe3a-e28f-43cf-bb3a-6e444fd0fa11",
+      "ConcordiaCourseId": "047142"
+    },
+    {
+      "Id": "d309790f-4de4-466e-9859-7cb306667994",
+      "ConcordiaCourseId": "047143"
+    },
+    {
+      "Id": "e18e92f9-468b-4b81-93b2-f71ac443a1ca",
+      "ConcordiaCourseId": "047144"
+    },
+    {
+      "Id": "f90195b9-c90f-4324-8325-cc3563719600",
+      "ConcordiaCourseId": "047145"
+    },
+    {
+      "Id": "7bfae5cc-4c7c-45df-8a2a-937ba37598eb",
+      "ConcordiaCourseId": "047146"
+    },
+    {
+      "Id": "08b62feb-505c-4e5c-a9e5-e5f6e243bb70",
+      "ConcordiaCourseId": "047147"
+    },
+    {
+      "Id": "43d47d3d-f913-4f03-a746-8fa32d7235e0",
+      "ConcordiaCourseId": "034884"
+    },
+    {
+      "Id": "ff0f8ca7-a27a-4243-bfd8-f30f713e2641",
+      "ConcordiaCourseId": "034885"
+    },
+    {
+      "Id": "a553500f-7931-4a02-b381-e2937afcfc48",
+      "ConcordiaCourseId": "034886"
+    },
+    {
+      "Id": "3bafebfc-3ef1-4534-9483-d598e90c4d61",
+      "ConcordiaCourseId": "034895"
+    },
+    {
+      "Id": "80dcd2f8-7663-435a-ad9f-6ee787bdb0c2",
+      "ConcordiaCourseId": "034896"
+    },
+    {
+      "Id": "ec1384d7-3210-46a3-b03e-f48e9bbb9dff",
+      "ConcordiaCourseId": "034898"
+    },
+    {
+      "Id": "27c49003-be0d-435c-b189-366402f686e4",
+      "ConcordiaCourseId": "034899"
+    },
+    {
+      "Id": "de90ef88-f0a9-4d7f-afde-e71df26927cb",
+      "ConcordiaCourseId": "034900"
+    },
+    {
+      "Id": "56a252f5-7a90-4229-a3ab-8231eb1566a6",
+      "ConcordiaCourseId": "034901"
+    },
+    {
+      "Id": "e7189703-e794-4227-946c-629159ee0426",
+      "ConcordiaCourseId": "034902"
+    },
+    {
+      "Id": "6144db04-2321-45cc-9604-0a9c853f89c6",
+      "ConcordiaCourseId": "034903"
+    },
+    {
+      "Id": "ba91d875-110b-4f7f-b733-c939a3a754b6",
+      "ConcordiaCourseId": "034904"
+    },
+    {
+      "Id": "52abc5c5-0ab8-4183-bc52-d247efc82c86",
+      "ConcordiaCourseId": "034919"
+    },
+    {
+      "Id": "4bbc4a66-9b37-4cf8-8546-55bf2248c782",
+      "ConcordiaCourseId": "034930"
+    },
+    {
+      "Id": "7ab50957-91f0-43d1-ba87-90a1ff56e5b7",
+      "ConcordiaCourseId": "034931"
+    },
+    {
+      "Id": "143499e6-d08a-428e-b676-67ba6aac6daa",
+      "ConcordiaCourseId": "034933"
+    },
+    {
+      "Id": "69827691-fa5b-4b77-9a80-89d0530532b8",
+      "ConcordiaCourseId": "034935"
+    },
+    {
+      "Id": "56326741-33ee-4e40-ab5f-a03b88c042ab",
+      "ConcordiaCourseId": "034936"
+    },
+    {
+      "Id": "9c880763-c3ad-4940-914c-d352b57581f3",
+      "ConcordiaCourseId": "034937"
+    },
+    {
+      "Id": "82f2c20e-0be6-4bbe-8792-23e2c9985184",
+      "ConcordiaCourseId": "047148"
+    },
+    {
+      "Id": "301fe2d0-2831-4b75-912b-3863daedeb83",
+      "ConcordiaCourseId": "047149"
+    },
+    {
+      "Id": "7da76cb2-af51-4e27-8f0c-4fdf58f965bf",
+      "ConcordiaCourseId": "047150"
+    },
+    {
+      "Id": "4913aaf5-fbb5-4f7e-819d-75b2ec07c6b7",
+      "ConcordiaCourseId": "047151"
+    },
+    {
+      "Id": "d76a760c-e09b-4ae3-8af4-85ec02974c98",
+      "ConcordiaCourseId": "047152"
+    },
+    {
+      "Id": "0984f67c-3c79-4e82-82ee-aa6f89182e0a",
+      "ConcordiaCourseId": "047225"
+    },
+    {
+      "Id": "1c7054f2-9d8d-4554-8b19-8954f59f2a71",
+      "ConcordiaCourseId": "047226"
+    },
+    {
+      "Id": "a833900c-5e65-43d6-ace7-39c0a162e41c",
+      "ConcordiaCourseId": "049226"
+    },
+    {
+      "Id": "91cf9bfc-577a-448a-9e22-47500fb4a434",
+      "ConcordiaCourseId": "049227"
+    },
+    {
+      "Id": "83743693-94d1-4b2d-b018-4331e5e7d9b7",
+      "ConcordiaCourseId": "050131"
+    },
+    {
+      "Id": "427cd576-ff72-4059-affc-603923b7ad39",
+      "ConcordiaCourseId": "050132"
+    },
+    {
+      "Id": "f28d8ed0-ea8e-4e61-bf42-37a217ed5835",
+      "ConcordiaCourseId": "050133"
+    }
+  ]
+}

--- a/Seeder/src/index.ts
+++ b/Seeder/src/index.ts
@@ -6,6 +6,8 @@ import { readFile, seedDataBase } from './util';
 import CourseComponents from './types/CourseComponents';
 import Course from './types/Course';
 import CourseReference from './types/CourseReferences';
+import CourseIdentifier from './types/CourseIdentifier';
+import CourseGrouping from './types/CourseGrouping';
 
 require('dotenv').config();
 const onlyValidateData: boolean = process.argv[2] === '--validateData';
@@ -33,8 +35,23 @@ const courseReferencesData = readFile(courseReferencesJsonFilePath, CourseRefere
 const groupsJsonFilePath = path.resolve(__dirname, 'data', 'Groups.json');
 const groupsData = readFile(groupsJsonFilePath, Group);
 
+const courseIdentifierJsonFilePath = path.resolve(__dirname, 'data', 'CourseIdentifiers.json');
+const courseIdentifierData = readFile(courseIdentifierJsonFilePath, CourseIdentifier);
+
+const courseGroupingJsonFilePath = path.resolve(__dirname, 'data', 'CourseGroupings.json');
+const courseGroupingData = readFile(courseGroupingJsonFilePath, CourseGrouping);
+
 if (!onlyValidateData) {
-  seedDataBase(connectionString, [rolesData, usersData, courseComponentsData, coursesData, courseReferencesData, groupsData]);
+  seedDataBase(connectionString, [
+    rolesData,
+    usersData,
+    courseComponentsData,
+    coursesData,
+    courseReferencesData,
+    groupsData,
+    courseIdentifierData,
+    courseGroupingData
+  ]);
 } else {
   console.log('Seeding data is valid!');
 }

--- a/Seeder/src/types/CourseGrouping.ts
+++ b/Seeder/src/types/CourseGrouping.ts
@@ -1,0 +1,93 @@
+import globalPgq from 'pg-promise';
+import { DataType } from './DataType';
+
+type CourseGroupingReference = {
+    Id: string
+    ChildGroupCommonIdentifier: string
+    GroupingType: number
+}
+
+type CourseGroupingCourseIdentifier = {
+    CourseGroupingId: string
+    CourseIdentifiersId: string
+}
+
+export default class CourseGrouping implements DataType {
+  Id: string;
+  CommonIdentifier: string;
+  Name: string;
+  RequiredCredits: string;
+  IsTopLevel: boolean;
+  School: number;
+  Description: string;
+  Notes: string;
+  State: number;
+  Version: number;
+  Published: boolean;
+  CourseGroupingReferences: CourseGroupingReference[];
+  CourseGroupingCourseIdentifier: CourseGroupingCourseIdentifier[];
+  CreatedDate: Date;
+  ModifiedDate: Date;
+
+  constructor(obj: any) {
+    this.validateParameter(obj);
+    this.Id = obj.Id;
+    this.CommonIdentifier = obj.CommonIdentifier;
+    this.Name = obj.Name;
+    this.RequiredCredits = obj.RequiredCredits;
+    this.IsTopLevel = obj.IsTopLevel;
+    this.School = obj.School;
+    this.Description = obj.Description;
+    this.Notes = obj.Notes;
+    this.State = obj.State;
+    this.Version = obj.Version;
+    this.Published = obj.Published;
+    this.CourseGroupingReferences = obj.CourseGroupingReferences;
+    this.CourseGroupingCourseIdentifier = obj.CourseGroupingCourseIdentifier;
+    this.CreatedDate = obj.CreatedDate;
+    this.ModifiedDate = obj.ModifiedDate;
+  }
+
+  CreateQuery(task: globalPgq.ITask<{}>): Promise<null>[] {
+    const insertIntoCourseGrouping = task.none('INSERT INTO "CourseGroupings" ("Id", "CommonIdentifier", "Name", "RequiredCredits", "IsTopLevel", "School", "Description", "Notes", "State", "Version", "Published", "CreatedDate", "ModifiedDate") VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) ON CONFLICT ("Id") DO NOTHING', [this.Id, this.CommonIdentifier, this.Name, this.RequiredCredits, this.IsTopLevel, this.School, this.Description, this.Notes, this.State, this.Version, this.Published, this.CreatedDate.toISOString(), this.ModifiedDate.toISOString()]);
+    const insertIntoCourseGroupingReferences = this.CourseGroupingReferences.map(c => task.none('INSERT INTO "CourseGroupingReferences" ("Id", "ParentGroupId", "ChildGroupCommonIdentifier", "CreatedDate", "ModifiedDate", "GroupingType") VALUES($1, $2, $3, $4, $5, $6) ON CONFLICT ("Id") DO NOTHING', [c.Id, this.Id, c.ChildGroupCommonIdentifier, this.CreatedDate.toISOString(), this.ModifiedDate.toISOString(), c.GroupingType]))
+    const insertIntoCourseGroupingCourseIdentifier = this.CourseGroupingCourseIdentifier.map(c => task.none('INSERT INTO "CourseGroupingCourseIdentifier" ("CourseGroupingId", "CourseIdentifiersId") VALUES($1, $2)', [c.CourseGroupingId, c.CourseIdentifiersId]))
+
+    return [insertIntoCourseGrouping, ...insertIntoCourseGroupingReferences, ...insertIntoCourseGroupingCourseIdentifier];
+  }
+
+  private validateParameter(obj: any) {
+    if (obj === null || obj === undefined)
+      throw new Error('Parameter is not defined.');
+    if (typeof obj.Id !== 'string' || obj.Id.trim() === '')
+      throw new Error(`Id must be a non-empty string. Passed value is of type ${typeof obj.Id}`);
+    if (typeof obj.CommonIdentifier !== 'string' || obj.CommonIdentifier.trim() === '')
+      throw new Error(`CommonIdentifier must be a non-empty string. Passed value is of type ${typeof obj.CommonIdentifier}`);
+    if (typeof obj.Name !== 'string' || obj.Name.trim() === '')
+      throw new Error(`Name must be a non-empty string. Passed value is of type ${typeof obj.Name}`);
+    if (typeof obj.RequiredCredits !== 'string' || obj.RequiredCredits.trim() === '')
+      throw new Error(`RequiredCredits must be a non-empty string. Passed value is of type ${typeof obj.RequiredCredits}`);
+    if (typeof obj.IsTopLevel !== 'boolean')
+      throw new Error(`IsTopLevel must be a boolean. Passed value is of type ${typeof obj.IsTopLevel}`);
+    if (typeof obj.School !== 'number')
+      throw new Error(`School must be a number. Passed value is of type ${typeof obj.School}`);
+    if (typeof obj.Description !== 'string')
+      throw new Error(`Description must be a string. Passed value is of type ${typeof obj.Description}`);
+    if (typeof obj.Notes !== 'string')
+      throw new Error(`Notes must be a string. Passed value is of type ${typeof obj.Notes}`);
+    if (typeof obj.State !== 'number' || isNaN(obj.State))
+      throw new Error(`State must be a number. Passed value is of type ${typeof obj.State}`);
+    if (typeof obj.Version !== 'number' || isNaN(obj.Version))
+      throw new Error(`Version must be a number. Passed value is of type ${typeof obj.Version}`);
+    if (typeof obj.Published !== 'boolean')
+      throw new Error(`Published must be a boolean. Passed value is of type ${typeof obj.Published}`);
+    if (!Array.isArray(obj.CourseGroupingReferences) || obj.CourseGroupingReferences.some((c: any) => (typeof c.Id !== 'string' || c.Id.trim() === '')))
+      throw new Error(`CourseGroupingReferences must be an array of CourseGroupingReference. Passed value is of type ${typeof obj.CourseGroupingReferences}`);
+    if (!Array.isArray(obj.CourseGroupingCourseIdentifier) || obj.CourseGroupingCourseIdentifier.some((c: any) => (typeof c.CourseGroupingId !== 'string' || c.CourseGroupingId.trim() === '')))
+      throw new Error(`CourseGroupingCourseIdentifier must be an array of CourseGroupingCourseIdentifier. Passed value is of type ${typeof obj.CourseGroupingCourseIdentifier}`);
+    if (!(obj.CreatedDate instanceof Date))
+      throw new Error(`CreatedDate must be a date. Passed value is of type ${typeof obj.CreatedDate}`);
+    if (!(obj.ModifiedDate instanceof Date))
+      throw new Error(`ModifiedDate must be a date. Passed value is of type ${typeof obj.ModifiedDate}`);
+  }
+}

--- a/Seeder/src/types/CourseIdentifier.ts
+++ b/Seeder/src/types/CourseIdentifier.ts
@@ -1,0 +1,34 @@
+import globalPgq from 'pg-promise';
+import { DataType } from './DataType';
+
+export default class CourseIdentifier implements DataType {
+  Id: string;
+  ConcordiaCourseId: string;
+  CreatedDate: Date;
+  ModifiedDate: Date;
+
+  constructor(obj: any) {
+    this.validateParameter(obj);
+    this.Id = obj.Id;
+    this.ConcordiaCourseId = obj.ConcordiaCourseId;
+    this.CreatedDate = obj.CreatedDate;
+    this.ModifiedDate = obj.ModifiedDate;
+  }
+
+  CreateQuery(task: globalPgq.ITask<{}>): Promise<null>[] {
+    return [task.none('INSERT INTO "CourseIdentifiers" ("Id", "ConcordiaCourseId", "CreatedDate", "ModifiedDate") VALUES($1, $2, $3, $4) ON CONFLICT ("Id") DO NOTHING', [this.Id, this.ConcordiaCourseId, this.CreatedDate.toISOString(), this.ModifiedDate.toISOString()])];
+  }
+
+  private validateParameter(obj: any) {
+    if (obj === null || obj === undefined)
+      throw new Error('Parameter is not defined.');
+    if (typeof obj.Id !== 'string' || obj.Id.trim() === '')
+      throw new Error(`Id must be a non-empty string. Passed value is of type ${typeof obj.Id}`);
+    if (typeof obj.ConcordiaCourseId !== 'string' || obj.ConcordiaCourseId.trim() === '')
+      throw new Error(`ConcordiaCourseId must be a non-empty string. Passed value is of type ${typeof obj.ConcordiaCourseId}`);
+    if (!(obj.CreatedDate instanceof Date))
+      throw new Error(`CreatedDate must be a date. Passed value is of type ${typeof obj.CreatedDate}`);
+    if (!(obj.ModifiedDate instanceof Date))
+      throw new Error(`ModifiedDate must be a date. Passed value is of type ${typeof obj.ModifiedDate}`);
+  }
+}

--- a/Server/ConcordiaCurriculumManager/AutoMapperProfile.cs
+++ b/Server/ConcordiaCurriculumManager/AutoMapperProfile.cs
@@ -51,6 +51,7 @@ public class AutoMapper : Profile
             .ForMember(dest => dest.CourseModificationRequests, opt => opt.MapFrom(d => d.Dossier.CourseModificationRequests))
             .ForMember(dest => dest.CourseDeletionRequests, opt => opt.MapFrom(d => d.Dossier.CourseDeletionRequests))
             .ForMember(dest => dest.ApprovalStages, opt => opt.MapFrom(d => d.Dossier.ApprovalStages));
+        CreateMap<CourseGroupingReference, CourseGroupingReferenceDTO>();
         CreateMap<CourseGrouping, CourseGroupingDTO>();
     }
 }

--- a/Server/ConcordiaCurriculumManager/AutoMapperProfile.cs
+++ b/Server/ConcordiaCurriculumManager/AutoMapperProfile.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using ConcordiaCurriculumManager.DTO;
+using ConcordiaCurriculumManager.DTO.CourseGrouping;
 using ConcordiaCurriculumManager.DTO.Courses;
 using ConcordiaCurriculumManager.DTO.Dossiers;
 using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests;
@@ -7,6 +8,7 @@ using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests.InputDTOs;
 using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests.OutputDTOs;
 using ConcordiaCurriculumManager.DTO.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Models.Users;
@@ -49,5 +51,6 @@ public class AutoMapper : Profile
             .ForMember(dest => dest.CourseModificationRequests, opt => opt.MapFrom(d => d.Dossier.CourseModificationRequests))
             .ForMember(dest => dest.CourseDeletionRequests, opt => opt.MapFrom(d => d.Dossier.CourseDeletionRequests))
             .ForMember(dest => dest.ApprovalStages, opt => opt.MapFrom(d => d.Dossier.ApprovalStages));
+        CreateMap<CourseGrouping, CourseGroupingDTO>();
     }
 }

--- a/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
@@ -1,0 +1,36 @@
+﻿using AutoMapper;
+using ConcordiaCurriculumManager.DTO.CourseGrouping;
+using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using System.ComponentModel.DataAnnotations;
+
+namespace ConcordiaCurriculumManager.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Authorize]
+public class CourseGroupingController : Controller
+{
+    private readonly IMapper _mapper;
+    private readonly ICourseGroupingService _courseGroupingService;
+
+    public CourseGroupingController(ICourseGroupingService courseGroupingService, IMapper mapper)
+    {
+        _courseGroupingService = courseGroupingService;
+        _mapper = mapper;
+    }
+
+    [HttpGet(nameof(GetCourseGrouping) + "/{courseGroupingId}")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Course grouping data retrieved")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    public async Task<ActionResult> GetCourseGrouping([FromRoute, Required] Guid courseGroupingId)
+    {
+        var courseGrouping = await _courseGroupingService.GetCourseGrouping(courseGroupingId);
+        var courseGroupingDTO = _mapper.Map<CourseGroupingDTO>(courseGrouping);
+
+        return Ok(courseGroupingDTO);
+    }
+}

--- a/Server/ConcordiaCurriculumManager/DTO/CourseGrouping/CourseGroupingDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/CourseGrouping/CourseGroupingDTO.cs
@@ -16,6 +16,7 @@ public class CourseGroupingDTO
     public required CourseGroupingStateEnum State { get; set; }
     public int? Version { get; set; }
     public required bool Published { get; set; }
+    public required ICollection<CourseGroupingReferenceDTO> SubGroupingReferences { get; set; } = new List<CourseGroupingReferenceDTO>();
     public required ICollection<CourseGroupingDTO> SubGroupings { get; set; } = new List<CourseGroupingDTO>();
     public required ICollection<CourseDataDTO> Courses { get; set; } = new List<CourseDataDTO>();
     public required DateTime CreatedDate { get; set; }

--- a/Server/ConcordiaCurriculumManager/DTO/CourseGrouping/CourseGroupingDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/CourseGrouping/CourseGroupingDTO.cs
@@ -1,0 +1,23 @@
+﻿using ConcordiaCurriculumManager.DTO.Courses;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+
+namespace ConcordiaCurriculumManager.DTO.CourseGrouping;
+
+public class CourseGroupingDTO
+{
+    public Guid Id { get; set; }
+    public required Guid CommonIdentifier { get; set; }
+    public required string Name { get; set; }
+    public required string RequiredCredits { get; set; }
+    public required bool IsTopLevel { get; set; }
+    public required SchoolEnum School { get; set; }
+    public string? Description { get; set; }
+    public string? Notes { get; set; }
+    public required CourseGroupingStateEnum State { get; set; }
+    public int? Version { get; set; }
+    public required bool Published { get; set; }
+    public required ICollection<CourseGroupingDTO> SubGroupings { get; set; } = new List<CourseGroupingDTO>();
+    public required ICollection<CourseDataDTO> Courses { get; set; } = new List<CourseDataDTO>();
+    public required DateTime CreatedDate { get; set; }
+    public required DateTime ModifiedDate { get; set; }
+}

--- a/Server/ConcordiaCurriculumManager/DTO/CourseGrouping/CourseGroupingReferenceDTO.cs
+++ b/Server/ConcordiaCurriculumManager/DTO/CourseGrouping/CourseGroupingReferenceDTO.cs
@@ -1,0 +1,11 @@
+﻿using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+
+namespace ConcordiaCurriculumManager.DTO.CourseGrouping;
+
+public class CourseGroupingReferenceDTO
+{
+    public required Guid Id { get; set; }
+    public required Guid ParentGroupId { get; set; }
+    public required Guid ChildGroupCommonIdentifier { get; set; }
+    public required GroupingTypeEnum GroupingType { get; set; }
+}

--- a/Server/ConcordiaCurriculumManager/Migrations/20240104221822_CreateCourseGroupings.Designer.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20240104221822_CreateCourseGroupings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConcordiaCurriculumManager.Migrations
 {
     [DbContext(typeof(CCMDbContext))]
-    partial class CCMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240104221822_CreateCourseGroupings")]
+    partial class CreateCourseGroupings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -152,9 +155,6 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Property<Guid>("CommonIdentifier")
                         .HasColumnType("uuid");
 
-                    b.Property<Guid?>("CourseGroupingId")
-                        .HasColumnType("uuid");
-
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
@@ -192,8 +192,6 @@ namespace ConcordiaCurriculumManager.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("CourseGroupingId");
-
                     b.ToTable("CourseGroupings");
                 });
 
@@ -206,11 +204,11 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Property<Guid>("ChildGroupCommonIdentifier")
                         .HasColumnType("uuid");
 
+                    b.Property<Guid?>("CourseGroupingId")
+                        .HasColumnType("uuid");
+
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("GroupingType")
-                        .HasColumnType("integer");
 
                     b.Property<DateTime>("ModifiedDate")
                         .HasColumnType("timestamp with time zone");
@@ -219,6 +217,8 @@ namespace ConcordiaCurriculumManager.Migrations
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("CourseGroupingId");
 
                     b.HasIndex("ParentGroupId");
 
@@ -234,6 +234,9 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Property<int>("ConcordiaCourseId")
                         .HasColumnType("integer");
 
+                    b.Property<Guid?>("CourseGroupingId")
+                        .HasColumnType("uuid");
+
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
@@ -241,6 +244,8 @@ namespace ConcordiaCurriculumManager.Migrations
                         .HasColumnType("timestamp with time zone");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("CourseGroupingId");
 
                     b.ToTable("CourseIdentifiers");
                 });
@@ -638,19 +643,19 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.ToTable("Users");
                 });
 
-            modelBuilder.Entity("CourseGroupingCourseIdentifier", b =>
+            modelBuilder.Entity("CourseGroupingCourseGrouping", b =>
                 {
-                    b.Property<Guid>("CourseGroupingId")
+                    b.Property<Guid>("OptionalGroupingsId")
                         .HasColumnType("uuid");
 
-                    b.Property<Guid>("CourseIdentifiersId")
+                    b.Property<Guid>("SubGroupingsId")
                         .HasColumnType("uuid");
 
-                    b.HasKey("CourseGroupingId", "CourseIdentifiersId");
+                    b.HasKey("OptionalGroupingsId", "SubGroupingsId");
 
-                    b.HasIndex("CourseIdentifiersId");
+                    b.HasIndex("SubGroupingsId");
 
-                    b.ToTable("CourseGroupingCourseIdentifier");
+                    b.ToTable("CourseGroupingCourseGrouping");
                 });
 
             modelBuilder.Entity("GroupUser", b =>
@@ -725,20 +730,24 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Navigation("CourseComponent");
                 });
 
-            modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", b =>
-                {
-                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
-                        .WithMany("SubGroupings")
-                        .HasForeignKey("CourseGroupingId");
-                });
-
             modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGroupingReference", b =>
                 {
                     b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
                         .WithMany("SubGroupingReferences")
+                        .HasForeignKey("CourseGroupingId");
+
+                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
+                        .WithMany("OptionalGroupingReferences")
                         .HasForeignKey("ParentGroupId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
+
+            modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseIdentifier", b =>
+                {
+                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
+                        .WithMany("CourseIdentifiers")
+                        .HasForeignKey("CourseGroupingId");
                 });
 
             modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.CourseReference", b =>
@@ -902,17 +911,17 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Navigation("Course");
                 });
 
-            modelBuilder.Entity("CourseGroupingCourseIdentifier", b =>
+            modelBuilder.Entity("CourseGroupingCourseGrouping", b =>
                 {
                     b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
                         .WithMany()
-                        .HasForeignKey("CourseGroupingId")
+                        .HasForeignKey("OptionalGroupingsId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseIdentifier", null)
+                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
                         .WithMany()
-                        .HasForeignKey("CourseIdentifiersId")
+                        .HasForeignKey("SubGroupingsId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -986,11 +995,13 @@ namespace ConcordiaCurriculumManager.Migrations
 
             modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", b =>
                 {
+                    b.Navigation("CourseIdentifiers");
+
                     b.Navigation("Courses");
 
-                    b.Navigation("SubGroupingReferences");
+                    b.Navigation("OptionalGroupingReferences");
 
-                    b.Navigation("SubGroupings");
+                    b.Navigation("SubGroupingReferences");
                 });
 
             modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.Dossiers.Dossier", b =>

--- a/Server/ConcordiaCurriculumManager/Migrations/20240104221822_CreateCourseGroupings.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20240104221822_CreateCourseGroupings.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcordiaCurriculumManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateCourseGroupings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CourseGroupingId",
+                table: "Courses",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CourseGroupings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommonIdentifier = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    RequiredCredits = table.Column<string>(type: "text", nullable: false),
+                    IsTopLevel = table.Column<bool>(type: "boolean", nullable: false),
+                    School = table.Column<int>(type: "integer", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    Notes = table.Column<string>(type: "text", nullable: true),
+                    State = table.Column<int>(type: "integer", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: true),
+                    Published = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourseGroupings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CourseGroupingCourseGrouping",
+                columns: table => new
+                {
+                    OptionalGroupingsId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubGroupingsId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourseGroupingCourseGrouping", x => new { x.OptionalGroupingsId, x.SubGroupingsId });
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingCourseGrouping_CourseGroupings_OptionalGroupi~",
+                        column: x => x.OptionalGroupingsId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingCourseGrouping_CourseGroupings_SubGroupingsId",
+                        column: x => x.SubGroupingsId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CourseGroupingReferences",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ParentGroupId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ChildGroupCommonIdentifier = table.Column<Guid>(type: "uuid", nullable: false),
+                    CourseGroupingId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourseGroupingReferences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingReferences_CourseGroupings_CourseGroupingId",
+                        column: x => x.CourseGroupingId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingReferences_CourseGroupings_ParentGroupId",
+                        column: x => x.ParentGroupId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CourseIdentifiers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConcordiaCourseId = table.Column<int>(type: "integer", nullable: false),
+                    CourseGroupingId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourseIdentifiers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CourseIdentifiers_CourseGroupings_CourseGroupingId",
+                        column: x => x.CourseGroupingId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Courses_CourseGroupingId",
+                table: "Courses",
+                column: "CourseGroupingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseGroupingCourseGrouping_SubGroupingsId",
+                table: "CourseGroupingCourseGrouping",
+                column: "SubGroupingsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseGroupingReferences_CourseGroupingId",
+                table: "CourseGroupingReferences",
+                column: "CourseGroupingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseGroupingReferences_ParentGroupId",
+                table: "CourseGroupingReferences",
+                column: "ParentGroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseIdentifiers_CourseGroupingId",
+                table: "CourseIdentifiers",
+                column: "CourseGroupingId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Courses_CourseGroupings_CourseGroupingId",
+                table: "Courses",
+                column: "CourseGroupingId",
+                principalTable: "CourseGroupings",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Courses_CourseGroupings_CourseGroupingId",
+                table: "Courses");
+
+            migrationBuilder.DropTable(
+                name: "CourseGroupingCourseGrouping");
+
+            migrationBuilder.DropTable(
+                name: "CourseGroupingReferences");
+
+            migrationBuilder.DropTable(
+                name: "CourseIdentifiers");
+
+            migrationBuilder.DropTable(
+                name: "CourseGroupings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Courses_CourseGroupingId",
+                table: "Courses");
+
+            migrationBuilder.DropColumn(
+                name: "CourseGroupingId",
+                table: "Courses");
+        }
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Migrations/20240105000353_CreateManyToManyCourseIdentifiers.Designer.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20240105000353_CreateManyToManyCourseIdentifiers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConcordiaCurriculumManager.Migrations
 {
     [DbContext(typeof(CCMDbContext))]
-    partial class CCMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240105000353_CreateManyToManyCourseIdentifiers")]
+    partial class CreateManyToManyCourseIdentifiers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -152,9 +155,6 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Property<Guid>("CommonIdentifier")
                         .HasColumnType("uuid");
 
-                    b.Property<Guid?>("CourseGroupingId")
-                        .HasColumnType("uuid");
-
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
 
@@ -192,8 +192,6 @@ namespace ConcordiaCurriculumManager.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("CourseGroupingId");
-
                     b.ToTable("CourseGroupings");
                 });
 
@@ -206,11 +204,11 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Property<Guid>("ChildGroupCommonIdentifier")
                         .HasColumnType("uuid");
 
+                    b.Property<Guid?>("CourseGroupingId")
+                        .HasColumnType("uuid");
+
                     b.Property<DateTime>("CreatedDate")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("GroupingType")
-                        .HasColumnType("integer");
 
                     b.Property<DateTime>("ModifiedDate")
                         .HasColumnType("timestamp with time zone");
@@ -219,6 +217,8 @@ namespace ConcordiaCurriculumManager.Migrations
                         .HasColumnType("uuid");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("CourseGroupingId");
 
                     b.HasIndex("ParentGroupId");
 
@@ -638,6 +638,21 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.ToTable("Users");
                 });
 
+            modelBuilder.Entity("CourseGroupingCourseGrouping", b =>
+                {
+                    b.Property<Guid>("OptionalGroupingsId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("SubGroupingsId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("OptionalGroupingsId", "SubGroupingsId");
+
+                    b.HasIndex("SubGroupingsId");
+
+                    b.ToTable("CourseGroupingCourseGrouping");
+                });
+
             modelBuilder.Entity("CourseGroupingCourseIdentifier", b =>
                 {
                     b.Property<Guid>("CourseGroupingId")
@@ -725,17 +740,14 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Navigation("CourseComponent");
                 });
 
-            modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", b =>
-                {
-                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
-                        .WithMany("SubGroupings")
-                        .HasForeignKey("CourseGroupingId");
-                });
-
             modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGroupingReference", b =>
                 {
                     b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
                         .WithMany("SubGroupingReferences")
+                        .HasForeignKey("CourseGroupingId");
+
+                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
+                        .WithMany("OptionalGroupingReferences")
                         .HasForeignKey("ParentGroupId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -902,6 +914,21 @@ namespace ConcordiaCurriculumManager.Migrations
                     b.Navigation("Course");
                 });
 
+            modelBuilder.Entity("CourseGroupingCourseGrouping", b =>
+                {
+                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
+                        .WithMany()
+                        .HasForeignKey("OptionalGroupingsId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
+                        .WithMany()
+                        .HasForeignKey("SubGroupingsId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("CourseGroupingCourseIdentifier", b =>
                 {
                     b.HasOne("ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping.CourseGrouping", null)
@@ -988,9 +1015,9 @@ namespace ConcordiaCurriculumManager.Migrations
                 {
                     b.Navigation("Courses");
 
-                    b.Navigation("SubGroupingReferences");
+                    b.Navigation("OptionalGroupingReferences");
 
-                    b.Navigation("SubGroupings");
+                    b.Navigation("SubGroupingReferences");
                 });
 
             modelBuilder.Entity("ConcordiaCurriculumManager.Models.Curriculum.Dossiers.Dossier", b =>

--- a/Server/ConcordiaCurriculumManager/Migrations/20240105000353_CreateManyToManyCourseIdentifiers.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20240105000353_CreateManyToManyCourseIdentifiers.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcordiaCurriculumManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateManyToManyCourseIdentifiers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CourseIdentifiers_CourseGroupings_CourseGroupingId",
+                table: "CourseIdentifiers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CourseIdentifiers_CourseGroupingId",
+                table: "CourseIdentifiers");
+
+            migrationBuilder.DropColumn(
+                name: "CourseGroupingId",
+                table: "CourseIdentifiers");
+
+            migrationBuilder.CreateTable(
+                name: "CourseGroupingCourseIdentifier",
+                columns: table => new
+                {
+                    CourseGroupingId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CourseIdentifiersId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourseGroupingCourseIdentifier", x => new { x.CourseGroupingId, x.CourseIdentifiersId });
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingCourseIdentifier_CourseGroupings_CourseGroupi~",
+                        column: x => x.CourseGroupingId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingCourseIdentifier_CourseIdentifiers_CourseIden~",
+                        column: x => x.CourseIdentifiersId,
+                        principalTable: "CourseIdentifiers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseGroupingCourseIdentifier_CourseIdentifiersId",
+                table: "CourseGroupingCourseIdentifier",
+                column: "CourseIdentifiersId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CourseGroupingCourseIdentifier");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "CourseGroupingId",
+                table: "CourseIdentifiers",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseIdentifiers_CourseGroupingId",
+                table: "CourseIdentifiers",
+                column: "CourseGroupingId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CourseIdentifiers_CourseGroupings_CourseGroupingId",
+                table: "CourseIdentifiers",
+                column: "CourseGroupingId",
+                principalTable: "CourseGroupings",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Migrations/20240105002405_LabelGroupingReferenceTypes.Designer.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20240105002405_LabelGroupingReferenceTypes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace ConcordiaCurriculumManager.Migrations
 {
     [DbContext(typeof(CCMDbContext))]
-    partial class CCMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240105002405_LabelGroupingReferenceTypes")]
+    partial class LabelGroupingReferenceTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/ConcordiaCurriculumManager/Migrations/20240105002405_LabelGroupingReferenceTypes.cs
+++ b/Server/ConcordiaCurriculumManager/Migrations/20240105002405_LabelGroupingReferenceTypes.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConcordiaCurriculumManager.Migrations
+{
+    /// <inheritdoc />
+    public partial class LabelGroupingReferenceTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CourseGroupingReferences_CourseGroupings_CourseGroupingId",
+                table: "CourseGroupingReferences");
+
+            migrationBuilder.DropTable(
+                name: "CourseGroupingCourseGrouping");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CourseGroupingReferences_CourseGroupingId",
+                table: "CourseGroupingReferences");
+
+            migrationBuilder.DropColumn(
+                name: "CourseGroupingId",
+                table: "CourseGroupingReferences");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "CourseGroupingId",
+                table: "CourseGroupings",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "GroupingType",
+                table: "CourseGroupingReferences",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseGroupings_CourseGroupingId",
+                table: "CourseGroupings",
+                column: "CourseGroupingId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CourseGroupings_CourseGroupings_CourseGroupingId",
+                table: "CourseGroupings",
+                column: "CourseGroupingId",
+                principalTable: "CourseGroupings",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CourseGroupings_CourseGroupings_CourseGroupingId",
+                table: "CourseGroupings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CourseGroupings_CourseGroupingId",
+                table: "CourseGroupings");
+
+            migrationBuilder.DropColumn(
+                name: "CourseGroupingId",
+                table: "CourseGroupings");
+
+            migrationBuilder.DropColumn(
+                name: "GroupingType",
+                table: "CourseGroupingReferences");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "CourseGroupingId",
+                table: "CourseGroupingReferences",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "CourseGroupingCourseGrouping",
+                columns: table => new
+                {
+                    OptionalGroupingsId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SubGroupingsId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CourseGroupingCourseGrouping", x => new { x.OptionalGroupingsId, x.SubGroupingsId });
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingCourseGrouping_CourseGroupings_OptionalGroupi~",
+                        column: x => x.OptionalGroupingsId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CourseGroupingCourseGrouping_CourseGroupings_SubGroupingsId",
+                        column: x => x.SubGroupingsId,
+                        principalTable: "CourseGroupings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseGroupingReferences_CourseGroupingId",
+                table: "CourseGroupingReferences",
+                column: "CourseGroupingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CourseGroupingCourseGrouping_SubGroupingsId",
+                table: "CourseGroupingCourseGrouping",
+                column: "SubGroupingsId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CourseGroupingReferences_CourseGroupings_CourseGroupingId",
+                table: "CourseGroupingReferences",
+                column: "CourseGroupingId",
+                principalTable: "CourseGroupings",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/CourseGrouping/CourseGrouping.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/CourseGrouping/CourseGrouping.cs
@@ -1,0 +1,54 @@
+﻿using NpgsqlTypes;
+
+namespace ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+
+public class CourseGrouping : BaseModel
+{
+    public required Guid CommonIdentifier { get; set; }
+    public required string Name { get; set; }
+    public required string RequiredCredits { get; set; }
+    public required bool IsTopLevel { get; set; }
+    public required SchoolEnum School { get; set; }
+    public string? Description { get; set; }
+    public string? Notes { get; set; }
+    public required CourseGroupingStateEnum State { get; set; }
+    public int? Version { get; set; }
+    public required bool Published { get; set; }
+    public required ICollection<CourseGroupingReference> SubGroupingReferences { get; set; } = new List<CourseGroupingReference>();
+    public required ICollection<CourseGrouping> SubGroupings { get; set; } = new List<CourseGrouping>();
+    public required ICollection<CourseIdentifier> CourseIdentifiers { get; set; } = new List<CourseIdentifier>();
+    public required ICollection<Course> Courses { get; set; } = new List<Course>();
+}
+
+public enum SchoolEnum
+{
+    [PgName(nameof(GinaCody))]
+    GinaCody,
+
+    [PgName(nameof(ArtsAndScience))]
+    ArtsAndScience,
+
+    [PgName(nameof(FineArts))]
+    FineArts,
+
+    [PgName(nameof(JMSB))]
+    JMSB
+}
+
+public enum CourseGroupingStateEnum
+{
+    [PgName(nameof(Accepted))]
+    Accepted,
+
+    [PgName(nameof(NewCourseGroupingProposal))]
+    NewCourseGroupingProposal,
+
+    [PgName(nameof(CourseGroupingChangeProposal))]
+    CourseGroupingChangeProposal,
+
+    [PgName(nameof(CourseGroupingDeletionProposal))]
+    CourseGroupingDeletionProposal,
+
+    [PgName(nameof(Deleted))]
+    Deleted
+}

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/CourseGrouping/CourseGroupingReference.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/CourseGrouping/CourseGroupingReference.cs
@@ -1,0 +1,19 @@
+﻿using NpgsqlTypes;
+
+namespace ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+
+public class CourseGroupingReference : BaseModel
+{
+    public required Guid ParentGroupId { get; set; }
+    public required Guid ChildGroupCommonIdentifier { get; set; }
+    public required GroupingTypeEnum GroupingType { get; set; }
+}
+
+public enum GroupingTypeEnum
+{
+    [PgName(nameof(SubGrouping))]
+    SubGrouping,
+
+    [PgName(nameof(OptionalGrouping))]
+    OptionalGrouping,
+}

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/CourseGrouping/CourseIdentifier.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/CourseGrouping/CourseIdentifier.cs
@@ -1,0 +1,6 @@
+﻿namespace ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+
+public class CourseIdentifier : BaseModel
+{
+    public required int ConcordiaCourseId { get; set; }
+}

--- a/Server/ConcordiaCurriculumManager/Program.cs
+++ b/Server/ConcordiaCurriculumManager/Program.cs
@@ -180,6 +180,7 @@ public class Program
 
         services.AddScoped<IUserAuthenticationService, UserAuthenticationService>();
         services.AddScoped<ICourseService, CourseService>();
+        services.AddScoped<ICourseGroupingService, CourseGroupingService>();
         services.AddScoped<IDossierService, DossierService>();
         services.AddScoped<IDossierReviewService, DossierReviewService>();
         services.AddScoped<IGroupService, GroupService>();
@@ -188,6 +189,7 @@ public class Program
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IGroupRepository, GroupRepository>();
         services.AddScoped<ICourseRepository, CourseRepository>();
+        services.AddScoped<ICourseGroupingRepository, CourseGroupingRepository>();
         services.AddScoped<IDossierRepository, DossierRepository>();
         services.AddScoped<IDossierReviewRepository, DossierReviewRepository>();
     }

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
@@ -1,0 +1,37 @@
+﻿using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+using ConcordiaCurriculumManager.Repositories.DatabaseContext;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcordiaCurriculumManager.Repositories;
+
+public interface ICourseGroupingRepository
+{
+    public Task<CourseGrouping?> GetCourseGroupingById(Guid groupingId);
+    public Task<CourseGrouping?> GetCourseGroupingByCommonIdentifier(Guid commonId);
+}
+
+public class CourseGroupingRepository : ICourseGroupingRepository
+{
+    private readonly CCMDbContext _dbContext;
+
+    public CourseGroupingRepository(CCMDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<CourseGrouping?> GetCourseGroupingById(Guid groupingId) => await _dbContext.CourseGroupings
+        .Where(cg => cg.Id.Equals(groupingId))
+        .Include(cg => cg.SubGroupingReferences)
+        .Include(cg => cg.CourseIdentifiers)
+        .FirstOrDefaultAsync();
+
+    public async Task<CourseGrouping?> GetCourseGroupingByCommonIdentifier(Guid commonId) => await _dbContext.CourseGroupings
+        .Where(cg => cg.CommonIdentifier.Equals(commonId)
+            && cg.State == CourseGroupingStateEnum.Accepted
+            && cg.Version != null)
+        .Include(cg => cg.SubGroupingReferences)
+        .Include(cg => cg.CourseIdentifiers)
+        .OrderByDescending(cg => cg.Version)
+        .FirstOrDefaultAsync();
+}

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
@@ -1,4 +1,5 @@
 ﻿using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
 using ConcordiaCurriculumManager.Models.Users;
 using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
@@ -13,6 +14,7 @@ public interface ICourseRepository
     public Task<bool> SaveCourse(Course course);
     public Task<Course?> GetCourseByCourseId(int courseId);
     public Task<Course?> GetCourseByCourseIdAndLatestVersion(int courseId);
+    public Task<IList<Course>> GetCoursesByConcordiaCourseIds(IList<int> courseIds);
     public Task<Course?> GetCourseWithSupportingFilesBySubjectAndCatalog(string subject, string catalog);
     public Task<int?> GetCurrentCourseVersion(string subject, string catalog);
 }
@@ -34,7 +36,8 @@ public class CourseRepository : ICourseRepository
         .Where(course => 
             course.Subject == subject 
             && course.Catalog == catalog 
-            && (course.CourseState == CourseStateEnum.Accepted || course.CourseState == CourseStateEnum.Deleted))
+            && (course.CourseState == CourseStateEnum.Accepted || course.CourseState == CourseStateEnum.Deleted
+            && course.Version != null))
         .OrderByDescending(course => course.Version)
         .Select(ObjectSelectors.CourseSelector())
         .FirstOrDefaultAsync();
@@ -47,13 +50,29 @@ public class CourseRepository : ICourseRepository
         return result > 0;
     }
 
-    public Task<Course?> GetCourseByCourseIdAndLatestVersion(int courseId) => _dbContext.Courses
+    public async Task<Course?> GetCourseByCourseIdAndLatestVersion(int courseId) => await _dbContext.Courses
     .Where(course => 
         course.CourseID == courseId 
-        && course.CourseState == CourseStateEnum.Accepted)
+        && course.CourseState == CourseStateEnum.Accepted
+        && course.Version != null)
     .OrderByDescending(course => course.Version)
-    .Select(ObjectSelectors.CourseSelector())
+    .Include(course => course.CourseCourseComponents)
     .FirstOrDefaultAsync();
+
+    public async Task<IList<Course>> GetCoursesByConcordiaCourseIds(IList<int> courseIds)
+    {
+        if (courseIds.Count == 0)
+            return new List<Course>();
+
+        var query = _dbContext.Courses.FromSqlInterpolated(
+                $@"SELECT DISTINCT ON (""CourseID"") c.* FROM ""Courses"" c WHERE ""Version"" IS NOT NULL ORDER BY ""CourseID"", ""Version"" DESC"
+            );
+
+        query = query.Where(course => courseIds.Contains(course.CourseID));
+        query = query.Include(course => course.CourseCourseComponents);
+
+        return await query.ToListAsync();
+    }
 
     public async Task<Course?> GetCourseByCourseId(int courseId) => await _dbContext.Courses
         .Where(course => course.CourseID == courseId && course.CourseState == CourseStateEnum.Accepted)
@@ -65,7 +84,8 @@ public class CourseRepository : ICourseRepository
         .Where(course =>
             course.Subject == subject
             && course.Catalog == catalog
-            && (course.CourseState == CourseStateEnum.Accepted || course.CourseState == CourseStateEnum.Deleted))
+            && (course.CourseState == CourseStateEnum.Accepted || course.CourseState == CourseStateEnum.Deleted
+            && course.Version != null))
         .Include(course => course.SupportingFiles)
         .Include(course => course.CourseCourseComponents)
         .OrderByDescending(course => course.Version)

--- a/Server/ConcordiaCurriculumManager/Repositories/DatabaseContext/CCMDbContext.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DatabaseContext/CCMDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Models.Users;
@@ -40,6 +41,12 @@ public class CCMDbContext : DbContext
 
     public DbSet<CourseReference> CourseReferences { get; set; }
 
+    public DbSet<CourseGrouping> CourseGroupings { get; set; }
+
+    public DbSet<CourseGroupingReference> CourseGroupingReferences { get; set; }
+
+    public DbSet<CourseIdentifier> CourseIdentifiers { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -48,6 +55,7 @@ public class CCMDbContext : DbContext
         ConfigureCourseReferencesRelationship(modelBuilder);
         ConfigureGroupUserRelationship(modelBuilder);
         ConfigureDossierReviewRelationships(modelBuilder);
+        ConfigureCourseGroupingRelationships(modelBuilder);
     }
 
     private static void ConfigureCourseReferencesRelationship(ModelBuilder modelBuilder)
@@ -175,5 +183,17 @@ public class CCMDbContext : DbContext
             .HasOne(message => message.ParentDiscussionMessage)
             .WithMany()
             .HasForeignKey(message => message.ParentDiscussionMessageId);
+    }
+
+    private static void ConfigureCourseGroupingRelationships(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<CourseGrouping>()
+            .HasMany(cg => cg.SubGroupingReferences)
+            .WithOne()
+            .HasForeignKey(sgr => sgr.ParentGroupId);
+
+        modelBuilder.Entity<CourseGrouping>()
+            .HasMany(cg => cg.CourseIdentifiers)
+            .WithMany();
     }
 }

--- a/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
@@ -13,11 +13,11 @@ public interface ICourseGroupingService
 
 public class CourseGroupingService : ICourseGroupingService
 {
-    private readonly ILogger<CourseService> _logger;
+    private readonly ILogger<CourseGroupingService> _logger;
     private readonly ICourseRepository _courseRepository;
     private readonly ICourseGroupingRepository _courseGroupingRepository;
 
-    public CourseGroupingService(ILogger<CourseService> logger, ICourseRepository courseRepository, ICourseGroupingRepository courseGroupingRepository)
+    public CourseGroupingService(ILogger<CourseGroupingService> logger, ICourseRepository courseRepository, ICourseGroupingRepository courseGroupingRepository)
     {
         _logger = logger;
         _courseRepository = courseRepository;

--- a/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
@@ -1,0 +1,64 @@
+﻿using ConcordiaCurriculumManager.Filters.Exceptions;
+using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+using ConcordiaCurriculumManager.Repositories;
+
+namespace ConcordiaCurriculumManager.Services;
+
+public interface ICourseGroupingService
+{
+    public Task<CourseGrouping> GetCourseGrouping(Guid groupingId);
+    public Task<CourseGrouping> GetCourseGroupingByCommonIdentifier(Guid commonId);
+}
+
+public class CourseGroupingService : ICourseGroupingService
+{
+    private readonly ILogger<CourseService> _logger;
+    private readonly ICourseRepository _courseRepository;
+    private readonly ICourseGroupingRepository _courseGroupingRepository;
+
+    public CourseGroupingService(ILogger<CourseService> logger, ICourseRepository courseRepository, ICourseGroupingRepository courseGroupingRepository)
+    {
+        _logger = logger;
+        _courseRepository = courseRepository;
+        _courseGroupingRepository = courseGroupingRepository;
+    }
+
+    public async Task<CourseGrouping> GetCourseGrouping(Guid groupingId)
+    {
+        CourseGrouping grouping = await _courseGroupingRepository.GetCourseGroupingById(groupingId)
+            ?? throw new NotFoundException($"The course grouping with ID {groupingId} was not found.");
+
+        await QueryRelatedCourseGroupingData(grouping);
+
+        return grouping;
+    }
+
+    public async Task<CourseGrouping> GetCourseGroupingByCommonIdentifier(Guid commonId)
+    {
+        CourseGrouping grouping = await _courseGroupingRepository.GetCourseGroupingByCommonIdentifier(commonId)
+            ?? throw new NotFoundException($"The course grouping with common ID {commonId} was not found.");
+
+        await QueryRelatedCourseGroupingData(grouping);
+
+        return grouping;
+    }
+
+    private async Task QueryRelatedCourseGroupingData(CourseGrouping grouping)
+    {
+        grouping.Courses = await GetCoursesFromIdentifiers(grouping.CourseIdentifiers);
+
+        foreach (var subGroupingReference in grouping.SubGroupingReferences)
+        {
+            var subGrouping = await GetCourseGroupingByCommonIdentifier(subGroupingReference.ChildGroupCommonIdentifier);
+            grouping.SubGroupings.Add(subGrouping);
+        }
+    }
+
+    private async Task<IList<Course>> GetCoursesFromIdentifiers(ICollection<CourseIdentifier> identifiers)
+    {
+        IList<int> courseIds = identifiers.Select(id => id.ConcordiaCourseId).ToList();
+
+        return await _courseRepository.GetCoursesByConcordiaCourseIds(courseIds);
+    }
+}

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
@@ -1,0 +1,85 @@
+﻿using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+using ConcordiaCurriculumManager.Repositories;
+using ConcordiaCurriculumManager.Services;
+using ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConcordiaCurriculumManagerTest.UnitTests.Services;
+
+[TestClass]
+public class CourseGroupingServiceTest
+{
+    private Mock<ILogger<CourseGroupingService>> logger = null!;
+    private Mock<ICourseRepository> courseRepository = null!;
+    private Mock<ICourseGroupingRepository> courseGroupingRepository = null!;
+
+    private CourseGroupingService courseGroupingService = null!;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        logger = new Mock<ILogger<CourseGroupingService>>();
+        courseRepository = new Mock<ICourseRepository>();
+        courseGroupingRepository = new Mock<ICourseGroupingRepository>();
+
+        courseGroupingService = new CourseGroupingService(
+            logger.Object,
+            courseRepository.Object,
+            courseGroupingRepository.Object
+        );
+    }
+
+    [TestMethod]
+    public async Task GetCourseGrouping_WithMultipleLevels_QueriesRecursively()
+    {
+        var grouping = TestData.GetSampleCourseGrouping();
+        var subgrouping = grouping.SubGroupings.First();
+        var course = grouping.Courses.First();
+        grouping.SubGroupings = new List<CourseGrouping>();
+        grouping.Courses = new List<Course>();
+        subgrouping.Courses = new List<Course>();
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingById(grouping.Id)).ReturnsAsync(grouping);
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingByCommonIdentifier(subgrouping.CommonIdentifier)).ReturnsAsync(subgrouping);
+        courseRepository.Setup(cr => cr.GetCoursesByConcordiaCourseIds(It.IsAny<IList<int>>())).ReturnsAsync(new List<Course> { { course } } );
+
+        var output = await courseGroupingService.GetCourseGrouping(grouping.Id);
+
+        Assert.AreEqual(course.Id, grouping.Courses.First().Id);
+        Assert.AreEqual(course.Id, subgrouping.Courses.First().Id);
+        Assert.AreEqual(subgrouping.CommonIdentifier, grouping.SubGroupings.First().CommonIdentifier);
+        Assert.AreEqual(subgrouping.CommonIdentifier, grouping.SubGroupingReferences.First().ChildGroupCommonIdentifier);
+
+        courseGroupingRepository.Verify(mock => mock.GetCourseGroupingById(It.IsAny<Guid>()), Times.Once());
+        courseGroupingRepository.Verify(mock => mock.GetCourseGroupingByCommonIdentifier(It.IsAny<Guid>()), Times.Once());
+        courseRepository.Verify(mock => mock.GetCoursesByConcordiaCourseIds(It.IsAny<List<int>>()), Times.Exactly(2));
+    }
+
+    [TestMethod]
+    public async Task GetCourseGrouping_WithLowestLevel_QueriesOnlyOnce()
+    {
+        var grouping = TestData.GetSampleCourseGrouping().SubGroupings.First();
+        var course = grouping.Courses.First();
+        grouping.Courses = new List<Course>();
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingById(grouping.Id)).ReturnsAsync(grouping);
+        courseRepository.Setup(cr => cr.GetCoursesByConcordiaCourseIds(It.IsAny<IList<int>>())).ReturnsAsync(new List<Course> { { course } });
+
+        var output = await courseGroupingService.GetCourseGrouping(grouping.Id);
+
+        Assert.AreEqual(course.Id, grouping.Courses.First().Id);
+        Assert.AreEqual(0, grouping.SubGroupings.Count);
+
+        courseGroupingRepository.Verify(mock => mock.GetCourseGroupingById(It.IsAny<Guid>()), Times.Once());
+        courseGroupingRepository.Verify(mock => mock.GetCourseGroupingByCommonIdentifier(It.IsAny<Guid>()), Times.Never());
+        courseRepository.Verify(mock => mock.GetCoursesByConcordiaCourseIds(It.IsAny<List<int>>()), Times.Once());
+    }
+}

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
@@ -6,6 +6,7 @@ using ConcordiaCurriculumManager.Models.Users;
 using ConcordiaCurriculumManager.DTO.Dossiers;
 using ConcordiaCurriculumManager.DTO.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
 
 namespace ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
 public static class TestData
@@ -545,6 +546,61 @@ public static class TestData
         {
             Id = Guid.NewGuid(),
             Name = "Senate"
+        };
+    }
+
+    // COURSE GROUPINGS
+    public static CourseGrouping GetSampleCourseGrouping()
+    {
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        var common1 = Guid.NewGuid();
+        var common2 = Guid.NewGuid();
+        var course = GetSampleAcceptedCourse();
+
+        return new CourseGrouping
+        {
+            Id = id1,
+            CommonIdentifier = common1,
+            Name = "Top level",
+            RequiredCredits = "30.00",
+            IsTopLevel = true,
+            School = SchoolEnum.GinaCody,
+            State = CourseGroupingStateEnum.Accepted,
+            Published = true,
+            SubGroupingReferences = new List<CourseGroupingReference>
+            {
+                {
+                    new CourseGroupingReference
+                    {
+                        ParentGroupId = id1,
+                        ChildGroupCommonIdentifier = common2,
+                        GroupingType = GroupingTypeEnum.SubGrouping
+                    }
+                }
+            },
+            SubGroupings = new List<CourseGrouping>
+            {
+                {
+                    new CourseGrouping
+                    {
+                        Id = id2,
+                        CommonIdentifier = common2,
+                        Name = "subgroup",
+                        RequiredCredits = "10.00",
+                        IsTopLevel = false,
+                        School = SchoolEnum.GinaCody,
+                        State = CourseGroupingStateEnum.Accepted,
+                        Published = true,
+                        SubGroupingReferences = new List<CourseGroupingReference>(),
+                        SubGroupings = new List<CourseGrouping>(),
+                        CourseIdentifiers = new List<CourseIdentifier>() { { new CourseIdentifier { ConcordiaCourseId = course.CourseID } } },
+                        Courses = new List<Course>() { { course } }
+                    }
+                }
+            },
+            CourseIdentifiers = new List<CourseIdentifier>() { { new CourseIdentifier { ConcordiaCourseId = course.CourseID } } },
+            Courses = new List<Course>() { { course } }
         };
     }
 }


### PR DESCRIPTION
Setup curriculums, called CourseGroupings. Each course grouping is composed of courses and other course groupings, making the structure recursive. Each course grouping has an ID to represent its row in the database and a CommonIdentifier, which is roughly analogous to the Course model's CourseID field and can be used to represent this grouping across different versions. The versioning system of course groupings follows a similar pattern to the versioning system of the courses.

The course groupings keep track of which groupings are children to them through a List of CourseGroupingReference objects, each with a reference to the parent row and the child's CommonIdentifier, rather than its ID, so that the parent can track the child across different versions. A grouping may be a child to multiple parent groupings. Each CourseGroupingReference has a GroupingType field, which represents various purposes of subgroupings. Some subgroupings represent a mandatory set of courses (such as the Engineering Core to all engineering programs), while others represent optional suggestions, such as software engineering's games group or its web applications group). As we seed more curriculums, we can add more types, as needed.

Groupings have a many-to-many relationship to courses, thus each grouping has a List of CourseIdentifier objects, each containing the CourseID of the referenced course, rather than the ID of the referenced course, so that the course grouping can track the same course across all its versions.

The Seeder project is modified to seed the data for the Industrial Engineering curriculum. To access this data for visualization purposes, query `/CourseGrouping/GetCourseGrouping/bdc47eed-7567-4d80-8e93-d5b41fa2059e`. The industrial engineering curriculum after being mapped to its DTO looks like so: 
[industrialengineering.txt](https://github.com/JamesPartsafas/ConcordiaCurriculumManager/files/13846198/industrialengineering.txt)

Due to the complexity of the modeling of course groupings, the querying of it is somewhat inefficient, requiring an extra query to get all its courses (an already complex query) and for each subgrouping, we must recursively repeat the querying process. If we find it slow, we can optimize this at a later date, but currently it loads quite fast regardless.

This PR closes #277  