### PR TITLE
#310 Remove object selectors for course and role

### DIFF
--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/Course.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/Course.cs
@@ -43,9 +43,9 @@ public class Course : BaseModel
     public CourseDeletionRequest? CourseDeletionRequest { get; set; }
 
     // Self-reference related fields
-    public ICollection<CourseReference>? CourseReferenced { get; set; }
+    public ICollection<CourseReference> CourseReferenced { get; set; } = new List<CourseReference>();
 
-    public ICollection<CourseReference>? CourseReferencing { get; set; }
+    public ICollection<CourseReference> CourseReferencing { get; set; } = new List<CourseReference>();
 
     public bool IsCourseStateFinalized() => CourseState == CourseStateEnum.Accepted || CourseState == CourseStateEnum.Deleted;
 

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
@@ -40,7 +40,14 @@ public class CourseRepository : ICourseRepository
             && (course.CourseState == CourseStateEnum.Accepted || course.CourseState == CourseStateEnum.Deleted
             && course.Version != null))
         .OrderByDescending(course => course.Version)
-        .Select(ObjectSelectors.CourseSelector())
+        .Include(course => course.CourseCourseComponents)
+        .Include(course => course.CourseCreationRequest)
+        .Include(course => course.CourseModificationRequest)
+        .Include(course => course.CourseDeletionRequest)
+        .Include(course => course.CourseReferencing)
+        .ThenInclude(cr => cr.CourseReferenced)
+        .Include(course => course.CourseReferenced)
+        .ThenInclude(cr => cr.CourseReferencing)
         .FirstOrDefaultAsync();
 
     public async Task<bool> SaveCourse(Course course)
@@ -78,7 +85,14 @@ public class CourseRepository : ICourseRepository
     public async Task<Course?> GetCourseByCourseId(int courseId) => await _dbContext.Courses
         .Where(course => course.CourseID == courseId && course.CourseState == CourseStateEnum.Accepted)
         .OrderByDescending(course => course.Version)
-        .Select(ObjectSelectors.CourseSelector())
+        .Include(course => course.CourseCourseComponents)
+        .Include(course => course.CourseCreationRequest)
+        .Include(course => course.CourseModificationRequest)
+        .Include(course => course.CourseDeletionRequest)
+        .Include(course => course.CourseReferencing)
+        .ThenInclude(cr => cr.CourseReferenced)
+        .Include(course => course.CourseReferenced)
+        .ThenInclude(cr => cr.CourseReferencing)
         .FirstOrDefaultAsync();
 
     public Task<Course?> GetCourseWithSupportingFilesBySubjectAndCatalog(string subject, string catalog) => _dbContext.Courses

--- a/Server/ConcordiaCurriculumManager/Repositories/ObjectSelectors.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/ObjectSelectors.cs
@@ -9,11 +9,6 @@ namespace ConcordiaCurriculumManager.Repositories;
 
 public static class ObjectSelectors
 {
-    public static Expression<Func<Role, Role>> RoleSelector() => role => new Role
-    {
-        UserRole = role.UserRole
-    };
-
     public static Expression<Func<User, User>> UserSelector() => user => new User
     {
         Id = user.Id,
@@ -65,91 +60,5 @@ public static class ObjectSelectors
                 UserRole = role.UserRole
             })
         })
-    };
-
-    public static Expression<Func<Course, Course>> CourseSelector() => course => new Course
-    {
-        Id = course.Id,
-        CreatedDate = course.CreatedDate,
-        ModifiedDate = course.ModifiedDate,
-        CourseID = course.CourseID,
-        Subject = course.Subject,
-        Catalog = course.Catalog,
-        Title = course.Title,
-        Description = course.Description,
-        CourseNotes = course.CourseNotes,
-        CreditValue = course.CreditValue,
-        PreReqs = course.PreReqs,
-        Career = course.Career,
-        EquivalentCourses = course.EquivalentCourses,
-        CourseState = course.CourseState,
-        Version = course.Version,
-        Published = course.Published,
-        CourseCourseComponents = course.CourseCourseComponents != null ? (ICollection<CourseCourseComponent>)course.CourseCourseComponents.Select(component => new CourseCourseComponent
-        {
-            Id = component.Id,
-            CreatedDate = component.CreatedDate,
-            ModifiedDate = component.ModifiedDate,
-            CourseComponent = component.CourseComponent,
-            ComponentCode = component.ComponentCode,
-            CourseId = component.CourseId,
-            HoursPerWeek = component.HoursPerWeek
-        }) : null,
-        CourseCreationRequest = course.CourseCreationRequest != null ? new CourseCreationRequest
-        {
-            Id = course.CourseCreationRequest.Id,
-            CreatedDate = course.CourseCreationRequest.CreatedDate,
-            ModifiedDate = course.CourseCreationRequest.ModifiedDate,
-            NewCourseId = course.CourseCreationRequest.NewCourseId,
-            NewCourse = course.CourseCreationRequest.NewCourse,
-            DossierId = course.CourseCreationRequest.DossierId,
-            ResourceImplication = course.CourseCreationRequest.ResourceImplication,
-            Rationale = course.CourseCreationRequest.Rationale,
-            Comment = course.CourseCreationRequest.Comment
-        } : null,
-        CourseModificationRequest = course.CourseModificationRequest != null ? new CourseModificationRequest
-        {
-            Id = course.CourseModificationRequest.Id,
-            CreatedDate = course.CourseModificationRequest.CreatedDate,
-            ModifiedDate = course.CourseModificationRequest.ModifiedDate,
-            CourseId = course.CourseModificationRequest.CourseId,
-            Course = course.CourseModificationRequest.Course,
-            DossierId = course.CourseModificationRequest.DossierId,
-            ResourceImplication = course.CourseModificationRequest.ResourceImplication,
-            Rationale = course.CourseModificationRequest.Rationale,
-            Comment = course.CourseModificationRequest.Comment
-        } : null,
-        CourseDeletionRequest = course.CourseDeletionRequest != null ? new CourseDeletionRequest
-        {
-            Id = course.CourseDeletionRequest.Id,
-            CreatedDate = course.CourseDeletionRequest.CreatedDate,
-            ModifiedDate = course.CourseDeletionRequest.ModifiedDate,
-            CourseId = course.CourseDeletionRequest.CourseId,
-            Course = course.CourseDeletionRequest.Course,
-            DossierId = course.CourseDeletionRequest.DossierId,
-            ResourceImplication = course.CourseDeletionRequest.ResourceImplication,
-            Rationale = course.CourseDeletionRequest.Rationale,
-            Comment = course.CourseDeletionRequest.Comment
-        } : null,
-        CourseReferenced = course.CourseReferenced != null ? (ICollection<CourseReference>)course.CourseReferenced.Select(courseRefenced => new CourseReference
-        {
-            Id = courseRefenced.Id,
-            CreatedDate = courseRefenced.CreatedDate,
-            ModifiedDate = courseRefenced.ModifiedDate,
-            CourseReferencingId = courseRefenced.CourseReferencingId,
-            CourseReferencing = courseRefenced.CourseReferencing,
-            CourseReferencedId = courseRefenced.CourseReferencedId,
-            CourseReferenced = courseRefenced.CourseReferenced
-        }) : null,
-        CourseReferencing = course.CourseReferencing != null ? (ICollection<CourseReference>)course.CourseReferencing.Select(courseRefencing => new CourseReference
-        {
-            Id = courseRefencing.Id,
-            CreatedDate = courseRefencing.CreatedDate,
-            ModifiedDate = courseRefencing.ModifiedDate,
-            CourseReferencingId = courseRefencing.CourseReferencingId,
-            CourseReferencing = courseRefencing.CourseReferencing,
-            CourseReferencedId = courseRefencing.CourseReferencedId,
-            CourseReferenced = courseRefencing.CourseReferenced
-        }) : null,
     };
 }


### PR DESCRIPTION
Remove object selectors for course and role, which simplifies the code and removes edge cases where certain courses like ENCS 282 couldn't have modification requests made for them. The UserSelector and GroupSelector were left in, as they are intricately tied and when replaced with .Include statements, many queries would break, and as such are beyond the scope of this task.

This PR closes #310 