### PR TITLE
#312 Implement endpoint to get course groupings by school

### DIFF
--- a/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 using ConcordiaCurriculumManager.DTO.CourseGrouping;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
 using ConcordiaCurriculumManager.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -32,5 +33,17 @@ public class CourseGroupingController : Controller
         var courseGroupingDTO = _mapper.Map<CourseGroupingDTO>(courseGrouping);
 
         return Ok(courseGroupingDTO);
+    }
+
+    [HttpGet(nameof(GetCourseGroupingsBySchool) + "/{school}")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Course grouping data retrieved")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    public async Task<ActionResult> GetCourseGroupingsBySchool([FromRoute, Required] SchoolEnum school)
+    {
+        var courseGroupings = await _courseGroupingService.GetCourseGroupingsBySchoolNonRecursive(school);
+        var courseGroupingDTOs = _mapper.Map<ICollection<CourseGroupingDTO>>(courseGroupings);
+
+        return Ok(courseGroupingDTOs);
     }
 }

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
@@ -9,6 +9,7 @@ public interface ICourseGroupingRepository
 {
     public Task<CourseGrouping?> GetCourseGroupingById(Guid groupingId);
     public Task<CourseGrouping?> GetCourseGroupingByCommonIdentifier(Guid commonId);
+    public Task<ICollection<CourseGrouping>> GetCourseGroupingsBySchool(SchoolEnum school);
 }
 
 public class CourseGroupingRepository : ICourseGroupingRepository
@@ -34,4 +35,10 @@ public class CourseGroupingRepository : ICourseGroupingRepository
         .Include(cg => cg.CourseIdentifiers)
         .OrderByDescending(cg => cg.Version)
         .FirstOrDefaultAsync();
+
+    public async Task<ICollection<CourseGrouping>> GetCourseGroupingsBySchool(SchoolEnum school) => await _dbContext.CourseGroupings
+        .Where(cg => cg.School.Equals(school) && cg.IsTopLevel)
+        .Include(cg => cg.SubGroupingReferences)
+        .Include(cg => cg.CourseIdentifiers)
+        .ToListAsync();
 }

--- a/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
@@ -9,6 +9,7 @@ public interface ICourseGroupingService
 {
     public Task<CourseGrouping> GetCourseGrouping(Guid groupingId);
     public Task<CourseGrouping> GetCourseGroupingByCommonIdentifier(Guid commonId);
+    public Task<ICollection<CourseGrouping>> GetCourseGroupingsBySchoolNonRecursive(SchoolEnum school);
 }
 
 public class CourseGroupingService : ICourseGroupingService
@@ -43,6 +44,9 @@ public class CourseGroupingService : ICourseGroupingService
 
         return grouping;
     }
+
+    public async Task<ICollection<CourseGrouping>> GetCourseGroupingsBySchoolNonRecursive(SchoolEnum school) =>
+        await _courseGroupingRepository.GetCourseGroupingsBySchool(school);
 
     private async Task QueryRelatedCourseGroupingData(CourseGrouping grouping)
     {

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
@@ -82,4 +82,17 @@ public class CourseGroupingServiceTest
         courseGroupingRepository.Verify(mock => mock.GetCourseGroupingByCommonIdentifier(It.IsAny<Guid>()), Times.Never());
         courseRepository.Verify(mock => mock.GetCoursesByConcordiaCourseIds(It.IsAny<List<int>>()), Times.Once());
     }
+
+    [TestMethod]
+    public async Task GetCourseGroupingBySchool_WithValidSchool_QueriesOnlyOnce()
+    {
+        var grouping = TestData.GetSampleCourseGrouping();
+        var groupings = new List<CourseGrouping> { { grouping } };
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingsBySchool(grouping.School)).ReturnsAsync(groupings);
+
+        var output = await courseGroupingService.GetCourseGroupingsBySchoolNonRecursive(grouping.School);
+
+        courseGroupingRepository.Verify(mock => mock.GetCourseGroupingsBySchool(It.IsAny<SchoolEnum>()), Times.Once());
+    }
 }


### PR DESCRIPTION
Create endpoint to get course groupings by the school they belong to. The API accepts either the stringified version of the school enum or the integer value when querying. This endpoint will be used as part of a curriculum browser page.

This PR closes #312 