### PR TITLE
#317 block deletion request

### DIFF
--- a/App/src/pages/DeleteCourse.tsx
+++ b/App/src/pages/DeleteCourse.tsx
@@ -83,8 +83,13 @@ export default function DeleteCourse() {
                     toggleLoading(false);
                     navigate(BaseRoutes.DossierDetails.replace(":dossierId", dossierId));
                 })
-                .catch(() => {
-                    showToast(toast, "Error!", "One or more validation errors occurred", "error");
+                .catch((err) => {
+                    showToast(
+                        toast,
+                        "Error!",
+                        err.response ? err.response.data : "One or more validation errors occurred",
+                        "error"
+                    );
                     toggleLoading(false);
                 });
         }

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
@@ -9,6 +9,7 @@ public interface ICourseGroupingRepository
 {
     public Task<CourseGrouping?> GetCourseGroupingById(Guid groupingId);
     public Task<CourseGrouping?> GetCourseGroupingByCommonIdentifier(Guid commonId);
+    public Task<CourseGrouping?> GetCourseGroupingContainingCourse(Course course);
 }
 
 public class CourseGroupingRepository : ICourseGroupingRepository
@@ -33,5 +34,10 @@ public class CourseGroupingRepository : ICourseGroupingRepository
         .Include(cg => cg.SubGroupingReferences)
         .Include(cg => cg.CourseIdentifiers)
         .OrderByDescending(cg => cg.Version)
+        .FirstOrDefaultAsync();
+
+    public async Task<CourseGrouping?> GetCourseGroupingContainingCourse(Course course) => await _dbContext.CourseGroupings
+        .Include(cg => cg.CourseIdentifiers)
+        .Where(cg => cg.CourseIdentifiers.Any(ci => ci.ConcordiaCourseId.Equals(course.CourseID)))
         .FirstOrDefaultAsync();
 }


### PR DESCRIPTION
If a course is part of a course grouping, a deletion request for it cannot be created, to ensure consistency in data. In addition, the frontend is modified to correctly display the error message.

This PR closes #317.