### PR TITLE
Important fix in initiating a course creation request

### DIFF
--- a/Server/ConcordiaCurriculumManager/Program.cs
+++ b/Server/ConcordiaCurriculumManager/Program.cs
@@ -206,5 +206,6 @@ public class Program
         services.AddScoped<ICourseGroupingRepository, CourseGroupingRepository>();
         services.AddScoped<IDossierRepository, DossierRepository>();
         services.AddScoped<IDossierReviewRepository, DossierReviewRepository>();
+        services.AddScoped<ICourseIdentifiersRepository, CourseIdentifiersRepository>();
     }
 }

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseIdentifiersRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseIdentifiersRepository.cs
@@ -1,0 +1,37 @@
+﻿using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
+using ConcordiaCurriculumManager.Repositories.DatabaseContext;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcordiaCurriculumManager.Repositories
+{
+    public interface ICourseIdentifiersRepository
+    {
+        public Task<CourseIdentifier?> GetCourseIdentifierByConcordiaCourseId(int concordiaCourseId);
+        public Task<bool> SaveCourseIdentifier(CourseIdentifier courseIdentifier);
+    }
+
+    public class CourseIdentifiersRepository: ICourseIdentifiersRepository
+    {
+        private readonly CCMDbContext _dbContext;
+
+        public CourseIdentifiersRepository(CCMDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task<CourseIdentifier?> GetCourseIdentifierByConcordiaCourseId(int concordiaCourseId)
+        {
+            return await _dbContext.CourseIdentifiers
+                .Where(ci => ci.ConcordiaCourseId.Equals(concordiaCourseId))
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<bool> SaveCourseIdentifier(CourseIdentifier courseIdentifier)
+        {
+            await _dbContext.CourseIdentifiers.AddAsync(courseIdentifier);
+            var result = await _dbContext.SaveChangesAsync();
+            return result > 0;
+        }
+    }
+}
+

--- a/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseRepository.cs
@@ -18,6 +18,7 @@ public interface ICourseRepository
     public Task<Course?> GetCourseWithSupportingFilesBySubjectAndCatalog(string subject, string catalog);
     public Task<int?> GetCurrentCourseVersion(string subject, string catalog);
     public Task<Course?> GetPublishedVersion(string subject, string catalog);
+    public Task<Course?> GetCourseInProposalBySubjectAndCatalog(string subject, string catalog);
 }
 
 public class CourseRepository : ICourseRepository
@@ -122,4 +123,11 @@ public class CourseRepository : ICourseRepository
             && course.Published)
         .Include(course => course.CourseCourseComponents)
         .FirstOrDefaultAsync();
+
+    public async Task<Course?> GetCourseInProposalBySubjectAndCatalog(string subject, string catalog) => await _dbContext.Courses
+    .Where(course =>
+            course.Subject == subject
+            && course.Catalog == catalog
+            && course.CourseState == CourseStateEnum.NewCourseProposal)
+    .FirstOrDefaultAsync();
 }

--- a/Server/ConcordiaCurriculumManager/Services/CourseService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseService.cs
@@ -2,6 +2,7 @@
 using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests.InputDTOs;
 using ConcordiaCurriculumManager.Filters.Exceptions;
 using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGrouping;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 using ConcordiaCurriculumManager.Models.Users;
 using ConcordiaCurriculumManager.Repositories;
@@ -37,19 +38,22 @@ public class CourseService : ICourseService
     private readonly IDossierService _dossierService;
     private readonly IDossierRepository _dossierRepository;
     private readonly ICourseGroupingRepository _courseGroupingRepository;
+    private readonly ICourseIdentifiersRepository _courseIdentifiersRepository;
 
     public CourseService(
         ILogger<CourseService> logger,
         ICourseRepository courseRepository,
         IDossierService dossierService,
         IDossierRepository dossierRepository,
-        ICourseGroupingRepository courseGroupingRepository)
+        ICourseGroupingRepository courseGroupingRepository,
+        ICourseIdentifiersRepository courseIdentifierRepository)
     {
         _logger = logger;
         _courseRepository = courseRepository;
         _dossierService = dossierService;
         _dossierRepository = dossierRepository;
         _courseGroupingRepository = courseGroupingRepository;
+        _courseIdentifiersRepository = courseIdentifierRepository;
     }
 
     public IEnumerable<CourseCareerDTO> GetAllCourseCareers()
@@ -139,6 +143,18 @@ public class CourseService : ICourseService
             Comment = initiation.Comment,
             Conflict = string.Empty,
         };
+
+        var courseIdentifier = await _courseIdentifiersRepository.GetCourseIdentifierByConcordiaCourseId(course.CourseID);
+
+        if (courseIdentifier is null)
+        {
+            courseIdentifier = new CourseIdentifier
+            {
+                Id = Guid.NewGuid(),
+                ConcordiaCourseId = course.CourseID
+            };
+            await _courseIdentifiersRepository.SaveCourseIdentifier(courseIdentifier);
+        }
 
         await _dossierService.SaveCourseCreationRequest(courseCreationRequest);
 

--- a/Server/ConcordiaCurriculumManager/Services/CourseService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseService.cs
@@ -127,11 +127,14 @@ public class CourseService : ICourseService
 
         Dossier dossier = await _dossierService.GetDossierForUserOrThrow(initiation.DossierId, userId);
 
-        int concordiaCourseId = courseFromDb != null ? courseFromDb.CourseID : (await _courseRepository.GetMaxCourseId()) + 1;
+        var courseInProposal = await _courseRepository.GetCourseInProposalBySubjectAndCatalog(initiation.Subject, initiation.Catalog);
+
+        int concordiaCourseId;
+        if (courseFromDb != null) concordiaCourseId = courseFromDb.CourseID;
+        else if (courseInProposal != null) concordiaCourseId = courseInProposal.CourseID;
+        else concordiaCourseId = (await _courseRepository.GetMaxCourseId()) + 1;
 
         var course = Course.CreateCourseFromDTOData(initiation, concordiaCourseId, null);
-
-        var courseInProposal = await _courseRepository.GetCourseInProposalBySubjectAndCatalog(course.Subject, course.Catalog);
 
         if (courseInProposal is null && courseFromDb is null)
         {

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/CourseIdentifiersRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/CourseIdentifiersRepositoryTests.cs
@@ -1,0 +1,57 @@
+﻿using ConcordiaCurriculumManager.Repositories;
+using ConcordiaCurriculumManager.Repositories.DatabaseContext;
+using ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
+using Microsoft.EntityFrameworkCore;
+
+namespace ConcordiaCurriculumManagerTest.IntegrationTests.Repositories
+{
+    [TestClass]
+    public class CourseIdentifiersRepositoryTests
+    {
+        private static CCMDbContext dbContext = null!;
+        private ICourseIdentifiersRepository courseIdentifiersRepository = null!;
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext _)
+        {
+            var options = new DbContextOptionsBuilder<CCMDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            dbContext = new CCMDbContext(options);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup() => dbContext.Dispose();
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            courseIdentifiersRepository = new CourseIdentifiersRepository(dbContext);
+        }
+
+        [TestMethod]
+        public async Task GetCourseIdentiferByConcordiaCourseId_ValidId_ReturnsCourseIdentifier()
+        {
+            var courseIdentifier = TestData.GetSampleCourseIdentifier();
+
+            dbContext.CourseIdentifiers.Add(courseIdentifier);
+            await dbContext.SaveChangesAsync();
+
+            var result = await courseIdentifiersRepository.GetCourseIdentifierByConcordiaCourseId(courseIdentifier.ConcordiaCourseId);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.ConcordiaCourseId, courseIdentifier.ConcordiaCourseId);
+        }
+
+        [TestMethod]
+        public async Task SaveCourseIdentifier_ReturnsTrue()
+        {
+            var courseIdentifier = TestData.GetSampleCourseIdentifier();
+
+            var result = await courseIdentifiersRepository.SaveCourseIdentifier(courseIdentifier);
+
+            Assert.IsTrue(result);
+        }
+    }
+}
+

--- a/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/CourseRepositoryTests.cs
+++ b/Server/ConcordiaCurriculumManagerTest/IntegrationTests/Repositories/CourseRepositoryTests.cs
@@ -300,4 +300,39 @@ public class CourseRepositoryTests
         Assert.IsNotNull(result.CourseCourseComponents);
         Assert.IsNotNull(result.SupportingFiles);
     }
+
+    [TestMethod]
+    public async Task GetCourseInProposalBySubjectAndCatalog_ValidSubjectAndCatalog_ReturnsCourse()
+    {
+        var id = Guid.NewGuid();
+        var course = new Course
+        {
+            Id = Guid.NewGuid(),
+            CourseID = 1000,
+            Subject = "SOEN",
+            Catalog = "490",
+            Title = "Capstone",
+            Description = "Curriculum manager building simulator",
+            CreditValue = "6",
+            PreReqs = "SOEN 390",
+            CourseNotes = "Lots of fun",
+            Career = CourseCareerEnum.UGRD,
+            EquivalentCourses = "",
+            CourseState = CourseStateEnum.NewCourseProposal,
+            Version = 1,
+            Published = true,
+            CourseCourseComponents = CourseCourseComponent.GetComponentCodeMapping(new Dictionary<ComponentCodeEnum, int?>
+                { { ComponentCodeEnum.LEC, 3 }, { ComponentCodeEnum.WKS, 5 } },
+                id
+            )
+        };
+
+        dbContext.Courses.Add(course);
+        await dbContext.SaveChangesAsync();
+
+        var result = await courseRepository.GetCourseInProposalBySubjectAndCatalog("SOEN", "490");
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(result.CourseID, course.CourseID);
+    }
 }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseServiceTest.cs
@@ -19,6 +19,7 @@ public class CourseServiceTest
     private CourseService courseService = null!;
     private Mock<IDossierRepository> dossierRepository = null!;
     private Mock<ICourseGroupingRepository> courseGroupingRepository = null!;
+    private Mock<ICourseIdentifiersRepository> courseIdentifierRepository = null!;
 
     [TestInitialize]
     public void TestInitialize()
@@ -28,8 +29,9 @@ public class CourseServiceTest
         dossierService = new Mock<IDossierService>();
         dossierRepository = new Mock<IDossierRepository>();
         courseGroupingRepository = new Mock<ICourseGroupingRepository>();
+        courseIdentifierRepository = new Mock<ICourseIdentifiersRepository>();
 
-        courseService = new CourseService(logger.Object, courseRepository.Object, dossierService.Object, dossierRepository.Object, courseGroupingRepository.Object);
+        courseService = new CourseService(logger.Object, courseRepository.Object, dossierService.Object, dossierRepository.Object, courseGroupingRepository.Object, courseIdentifierRepository.Object);
     }
 
     [TestMethod]

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
@@ -628,4 +628,13 @@ public static class TestData
             Courses = new List<Course>() { { course } }
         };
     }
+
+    public static CourseIdentifier GetSampleCourseIdentifier()
+    {
+        return new CourseIdentifier
+        {
+            Id = Guid.NewGuid(),
+            ConcordiaCourseId = 999999,
+        };
+    }
 }


### PR DESCRIPTION
When initiating a course creation request, the CourseIdentifier table should be updated so course grouping data is consistent. This PR closes #322 .