### PR TITLE
Implement endpoint to edit a curriculum deletion request

### DIFF
--- a/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
@@ -119,6 +119,19 @@ public class CourseGroupingController : Controller
         return Created($"/{nameof(EditCourseGroupingModification)}", groupingDTO);
     }
 
+    [HttpPut(nameof(EditCourseGroupingDeletion) + "/{dossierId}" + "/{requestId}")]
+    [Authorize(Policies.IsOwnerOfDossier)]
+    [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    [SwaggerResponse(StatusCodes.Status201Created, "Course grouping deletion edited successfully", typeof(CourseGroupingRequestDTO))]
+    public async Task<ActionResult> EditCourseGroupingDeletion([FromRoute, Required] Guid requestId, [FromBody, Required] CourseGroupingModificationRequestDTO dto)
+    {
+        var grouping = await _courseGroupingService.EditCourseGroupingDeletion(requestId, dto);
+        var groupingDTO = _mapper.Map<CourseGroupingRequestDTO>(grouping);
+
+        return Created($"/{nameof(EditCourseGroupingDeletion)}", groupingDTO);
+    }
+
     [HttpDelete(nameof(DeleteCourseGroupingRequest) + "/{dossierId}" + "/{requestId}")]
     [Authorize(Policies.IsOwnerOfDossier)]
     [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]

--- a/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
@@ -20,6 +20,7 @@ public interface ICourseGroupingService
     public Task<CourseGroupingRequest> InitiateCourseGroupingModification(CourseGroupingModificationRequestDTO dto);
     public Task<CourseGroupingRequest> InitiateCourseGroupingDeletion(CourseGroupingModificationRequestDTO dto);
     public Task<CourseGroupingRequest> EditCourseGroupingModification(Guid originalRequestId, CourseGroupingModificationRequestDTO dto);
+    public Task<CourseGroupingRequest> EditCourseGroupingDeletion(Guid originalRequestId, CourseGroupingModificationRequestDTO dto);
     public Task DeleteCourseGroupingRequest(Guid dossierId, Guid requestId);
 }
 
@@ -169,6 +170,15 @@ public class CourseGroupingService : ICourseGroupingService
         await DeleteCourseGroupingRequest(dto.DossierId, originalRequestId);
 
         return await InitiateCourseGroupingModification(dto);
+    }
+
+    public async Task<CourseGroupingRequest> EditCourseGroupingDeletion(Guid originalRequestId, CourseGroupingModificationRequestDTO dto)
+    {
+        await VerifyEditRequestsMatchOrThrow(originalRequestId, dto);
+
+        await DeleteCourseGroupingRequest(dto.DossierId, originalRequestId);
+
+        return await InitiateCourseGroupingDeletion(dto);
     }
 
     private async Task VerifyEditRequestsMatchOrThrow(Guid originalRequestId, CourseGroupingModificationRequestDTO dto)

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
@@ -334,6 +334,61 @@ public class CourseGroupingServiceTest
     }
 
     [TestMethod]
+    [ExpectedException(typeof(ServiceUnavailableException))]
+    public async Task EditCourseGroupingDeletion_FailsToQuery_Throws()
+    {
+        var dto = TestData.GetSampleCourseGroupingModificationRequestDTO();
+        var originalRequestId = Guid.NewGuid();
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingRequestById(originalRequestId)).ReturnsAsync((CourseGroupingRequest)null!);
+
+        await courseGroupingService.EditCourseGroupingDeletion(originalRequestId, dto);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ServiceUnavailableException))]
+    public async Task EditCourseGroupingDeletion_FailsToQueryIncludedGrouping_Throws()
+    {
+        var dto = TestData.GetSampleCourseGroupingModificationRequestDTO();
+        var request = TestData.GetSampleCourseGroupingRequest();
+        request.CourseGrouping = null;
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingRequestById(request.Id)).ReturnsAsync(request);
+
+        await courseGroupingService.EditCourseGroupingDeletion(request.Id, dto);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(BadRequestException))]
+    public async Task EditCourseGroupingDeletion_WithMismatchedCommonIdentifier_Throws()
+    {
+        var dto = TestData.GetSampleCourseGroupingModificationRequestDTO();
+        var request = TestData.GetSampleCourseGroupingRequest();
+        request.DossierId = dto.DossierId;
+        dto.CourseGrouping.CommonIdentifier = Guid.NewGuid();
+        request.CourseGrouping!.CommonIdentifier = Guid.NewGuid();
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingRequestById(request.Id)).ReturnsAsync(request);
+
+        await courseGroupingService.EditCourseGroupingDeletion(request.Id, dto);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(BadRequestException))]
+    public async Task EditCourseGroupingDeletion_WithMismatchedDossierId_Throws()
+    {
+        var dto = TestData.GetSampleCourseGroupingModificationRequestDTO();
+        var request = TestData.GetSampleCourseGroupingRequest();
+        request.DossierId = Guid.NewGuid();
+        dto.DossierId = Guid.NewGuid();
+        dto.CourseGrouping.CommonIdentifier = request.CourseGrouping!.CommonIdentifier;
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingRequestById(request.Id)).ReturnsAsync(request);
+
+        await courseGroupingService.EditCourseGroupingDeletion(request.Id, dto);
+    }
+
+    [TestMethod]
     [ExpectedException(typeof(BadRequestException))]
     public async Task DeleteCourseGroupingRequest_RequestDoesNotExist_Throws()
     {


### PR DESCRIPTION
As an initiator, I would like to be able to modify the data of a course grouping deletion request, including its base attributes such as its name or credits, as well as its courses and subgroupings.

This PR closes #415.