### PR TITLE
Implement endpoint to edit a curriculum creation request

### DIFF
--- a/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/CourseGroupingController.cs
@@ -106,6 +106,19 @@ public class CourseGroupingController : Controller
         return Created($"/{nameof(InitiateCourseGroupingDeletion)}", groupingDTO);
     }
 
+    [HttpPut(nameof(EditCourseGroupingCreation) + "/{dossierId}" + "/{requestId}")]
+    [Authorize(Policies.IsOwnerOfDossier)]
+    [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    [SwaggerResponse(StatusCodes.Status201Created, "Course grouping creation edited successfully", typeof(CourseGroupingRequestDTO))]
+    public async Task<ActionResult> EditCourseGroupingCreation([FromRoute, Required] Guid requestId, [FromBody, Required] CourseGroupingCreationRequestDTO dto)
+    {
+        var grouping = await _courseGroupingService.EditCourseGroupingCreation(requestId, dto);
+        var groupingDTO = _mapper.Map<CourseGroupingRequestDTO>(grouping);
+
+        return Created($"/{nameof(EditCourseGroupingCreation)}", groupingDTO);
+    }
+
     [HttpPut(nameof(EditCourseGroupingModification) + "/{dossierId}" + "/{requestId}")]
     [Authorize(Policies.IsOwnerOfDossier)]
     [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]

--- a/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
@@ -19,6 +19,7 @@ public interface ICourseGroupingService
     public Task<CourseGroupingRequest> InitiateCourseGroupingCreation(CourseGroupingCreationRequestDTO dto);
     public Task<CourseGroupingRequest> InitiateCourseGroupingModification(CourseGroupingModificationRequestDTO dto);
     public Task<CourseGroupingRequest> InitiateCourseGroupingDeletion(CourseGroupingModificationRequestDTO dto);
+    public Task<CourseGroupingRequest> EditCourseGroupingCreation(Guid originalRequestId, CourseGroupingCreationRequestDTO dto);
     public Task<CourseGroupingRequest> EditCourseGroupingModification(Guid originalRequestId, CourseGroupingModificationRequestDTO dto);
     public Task<CourseGroupingRequest> EditCourseGroupingDeletion(Guid originalRequestId, CourseGroupingModificationRequestDTO dto);
     public Task DeleteCourseGroupingRequest(Guid dossierId, Guid requestId);
@@ -161,6 +162,17 @@ public class CourseGroupingService : ICourseGroupingService
         var grouping = await _courseGroupingRepository.GetCourseGroupingByCommonIdentifier(dto.CommonIdentifier);
         if (grouping is null)
             throw new BadRequestException($"The course grouping with the identifier {dto.CommonIdentifier} does not exist");
+    }
+
+    public async Task<CourseGroupingRequest> EditCourseGroupingCreation(Guid originalRequestId, CourseGroupingCreationRequestDTO dto)
+    {
+        var request = await _courseGroupingRepository.GetCourseGroupingRequestById(originalRequestId);
+        if (request == null || request.CourseGrouping == null)
+            throw new ServiceUnavailableException("The course grouping request could not be edited");
+
+        await DeleteCourseGroupingRequest(dto.DossierId, originalRequestId);
+
+        return await InitiateCourseGroupingCreation(dto);
     }
 
     public async Task<CourseGroupingRequest> EditCourseGroupingModification(Guid originalRequestId, CourseGroupingModificationRequestDTO dto)

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseGroupingServiceTest.cs
@@ -280,6 +280,31 @@ public class CourseGroupingServiceTest
 
     [TestMethod]
     [ExpectedException(typeof(ServiceUnavailableException))]
+    public async Task EditCourseGroupingCreation_FailsToQuery_Throws()
+    {
+        var dto = TestData.GetSampleCourseGroupingCreationRequestDTO();
+        var originalRequestId = Guid.NewGuid();
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingRequestById(originalRequestId)).ReturnsAsync((CourseGroupingRequest)null!);
+
+        await courseGroupingService.EditCourseGroupingCreation(originalRequestId, dto);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ServiceUnavailableException))]
+    public async Task EditCourseGroupingCreation_FailsToQueryIncludedGrouping_Throws()
+    {
+        var dto = TestData.GetSampleCourseGroupingCreationRequestDTO();
+        var request = TestData.GetSampleCourseGroupingRequest();
+        request.CourseGrouping = null;
+
+        courseGroupingRepository.Setup(cgr => cgr.GetCourseGroupingRequestById(request.Id)).ReturnsAsync(request);
+
+        await courseGroupingService.EditCourseGroupingCreation(request.Id, dto);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ServiceUnavailableException))]
     public async Task EditCourseGroupingModification_FailsToQuery_Throws()
     {
         var dto = TestData.GetSampleCourseGroupingModificationRequestDTO();


### PR DESCRIPTION
As an initiator, I would like to be able to modify the data of a course grouping creation request.

This closes #416.