### PR TITLE
Add Browser Links and Course Groupings by Name Browser

### DIFF
--- a/App/src/App.tsx
+++ b/App/src/App.tsx
@@ -37,6 +37,7 @@ import DossierBrowser from "./pages/dossier/DossierBrowser";
 import GroupingBySchool from "./pages/CourseGroupingBySchool";
 import MyGroups from "./pages/groups/myGroups";
 import DossierChangeLog from "./pages/dossier/DossierChangeLog";
+import BrowserList from "./pages/BrowserList";
 
 export const UserContext = createContext<User | null>(null);
 
@@ -210,6 +211,11 @@ export function App() {
                     <Route
                         path={BaseRoutes.myGroups}
                         element={isLoggedIn == true ? <MyGroups /> : <Navigate to={BaseRoutes.Login} />}
+                    />
+
+                    <Route
+                        path={BaseRoutes.browserList}
+                        element={isLoggedIn == true ? <BrowserList /> : <Navigate to={BaseRoutes.Login} />}
                     />
                 </Routes>
             </UserContext.Provider>

--- a/App/src/App.tsx
+++ b/App/src/App.tsx
@@ -38,6 +38,7 @@ import GroupingBySchool from "./pages/CourseGroupingBySchool";
 import MyGroups from "./pages/groups/myGroups";
 import DossierChangeLog from "./pages/dossier/DossierChangeLog";
 import BrowserList from "./pages/BrowserList";
+import CourseGroupingByName from "./pages/CourseGroupingByName";
 
 export const UserContext = createContext<User | null>(null);
 
@@ -189,6 +190,10 @@ export function App() {
                     <Route
                         path={BaseRoutes.GroupingBySchool}
                         element={isLoggedIn == true ? <GroupingBySchool /> : <Navigate to={BaseRoutes.Login} />}
+                    />
+                    <Route
+                        path={BaseRoutes.GroupingByName}
+                        element={isLoggedIn == true ? <CourseGroupingByName /> : <Navigate to={BaseRoutes.Login} />}
                     />
                     <Route
                         path={BaseRoutes.NoData}

--- a/App/src/constants.ts
+++ b/App/src/constants.ts
@@ -28,4 +28,5 @@ export enum BaseRoutes {
     NoData = "/NoData",
     CourseGrouping = "/CourseGrouping/:courseGroupingId",
     myGroups = "/myGroups",
+    browserList = "/browserList",
 }

--- a/App/src/constants.ts
+++ b/App/src/constants.ts
@@ -25,6 +25,7 @@ export enum BaseRoutes {
     DossierBrowser = "/dossierbrowser",
     CourseDetails = "/CourseDetails",
     GroupingBySchool = "/GetCourseBySchool",
+    GroupingByName = "/GetCourseByName",
     NoData = "/NoData",
     CourseGrouping = "/CourseGrouping/:courseGroupingId",
     myGroups = "/myGroups",

--- a/App/src/pages/BrowserList.tsx
+++ b/App/src/pages/BrowserList.tsx
@@ -1,0 +1,65 @@
+import { Container, Stack, Text } from "@chakra-ui/react";
+import Button from "../components/Button";
+import { BaseRoutes } from "../constants";
+import { useNavigate } from "react-router-dom";
+
+export default function BrowserList() {
+    const navigate = useNavigate();
+    return (
+        <div>
+            <Container maxW={"5xl"} mt={5} pl={0}>
+                <Button
+                    style="primary"
+                    variant="outline"
+                    height="40px"
+                    width="fit-content"
+                    onClick={() => navigate(BaseRoutes.Home)}
+                >
+                    Return to Home
+                </Button>
+                <Text textAlign="center" fontSize="3xl" fontWeight="bold" marginTop="7%" marginBottom="5">
+                    Browser List
+                </Text>
+                <Stack spacing={6} direction={"row"} marginTop="7%" marginBottom="5">
+                    <Text fontWeight="bold">Course Browser: </Text>
+                    <Button
+                        style="primary"
+                        variant="solid"
+                        width="200px"
+                        height="40px"
+                        margin="0px"
+                        onClick={() => navigate(BaseRoutes.CourseBrowser)}
+                    >
+                        View Course Browser
+                    </Button>
+                </Stack>
+                <Stack spacing={6} direction={"row"} marginTop="7%" marginBottom="5">
+                    <Text fontWeight="bold">Dossier Browser: </Text>
+                    <Button
+                        style="primary"
+                        variant="solid"
+                        width="200px"
+                        height="40px"
+                        margin="0px"
+                        onClick={() => navigate(BaseRoutes.DossierBrowser)}
+                    >
+                        View Dossier Browser
+                    </Button>
+                </Stack>
+                <Stack spacing={6} direction={"row"} marginTop="7%" marginBottom="5">
+                    <Text fontWeight="bold">Curriculum by School Browser: </Text>
+                    <Button
+                        style="primary"
+                        variant="solid"
+                        width="240px"
+                        height="40px"
+                        margin="0px"
+                        onClick={() => navigate(BaseRoutes.GroupingBySchool)}
+                    >
+                        View Curriculum by School
+                    </Button>
+                </Stack>
+            </Container>
+        </div>
+    );
+}

--- a/App/src/pages/BrowserList.tsx
+++ b/App/src/pages/BrowserList.tsx
@@ -59,6 +59,45 @@ export default function BrowserList() {
                         View Curriculum by School
                     </Button>
                 </Stack>
+                <Stack spacing={6} direction={"row"} marginTop="7%" marginBottom="5">
+                    <Text fontWeight="bold">Curriculum by Name Browser: </Text>
+                    <Button
+                        style="primary"
+                        variant="solid"
+                        width="240px"
+                        height="40px"
+                        margin="0px"
+                        onClick={() => navigate(BaseRoutes.GroupingByName)}
+                    >
+                        View Curriculum by Name
+                    </Button>
+                </Stack>
+                <Stack spacing={6} direction={"row"} marginTop="7%" marginBottom="5">
+                    <Text fontWeight="bold">Courses by Subject Browser: </Text>
+                    <Button
+                        style="primary"
+                        variant="solid"
+                        width="240px"
+                        height="40px"
+                        margin="0px"
+                        //onClick={() => navigate(BaseRoutes.GroupingBySchool)}
+                    >
+                        View Course by Subject
+                    </Button>
+                </Stack>
+                <Stack spacing={6} direction={"row"} marginTop="7%" marginBottom="5">
+                    <Text fontWeight="bold">Group Browser: </Text>
+                    <Button
+                        style="primary"
+                        variant="solid"
+                        width="240px"
+                        height="40px"
+                        margin="0px"
+                        //onClick={() => navigate(BaseRoutes.GroupingBySchool)}
+                    >
+                        View Groups
+                    </Button>
+                </Stack>
             </Container>
         </div>
     );

--- a/App/src/pages/CourseGroupingByName.tsx
+++ b/App/src/pages/CourseGroupingByName.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { BaseRoutes } from "../constants";
+import { CourseGroupingDTO, MultiCourseGroupingDTO } from "../models/courseGrouping";
+import { useNavigate } from "react-router-dom";
+import {
+    Box,
+    Flex,
+    FormControl,
+    FormLabel,
+    Input,
+    Table,
+    TableContainer,
+    Text,
+    Tr,
+    Thead,
+    Th,
+    Tbody,
+    Td,
+    Tooltip,
+    IconButton,
+} from "@chakra-ui/react";
+import { InfoIcon } from "@chakra-ui/icons";
+import Button from "../components/Button";
+import { GetCourseGroupingByName } from "../services/courseGrouping";
+
+export default function CourseGroupingByName() {
+    const [courseGroupings, setCourseGroupings] = useState<CourseGroupingDTO[]>([]);
+    const [searchInput, setSearchInput] = useState<string>("");
+    const handleChange = (event) => setSearchInput(event.target.value);
+    const navigate = useNavigate();
+
+    function handleNavigateToCurriculumDetails(input: string) {
+        console.log(input);
+        navigate(BaseRoutes.CourseGrouping.replace(":courseGroupingId", input));
+    }
+
+    function searchByName(name: string) {
+        GetCourseGroupingByName(name)
+            .then((res: MultiCourseGroupingDTO) => {
+                setCourseGroupings(res.data);
+            })
+            .catch((err) => {
+                console.log(err);
+            });
+    }
+    return (
+        <div>
+            <Box maxW="5xl" m="auto">
+                <Flex flexDirection="column">
+                    <Text textAlign="center" fontSize="3xl" fontWeight="bold" marginTop="7%" marginBottom="5">
+                        Curriculum by Name
+                    </Text>
+                    <FormControl>
+                        <FormLabel htmlFor="search-text">Search By Title:</FormLabel>
+                        <Input id="searcher" type="text" value={searchInput} onChange={handleChange} />
+                    </FormControl>
+                    <Button
+                        mt={4}
+                        mb={2}
+                        style="secondary"
+                        variant="outline"
+                        width="22%"
+                        height="40px"
+                        onClick={() => {
+                            searchByName(searchInput);
+                        }}
+                    >
+                        Search
+                    </Button>
+                    <TableContainer borderRadius="xl" boxShadow="xl" border="2px">
+                        <Table variant="simple" style={{ backgroundColor: "white", tableLayout: "auto" }}>
+                            <Thead backgroundColor={"#e2e8f0"}>
+                                <Tr display={"flex"}>
+                                    <Th minW={"250px"} maxW={"250px"}>
+                                        Name
+                                    </Th>
+                                    <Th minW={"450px"} maxW={"450px"}>
+                                        Credits Required
+                                    </Th>
+                                    <Th minW={"120px"} maxW={"120px"}>
+                                        State
+                                    </Th>
+                                    <Th width={"25%"}>See Details</Th>
+                                </Tr>
+                            </Thead>
+                            <Tbody>
+                                {courseGroupings.slice(0, courseGroupings.length).map((grouping) => (
+                                    <Tr key={grouping.id} display={"flex"}>
+                                        <Td minW={"250px"} maxW={"250px"}>
+                                            {grouping.name}
+                                        </Td>
+                                        <Td minW={"455px"} maxW={"455px"}>
+                                            <Text overflow="hidden" textOverflow="ellipsis" maxW={"500px"}>
+                                                {grouping.requiredCredits}
+                                            </Text>
+                                        </Td>
+                                        <Td minW={"130px"} maxW={"130px"}>
+                                            {grouping.school}
+                                        </Td>
+
+                                        <Td width={"25%"}>
+                                            <Tooltip label="Curriculum Details">
+                                                <IconButton
+                                                    ml={2}
+                                                    aria-label="Details"
+                                                    icon={<InfoIcon />}
+                                                    onClick={() => {
+                                                        handleNavigateToCurriculumDetails(grouping.id);
+                                                    }}
+                                                />
+                                            </Tooltip>
+                                        </Td>
+                                    </Tr>
+                                ))}
+                            </Tbody>
+                        </Table>
+                    </TableContainer>
+                </Flex>
+            </Box>
+        </div>
+    );
+}

--- a/App/src/pages/CourseGroupingByName.tsx
+++ b/App/src/pages/CourseGroupingByName.tsx
@@ -71,13 +71,19 @@ export default function CourseGroupingByName() {
                         <Table variant="simple" style={{ backgroundColor: "white", tableLayout: "auto" }}>
                             <Thead backgroundColor={"#e2e8f0"}>
                                 <Tr display={"flex"}>
-                                    <Th minW={"250px"} maxW={"250px"}>
+                                    <Th
+                                        overflow="hidden"
+                                        textOverflow="ellipsis"
+                                        minW={"250px"}
+                                        maxW={"250px"}
+                                        style={{ whiteSpace: "normal" }}
+                                    >
                                         Name
                                     </Th>
-                                    <Th minW={"450px"} maxW={"450px"}>
+                                    <Th overflow="hidden" textOverflow="ellipsis" minW={"450px"} maxW={"450px"}>
                                         Credits Required
                                     </Th>
-                                    <Th minW={"120px"} maxW={"120px"}>
+                                    <Th overflow="hidden" textOverflow="ellipsis" minW={"120px"} maxW={"120px"}>
                                         State
                                     </Th>
                                     <Th width={"25%"}>See Details</Th>

--- a/App/src/pages/CourseGroupingBySchool.tsx
+++ b/App/src/pages/CourseGroupingBySchool.tsx
@@ -126,11 +126,16 @@ export default function GroupingBySchool() {
                             <Tbody>
                                 {courseGroupings.slice(0, courseGroupings.length).map((grouping) => (
                                     <Tr key={grouping.id} display={"flex"}>
-                                        <Td minW={"250px"} maxW={"250px"}>
+                                        <Td minW={"250px"} maxW={"250px"} style={{ whiteSpace: "normal" }}>
                                             {grouping.name}
                                         </Td>
                                         <Td minW={"455px"} maxW={"455px"}>
-                                            <Text overflow="hidden" textOverflow="ellipsis" maxW={"500px"}>
+                                            <Text
+                                                overflow="hidden"
+                                                textOverflow="ellipsis"
+                                                maxW={"500px"}
+                                                style={{ whiteSpace: "normal" }}
+                                            >
                                                 {grouping.requiredCredits}
                                             </Text>
                                         </Td>

--- a/App/src/pages/CourseGroupingBySchool.tsx
+++ b/App/src/pages/CourseGroupingBySchool.tsx
@@ -18,11 +18,14 @@ import { CourseGroupingDTO, MultiCourseGroupingDTO, SchoolEnum } from "../models
 import Button from "../components/Button";
 import { GetCourseGroupingBySchool } from "../services/courseGrouping";
 import { InfoIcon } from "@chakra-ui/icons";
+import { BaseRoutes } from "../constants";
+import { useNavigate } from "react-router-dom";
 export default function GroupingBySchool() {
     const selectedSchoolRef = useRef<HTMLSelectElement>(null);
     const [selectedSchool, setSelectedSchool] = useState<string>("GinaCody");
     const [changer, setChanger] = useState<SchoolEnum>(SchoolEnum.GinaCody);
     const [courseGroupings, setCourseGroupings] = useState<CourseGroupingDTO[]>([]);
+    const navigate = useNavigate();
 
     useEffect(() => {
         if (selectedSchool == "GinaCody") {
@@ -51,8 +54,8 @@ export default function GroupingBySchool() {
     }
 
     function handleNavigateToCurriculumDetails(input: string) {
-        //To Send to details page once it's implemented
         console.log(input);
+        navigate(BaseRoutes.CourseGrouping.replace(":courseGroupingId", input));
     }
     return (
         <div>

--- a/App/src/pages/Home.tsx
+++ b/App/src/pages/Home.tsx
@@ -49,7 +49,7 @@ export default function CallToActionWithIllustration() {
                     {isAdminOrGroupMaster(user) && (
                         <Stack>
                             <Text color={"gray.500"} maxW={"3xl"}>
-                                Manage Groups is reserved for admins only:
+                                Manage Groups is reserved for admins and group masters only:
                             </Text>
                             <Button
                                 style="secondary"
@@ -63,6 +63,21 @@ export default function CallToActionWithIllustration() {
                             </Button>
                         </Stack>
                     )}
+                    <Stack>
+                        <Text color={"gray.500"} maxW={"3xl"}>
+                            View list of browsers for courses, dossiers and curriculums:
+                        </Text>
+                        <Button
+                            style="primary"
+                            variant="solid"
+                            width="240px"
+                            height="40px"
+                            margin="auto"
+                            onClick={() => navigate(BaseRoutes.browserList)}
+                        >
+                            View List of Browsers
+                        </Button>
+                    </Stack>
                     <Flex w={"full"}>
                         {/* <Illustration height={{ sm: "24rem", lg: "28rem" }} mt={{ base: 12, sm: 16 }} /> */}
                     </Flex>

--- a/App/src/services/courseGrouping.ts
+++ b/App/src/services/courseGrouping.ts
@@ -23,5 +23,5 @@ export function GetCourseGroupingBySchool(school: SchoolEnum): Promise<GetMultiC
 }
 
 export function GetCourseGroupingByName(name: string): Promise<GetMultiCourseGroupingResponse> {
-    return axios.get("/CourseGrouping/SearchCourseGroupingsByName?name="+ name);
+    return axios.get("/CourseGrouping/SearchCourseGroupingsByName?name=" + name);
 }

--- a/App/src/services/courseGrouping.ts
+++ b/App/src/services/courseGrouping.ts
@@ -21,3 +21,7 @@ export function GetCourseGrouping(courseGroupingId: string): Promise<GetCourseGr
 export function GetCourseGroupingBySchool(school: SchoolEnum): Promise<GetMultiCourseGroupingResponse> {
     return axios.get("/CourseGrouping/GetCourseGroupingsBySchool/" + school);
 }
+
+export function GetCourseGroupingByName(name: string): Promise<GetMultiCourseGroupingResponse> {
+    return axios.get("/CourseGrouping/SearchCourseGroupingsByName?name="+ name);
+}

--- a/App/src/shared/Header.tsx
+++ b/App/src/shared/Header.tsx
@@ -277,7 +277,7 @@ const NAV_ITEMS: Array<NavItem> = [
         href: "/myGroups",
     },
     {
-        label: "Course info",
-        href: "/CourseBrowser",
+        label: "Browse",
+        href: "/browserList",
     },
 ];


### PR DESCRIPTION
Browser Links for View Course by Subject and View Groups are placeholders since those pages are still being worked on. All other links work as intended. Adds fix for course Grouping by School as well.

closes #423 
closes #422 