### PR TITLE
421 Ensure dossier consistency when creating requests

### DIFF
--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/Dossier.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/Dossier.cs
@@ -236,7 +236,77 @@ namespace ConcordiaCurriculumManager.Models.Curriculum.Dossiers
             if (request is null)
                 throw new BadRequestException($"The course grouping request with Id {requestId} does not exist");
 
+            CourseGroupingRequests.Remove(request);
+
             return request;
+        }
+
+        public bool IsDossierCreatingCourse(int concordiaCourseId)
+        {
+            var request = CourseCreationRequests.Where(request => request.NewCourse!.CourseID.Equals(concordiaCourseId)).FirstOrDefault();
+
+            if (request is null)
+                return false;
+
+            return true;
+        }
+
+        public bool IsDossierCreatingGrouping(Guid commonIdentifier)
+        {
+            var request = CourseGroupingRequests.Where(request =>
+                request.CourseGrouping!.CommonIdentifier.Equals(commonIdentifier) && request.RequestType.Equals(RequestType.CreationRequest))
+                .FirstOrDefault();
+
+            if (request is null)
+                return true;
+
+            return true;
+        }
+
+        public bool IsModifiedParentGroupingReferencingCourse(Guid parentCommonId, int courseId)
+        {
+            var request = CourseGroupingRequests.Where(request =>
+                request.CourseGrouping!.CommonIdentifier.Equals(parentCommonId) && request.RequestType.Equals(RequestType.ModificationRequest))
+                .FirstOrDefault();
+
+            if (request is null)
+                return true;
+
+            return request.CourseGrouping!.CourseIdentifiers.Any(identifier => identifier.ConcordiaCourseId.Equals(courseId));
+        }
+
+        public bool IsModifiedParentGroupingReferencingChildGrouping(Guid parentCommonId, Guid childCommonId)
+        {
+            var request = CourseGroupingRequests.Where(request =>
+                request.CourseGrouping!.CommonIdentifier.Equals(parentCommonId) && request.RequestType.Equals(RequestType.ModificationRequest))
+                .FirstOrDefault();
+
+            if (request is null)
+                return true;
+
+            return request.CourseGrouping!.SubGroupings.Any(subgrouping => subgrouping.CommonIdentifier.Equals(childCommonId));
+        }
+
+        public bool IsDossierDeletingCourse(int concordiaCourseId)
+        {
+            var request = CourseDeletionRequests.Where(request => request.Course!.CourseID.Equals(concordiaCourseId)).FirstOrDefault();
+
+            if (request is null)
+                return false;
+
+            return true;
+        }
+
+        public bool IsDossierDeletingGrouping(Guid commonIdentifier)
+        {
+            var request = CourseGroupingRequests.Where(request => 
+                request.CourseGrouping!.CommonIdentifier.Equals(commonIdentifier) && request.RequestType.Equals(RequestType.DeletionRequest))
+                .FirstOrDefault();
+
+            if (request is null)
+                return false;
+
+            return true;
         }
     }
 

--- a/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/Dossier.cs
+++ b/Server/ConcordiaCurriculumManager/Models/Curriculum/Dossiers/Dossier.cs
@@ -258,7 +258,7 @@ namespace ConcordiaCurriculumManager.Models.Curriculum.Dossiers
                 .FirstOrDefault();
 
             if (request is null)
-                return true;
+                return false;
 
             return true;
         }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/DossierTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Models/DossierTest.cs
@@ -157,4 +157,93 @@ public class DossierTest
 
         dossier.MarkAsReturned(user);
     }
+
+    [TestMethod]
+    public void IsDossierCreatingCourse_ThatIsCreating_ReturnsTrue()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+        var request = TestData.GetSampleCourseCreationRequest();
+        dossier.CourseCreationRequests.Add(request);
+
+        var result = dossier.IsDossierCreatingCourse(request.NewCourse!.CourseID);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void IsDossierCreatingCourse_ThatIsNotCreating_ReturnsFalse()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+
+        var result = dossier.IsDossierCreatingCourse(5);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void IsDossierCreatingGrouping_ThatIsCreating_ReturnsTrue()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+        var request = TestData.GetSampleCourseGroupingRequest();
+        dossier.CourseGroupingRequests.Add(request);
+
+        var result = dossier.IsDossierCreatingGrouping(request.CourseGrouping!.CommonIdentifier);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void IsDossierCreatingGrouping_ThatIsNotCreating_ReturnsFalse()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+
+        var result = dossier.IsDossierCreatingGrouping(Guid.NewGuid());
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void IsDossierDeletingCourse_ThatIsDeleting_ReturnsTrue()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+        var request = TestData.GetSampleCourseDeletionRequest();
+        dossier.CourseDeletionRequests.Add(request);
+
+        var result = dossier.IsDossierDeletingCourse(request.Course!.CourseID);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void IsDossierDeletingCourse_ThatIsDeleting_ReturnsFalse()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+
+        var result = dossier.IsDossierDeletingCourse(5);
+
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public void IsDossierDeletingGrouping_ThatIsDeleting_ReturnsTrue()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+        var request = TestData.GetSampleCourseGroupingRequest();
+        request.RequestType = RequestType.DeletionRequest;
+        dossier.CourseGroupingRequests.Add(request);
+
+        var result = dossier.IsDossierDeletingGrouping(request.CourseGrouping!.CommonIdentifier);
+
+        Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public void IsDossierDeletingGrouping_ThatIsDeleting_ReturnsFalse()
+    {
+        var dossier = TestData.GetSampleDossierInInitialStage();
+
+        var result = dossier.IsDossierDeletingGrouping(Guid.NewGuid());
+
+        Assert.IsFalse(result);
+    }
 }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
@@ -18,6 +18,7 @@ public class DossierServiceTest
     private Mock<IDossierRepository> dossierRepository = null!;
     private Mock<ILogger<DossierService>> logger = null!;
     private Mock<ICourseRepository> courseRepository = null!;
+    private Mock<ICourseGroupingRepository> courseGroupingRepository = null!;
     private DossierService dossierService = null!;
 
     [TestInitialize]
@@ -26,8 +27,9 @@ public class DossierServiceTest
         logger = new Mock<ILogger<DossierService>>();
         dossierRepository = new Mock<IDossierRepository>();
         courseRepository = new Mock<ICourseRepository>();
+        courseGroupingRepository = new Mock<ICourseGroupingRepository>();
 
-        dossierService = new DossierService(logger.Object, dossierRepository.Object, courseRepository.Object);
+        dossierService = new DossierService(logger.Object, dossierRepository.Object, courseRepository.Object, courseGroupingRepository.Object);
     }
 
     [TestMethod]


### PR DESCRIPTION
Implement service layer method to check for consistency in the dossier state. Rather than running the method every time a request is created or edited, in order to reduce database calls, as well as to reduce waiting time for the user, in addition to avoiding a large refactor to the way in which course requests are created, this method will be called prior to the final reviewing group accepting the dossier. A final implementation of this method to the approval process will be implemented in a subsequent task to accept course grouping changes.

This PR closes #421 