### PR TITLE
Display the course grouping requests in the dossier review page

### DIFF
--- a/App/src/models/courseGrouping.ts
+++ b/App/src/models/courseGrouping.ts
@@ -46,6 +46,16 @@ export interface CourseGroupingDTO {
     modifiedDate: string;
 }
 
+export interface CourseGroupingRequestDTO {
+    id: string;
+    dossierId: string;
+    rationale: string;
+    resourceImplication: string;
+    comment: string;
+    conflict: string;
+    courseGrouping: CourseGroupingDTO;
+}
+
 export interface MultiCourseGroupingDTO {
     data: CourseGroupingDTO[];
 }

--- a/App/src/models/dossier.ts
+++ b/App/src/models/dossier.ts
@@ -1,5 +1,6 @@
 import { GroupDTO } from "../services/group";
 import { Course, CourseCreationRequest, CourseDeletionRequest, CourseModificationRequest } from "./course";
+import { CourseGroupingRequestDTO } from "./courseGrouping";
 import { UserDTO } from "./user";
 
 export interface DossierDTO {
@@ -21,6 +22,7 @@ export interface DossierDetailsDTO {
     courseCreationRequests: CourseCreationRequest[];
     courseModificationRequests: CourseModificationRequest[];
     courseDeletionRequests: CourseDeletionRequest[];
+    courseGroupingRequests: CourseGroupingRequestDTO[];
     approvalStages: ApprovalStage[];
     approvalHistories: ApprovalHistoryDTO[];
     discussion: DossierDiscussion;

--- a/App/src/pages/dossier/DossierReview.tsx
+++ b/App/src/pages/dossier/DossierReview.tsx
@@ -687,6 +687,23 @@ export default function DossierReview() {
                                         </Text>
                                     ))}
                                 </Stack>
+                                <Stack mb={4}>
+                                    <Heading size={"md"} color="brandBlue">
+                                        Course Grouping Requests:
+                                    </Heading>
+                                    {dossierDetails?.courseGroupingRequests?.map((courseGroupingRequest) => (
+                                        <Text key={courseGroupingRequest.id} as="u">
+                                            <Link
+                                                to={BaseRoutes.CourseGrouping.replace(
+                                                    ":courseGroupingId",
+                                                    courseGroupingRequest?.courseGrouping.id
+                                                )}
+                                            >
+                                                {courseGroupingRequest?.courseGrouping.name}{" "}
+                                            </Link>
+                                        </Text>
+                                    ))}
+                                </Stack>
                             </Stack>
                         </Stack>
                         <Stack w="75%" p={8}>


### PR DESCRIPTION
As an initiator, I want to be able to see my course grouping request in the Dossier Review page.

This closes #427 