### PR TITLE
Add Course publish button to change log courses

### DIFF
--- a/App/src/pages/dossier/DossierChangeLog.tsx
+++ b/App/src/pages/dossier/DossierChangeLog.tsx
@@ -1,18 +1,24 @@
-import { Box, Center, Container, Flex, Heading, ListItem, OrderedList, Spacer, Text } from "@chakra-ui/react";
+import { Box, Center, Container, Flex, Heading, ListItem, OrderedList, Spacer, Text, useToast } from "@chakra-ui/react";
 import Button from "../../components/Button";
 import { BaseRoutes } from "../../constants";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { DossierReportDTO } from "../../models/dossier";
-import { getChangesAcrossAllDossiers } from "../../services/dossier";
+import { changeLogPublishCourse, getChangesAcrossAllDossiers } from "../../services/dossier";
 import { AllCourseSettings, componentMappings } from "../../models/course";
 import { getAllCourseSettings } from "../../services/course";
 import CourseDiffViewer from "../../components/CourseDifference/CourseDiffViewer";
 import { Divider } from "@chakra-ui/react";
 import "../../assets/styles/print.css";
 import { Link } from "react-router-dom";
+import { showToast } from "../../utils/toastUtils";
+import { useContext } from "react";
+import { isAdminOrGroupMaster } from "../../services/auth";
+import { UserContext } from "../../App";
 
 export default function DossierChangeLog() {
+    const toast = useToast();
+    const user = useContext(UserContext);
     const navigate = useNavigate();
     const [dossierReport, setDossierReport] = useState<DossierReportDTO | null>(null);
     const [allCourseSettings, setAllCourseSettings] = useState<AllCourseSettings>(null);
@@ -35,6 +41,23 @@ export default function DossierChangeLog() {
     function handlePrint() {
         window.print();
     }
+
+    const publishCourse = (subject: string, catalog: string) => {
+        changeLogPublishCourse(subject, catalog)
+            .then(() => {
+                showToast(toast, "Success!", "Course has been published.", "success");
+                getChangesAcrossAllDossiers()
+                    .then((response) => {
+                        setDossierReport(response.data);
+                    })
+                    .catch((error) => {
+                        showToast(toast, "Error!", error.message, "error");
+                    });
+            })
+            .catch((error) => {
+                showToast(toast, "Error!", error.response.data, "error");
+            });
+    };
 
     return (
         dossierReport && (
@@ -176,6 +199,23 @@ export default function DossierChangeLog() {
                                             : courseCreationRequest.newCourse.courseNotes}
                                     </Text>
                                 </div>
+                                {isAdminOrGroupMaster(user) && (
+                                    <Button
+                                        style="primary"
+                                        variant="outline"
+                                        height="40px"
+                                        width="fit-content"
+                                        onClick={() =>
+                                            publishCourse(
+                                                courseCreationRequest.newCourse.subject,
+                                                courseCreationRequest.newCourse.catalog
+                                            )
+                                        }
+                                        className="non-printable-content"
+                                    >
+                                        Publish
+                                    </Button>
+                                )}
                             </ListItem>
                         ))}
                     </OrderedList>
@@ -293,6 +333,23 @@ export default function DossierChangeLog() {
                                             : courseCreationRequest.course.courseNotes}
                                     </Text>
                                 </div>
+                                {isAdminOrGroupMaster(user) && (
+                                    <Button
+                                        style="primary"
+                                        variant="outline"
+                                        height="40px"
+                                        width="fit-content"
+                                        onClick={() =>
+                                            publishCourse(
+                                                courseCreationRequest.course.subject,
+                                                courseCreationRequest.course.catalog
+                                            )
+                                        }
+                                        className="non-printable-content"
+                                    >
+                                        Publish
+                                    </Button>
+                                )}
                             </ListItem>
                         ))}
                     </OrderedList>
@@ -359,6 +416,23 @@ export default function DossierChangeLog() {
                                     ></CourseDiffViewer>
                                     <Divider />
                                 </>
+                                {isAdminOrGroupMaster(user) && (
+                                    <Button
+                                        style="primary"
+                                        variant="outline"
+                                        height="40px"
+                                        width="fit-content"
+                                        onClick={() =>
+                                            publishCourse(
+                                                courseModificationRequest.course.subject,
+                                                courseModificationRequest.course.catalog
+                                            )
+                                        }
+                                        className="non-printable-content"
+                                    >
+                                        Publish
+                                    </Button>
+                                )}
                             </ListItem>
                         ))}
                     </OrderedList>

--- a/App/src/pages/dossier/DossierChangeLog.tsx
+++ b/App/src/pages/dossier/DossierChangeLog.tsx
@@ -373,7 +373,7 @@ export default function DossierChangeLog() {
                     m={14}
                     className="non-printable-content"
                 >
-                    Print Dossier Report
+                    Print Change Log
                 </Button>
             </div>
         )

--- a/App/src/services/dossier.ts
+++ b/App/src/services/dossier.ts
@@ -51,3 +51,7 @@ export function searchDossiers(title: string, state: DossierStateEnum, guid: str
 export function getChangesAcrossAllDossiers(): Promise<DossierReportResponse> {
     return axios.get(`/Dossier/GetChangesAcrossAllDossiers`);
 }
+
+export function changeLogPublishCourse(subject: string, catalog: string): Promise<void> {
+    return axios.put(`/Course/PublishCourse/${subject}/${catalog}`);
+}

--- a/App/src/shared/Header.tsx
+++ b/App/src/shared/Header.tsx
@@ -266,7 +266,7 @@ const NAV_ITEMS: Array<NavItem> = [
     },
     {
         label: "Current Change Log",
-        href: "#",
+        href: "/change-log",
     },
     {
         label: "User Settings",


### PR DESCRIPTION
1. Add “Publish” button for each course that appears if user is an admin and sends a request to the publish course endpoint.
2. Link the “Current Change Log” button in the navbar to the change-log page.
3. Change “Print Dossier Report” at the bottom of the page to write “Print Change Log”

closes #441 