### PR TITLE
Add horizontal scroll bar for groups in the Discussion Board

### DIFF
--- a/App/src/pages/dossier/DossierReview.tsx
+++ b/App/src/pages/dossier/DossierReview.tsx
@@ -714,8 +714,8 @@ export default function DossierReview() {
                                     </Heading>
                                 </Center>
                                 <Stack>
-                                    <Tabs defaultIndex={currentGroup?.stageIndex}>
-                                        <TabList>
+                                    <Tabs defaultIndex={currentGroup?.stageIndex} isFitted variant="enclosed">
+                                        <TabList overflowX="scroll" overflowY="hidden">
                                             <Tab>All Groups</Tab>
                                             {dossierDetails?.approvalStages
                                                 ?.sort((a, b) => a.stageIndex - b.stageIndex)


### PR DESCRIPTION
Added a horizontal scroll bar on the dossier review page to see the different groups in the Dossier Review page.

This closes #448 

Screenshot of page with the new change:

![image](https://github.com/JamesPartsafas/ConcordiaCurriculumManager/assets/66841718/dd333baf-11f4-40cc-9638-632921bd1eb0)
