### PR TITLE
Allow Reviewers to create course requests for a dossier in review

### DIFF
--- a/App/src/pages/AddCourse.tsx
+++ b/App/src/pages/AddCourse.tsx
@@ -254,7 +254,7 @@ export default function AddCourse() {
                 comment: comment,
             };
             if (pathname.includes("add-course")) {
-                addCourse(course)
+                addCourse(dossierId, course)
                     .then(() => {
                         showToast(toast, "Success!", "Course added successfully.", "success");
                         toggleLoading(false);

--- a/App/src/pages/AddCourse.tsx
+++ b/App/src/pages/AddCourse.tsx
@@ -385,7 +385,7 @@ export default function AddCourse() {
                 });
         } else {
             //create a new modification request
-            modifyCourse(course)
+            modifyCourse(dossierId, course)
                 .then(() => {
                     showToast(toast, "Success!", "Course modified successfully.", "success");
                     toggleLoading(false);

--- a/App/src/pages/DeleteCourse.tsx
+++ b/App/src/pages/DeleteCourse.tsx
@@ -77,7 +77,7 @@ export default function DeleteCourse() {
                 catalog: catalog,
                 comment: comment,
             };
-            deleteCourse(courseDeletionRequest)
+            deleteCourse(dossierId, courseDeletionRequest)
                 .then(() => {
                     showToast(toast, "Success!", "Course deletion request successfully added.", "success");
                     toggleLoading(false);

--- a/App/src/pages/EditCourse.tsx
+++ b/App/src/pages/EditCourse.tsx
@@ -207,7 +207,7 @@ export default function EditCourse() {
                     });
             } else {
                 //create a new modification request
-                modifyCourse(course)
+                modifyCourse(dossierId, course)
                     .then(() => {
                         showToast(toast, "Success!", "Course modified successfully.", "success");
                         toggleLoading(false);

--- a/App/src/services/course.ts
+++ b/App/src/services/course.ts
@@ -47,8 +47,8 @@ export function addCourse(course: Course): Promise<unknown> {
     return axios.post(CourseAPIEndpoints.AddCourse, course);
 }
 
-export function modifyCourse(course: Course): Promise<unknown> {
-    return axios.post(CourseAPIEndpoints.ModifyCourse, course);
+export function modifyCourse(dossierId: string, course: Course): Promise<unknown> {
+    return axios.post(`${CourseAPIEndpoints.ModifyCourse}/${dossierId}`, course);
 }
 
 export function deleteCourse(dossierId: string, courseDeletionRequest: CourseDeletionRequestDTO): Promise<unknown> {

--- a/App/src/services/course.ts
+++ b/App/src/services/course.ts
@@ -24,9 +24,9 @@ interface EditCourseDeletionRequestDTO {
 
 const CourseAPIEndpoints = {
     GetAllCourseSettings: "/Course/GetAllCourseSettings",
-    AddCourse: "/Course/InitiateCourseCreation",
-    ModifyCourse: "Course/InitiateCourseModification",
-    DeleteCourse: "/Course/InitiateCourseDeletion",
+    InitiateCourseCreation: "/Course/InitiateCourseCreation",
+    InitiateCourseModification: "Course/InitiateCourseModification",
+    InitiateCourseDeletion: "/Course/InitiateCourseDeletion",
     DeleteCourseCreationRequest: "/Course/DeleteCourseCreationRequest",
     DeleteCourseModificationRequest: "/Course/DeleteCourseModificationRequest",
     DeleteCourseDeletionRequest: "/Course/DeleteCourseDeletionRequest",
@@ -44,15 +44,15 @@ export function getAllCourseSettings(): Promise<GetAllCourseSettingsResponse> {
 }
 
 export function addCourse(dossierId: string, course: Course): Promise<unknown> {
-    return axios.post(`${CourseAPIEndpoints.AddCourse}/${dossierId}`, course);
+    return axios.post(`${CourseAPIEndpoints.InitiateCourseCreation}/${dossierId}`, course);
 }
 
 export function modifyCourse(dossierId: string, course: Course): Promise<unknown> {
-    return axios.post(`${CourseAPIEndpoints.ModifyCourse}/${dossierId}`, course);
+    return axios.post(`${CourseAPIEndpoints.InitiateCourseModification}/${dossierId}`, course);
 }
 
 export function deleteCourse(dossierId: string, courseDeletionRequest: CourseDeletionRequestDTO): Promise<unknown> {
-    return axios.post(`${CourseAPIEndpoints.DeleteCourse}/${dossierId}`, courseDeletionRequest);
+    return axios.post(`${CourseAPIEndpoints.InitiateCourseDeletion}/${dossierId}`, courseDeletionRequest);
 }
 
 export function deleteCourseCreationRequest(dossierId: string, courseRequestId: string): Promise<unknown> {

--- a/App/src/services/course.ts
+++ b/App/src/services/course.ts
@@ -51,8 +51,8 @@ export function modifyCourse(course: Course): Promise<unknown> {
     return axios.post(CourseAPIEndpoints.ModifyCourse, course);
 }
 
-export function deleteCourse(courseDeletionRequest: CourseDeletionRequestDTO): Promise<unknown> {
-    return axios.post(CourseAPIEndpoints.DeleteCourse, courseDeletionRequest);
+export function deleteCourse(dossierId: string, courseDeletionRequest: CourseDeletionRequestDTO): Promise<unknown> {
+    return axios.post(`${CourseAPIEndpoints.DeleteCourse}/${dossierId}`, courseDeletionRequest);
 }
 
 export function deleteCourseCreationRequest(dossierId: string, courseRequestId: string): Promise<unknown> {

--- a/App/src/services/course.ts
+++ b/App/src/services/course.ts
@@ -43,8 +43,8 @@ export function getAllCourseSettings(): Promise<GetAllCourseSettingsResponse> {
     return axios.get(CourseAPIEndpoints.GetAllCourseSettings);
 }
 
-export function addCourse(course: Course): Promise<unknown> {
-    return axios.post(CourseAPIEndpoints.AddCourse, course);
+export function addCourse(dossierId: string, course: Course): Promise<unknown> {
+    return axios.post(`${CourseAPIEndpoints.AddCourse}/${dossierId}`, course);
 }
 
 export function modifyCourse(dossierId: string, course: Course): Promise<unknown> {

--- a/Server/ConcordiaCurriculumManager/Controllers/CourseController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/CourseController.cs
@@ -85,9 +85,9 @@ public class CourseController : Controller
         return Created($"/{nameof(InitiateCourseCreation)}", courseCreationRequestDTO);
     }
 
-    [HttpPost(nameof(InitiateCourseModification))]
+    [HttpPost(nameof(InitiateCourseModification) + "/{dossierId}")]
     [Consumes(typeof(CourseModificationInitiationDTO), MediaTypeNames.Application.Json)]
-    [Authorize(Roles = RoleNames.Initiator)]
+    [Authorize(Policies.IsOwnerOfDossier)]
     [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
     [SwaggerResponse(StatusCodes.Status201Created, "Course modification created successfully", typeof(CourseModificationRequestDTO))]

--- a/Server/ConcordiaCurriculumManager/Controllers/CourseController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/CourseController.cs
@@ -57,6 +57,18 @@ public class CourseController : Controller
         return Ok(response);
     }
 
+    [HttpGet(nameof(GetCourseData) + "/{subject}" + "/{catalog}")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Course data retrieved")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
+    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
+    public async Task<ActionResult> GetCourseData([FromRoute, Required] string subject, string catalog)
+    {
+        var courseData = await _courseService.GetCourseDataWithSupportingFilesOrThrowOnDeleted(subject, catalog);
+        var courseDataDTOs = _mapper.Map<CourseDataDTO>(courseData);
+        _logger.LogInformation(string.Join(",", courseDataDTOs));
+        return Ok(courseDataDTOs);
+    }
+
     [HttpPost(nameof(InitiateCourseCreation))]
     [Consumes(typeof(CourseCreationInitiationDTO), MediaTypeNames.Application.Json)]
     [Authorize(Roles = RoleNames.Initiator)]
@@ -88,21 +100,9 @@ public class CourseController : Controller
         return Created($"/{nameof(InitiateCourseModification)}", courseModificationRequestDTO);
     }
 
-    [HttpGet(nameof(GetCourseData) + "/{subject}" + "/{catalog}")]
-    [SwaggerResponse(StatusCodes.Status200OK, "Course data retrieved")]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "User is not authorized")]
-    [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
-    public async Task<ActionResult> GetCourseData([FromRoute, Required] string subject, string catalog)
-    {
-        var courseData = await _courseService.GetCourseDataWithSupportingFilesOrThrowOnDeleted(subject, catalog);
-        var courseDataDTOs = _mapper.Map<CourseDataDTO>(courseData);
-        _logger.LogInformation(string.Join(",", courseDataDTOs));
-        return Ok(courseDataDTOs);
-    }
-
-    [HttpPost(nameof(InitiateCourseDeletion))]
+    [HttpPost(nameof(InitiateCourseDeletion) + "/{dossierId}")]
     [Consumes(typeof(CourseDeletionInitiationDTO), MediaTypeNames.Application.Json)]
-    [Authorize(Roles = RoleNames.Initiator)]
+    [Authorize(Policies.IsOwnerOfDossier)]
     [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
     [SwaggerResponse(StatusCodes.Status201Created, "Course deletion created successfully", typeof(CourseDeletionRequestDTO))]

--- a/Server/ConcordiaCurriculumManager/Controllers/CourseController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/CourseController.cs
@@ -69,9 +69,9 @@ public class CourseController : Controller
         return Ok(courseDataDTOs);
     }
 
-    [HttpPost(nameof(InitiateCourseCreation))]
+    [HttpPost(nameof(InitiateCourseCreation) + "/{dossierId}")]
     [Consumes(typeof(CourseCreationInitiationDTO), MediaTypeNames.Application.Json)]
-    [Authorize(Roles = RoleNames.Initiator)]
+    [Authorize(Policies.IsOwnerOfDossier)]
     [SwaggerResponse(StatusCodes.Status422UnprocessableEntity, "Invalid input")]
     [SwaggerResponse(StatusCodes.Status500InternalServerError, "Unexpected error")]
     [SwaggerResponse(StatusCodes.Status201Created, "Course creation dossier created successfully", typeof(CourseCreationRequestDTO))]

--- a/Server/ConcordiaCurriculumManager/Services/CourseService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseService.cs
@@ -182,7 +182,7 @@ public class CourseService : ICourseService
 
         var oldCourse = await GetCourseDataOrThrowOnDeleted(modification.Subject, modification.Catalog);
 
-        Dossier dossier = await _dossierService.GetDossierForUserOrThrow(modification.DossierId, userId);
+        Dossier dossier = await _dossierService.GetDossierDetailsByIdOrThrow(modification.DossierId);
 
         var newModifiedCourse = Course.CreateCourseFromDTOData(modification, oldCourse.CourseID, null);
 

--- a/Server/ConcordiaCurriculumManager/Services/CourseService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseService.cs
@@ -132,7 +132,7 @@ public class CourseService : ICourseService
             throw new BadRequestException("A course request for " + initiation.Subject + " " + initiation.Catalog + " already exists in this dossier.");
         }
 
-        Dossier dossier = await _dossierService.GetDossierForUserOrThrow(initiation.DossierId, userId);
+        Dossier dossier = await _dossierService.GetDossierDetailsByIdOrThrow(initiation.DossierId);
 
         var courseInProposal = await _courseRepository.GetCourseInProposalBySubjectAndCatalog(initiation.Subject, initiation.Catalog);
 

--- a/Server/ConcordiaCurriculumManager/Services/CourseService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseService.cs
@@ -217,7 +217,7 @@ public class CourseService : ICourseService
 
         await VerifyCourseIsNotInCourseGroupingOrThrow(oldCourse);
 
-        Dossier dossier = await _dossierService.GetDossierForUserOrThrow(deletion.DossierId, userId);
+        Dossier dossier = await _dossierService.GetDossierDetailsByIdOrThrow(deletion.DossierId);
 
         var newDeletedCourse = Course.CloneCourseForDeletionRequest(oldCourse);
 

--- a/Server/ConcordiaCurriculumManager/Services/DossierService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/DossierService.cs
@@ -20,7 +20,6 @@ public interface IDossierService
     public Task DeleteDossier(Guid dossierId);
     public Task<Dossier?> GetDossierDetailsById(Guid id);
     public Task<Dossier> GetDossierDetailsByIdOrThrow(Guid id);
-    public Task<Dossier> GetDossierForUserOrThrow(Guid dossierId, Guid userId);
     public Task SaveCourseCreationRequest(CourseCreationRequest courseCreationRequest);
     public Task SaveCourseModificationRequest(CourseModificationRequest courseModificationRequest);
     public Task SaveCourseDeletionRequest(CourseDeletionRequest courseDeletionRequest);
@@ -125,17 +124,6 @@ public class DossierService : IDossierService
 
     public async Task<Dossier> GetDossierDetailsByIdOrThrow(Guid id) => await _dossierRepository.GetDossierByDossierId(id)
         ?? throw new NotFoundException("The dossier does not exist.");
-
-    public async Task<Dossier> GetDossierForUserOrThrow(Guid dossierId, Guid userId)
-    {
-        var dossier = await GetDossierDetailsById(dossierId) ?? throw new ArgumentException("The dossier does not exist.");
-        if (dossier.InitiatorId != userId)
-        {
-            throw new BadRequestException($"Error retrieving the dossier {typeof(Dossier)} {dossier.Id}: does not belong to the user");
-        }
-
-        return dossier;
-    }
 
     public async Task SaveCourseCreationRequest(CourseCreationRequest courseCreationRequest)
     {

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/CourseServiceTest.cs
@@ -75,7 +75,7 @@ public class CourseServiceTest
         var user = TestData.GetSampleUser();
         var dossier = TestData.GetSampleDossier(user);
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((Course?)null);
-        dossierService.Setup(cr => cr.GetDossierForUserOrThrow(It.IsAny<Guid>(), user.Id)).ReturnsAsync(TestData.GetSampleDossier(user));
+        dossierService.Setup(cr => cr.GetDossierDetailsByIdOrThrow(It.IsAny<Guid>())).ReturnsAsync(TestData.GetSampleDossier(user));
 
         await courseService.InitiateCourseCreation(TestData.GetSampleCourseCreationInitiationDTO(dossier), Guid.NewGuid());
 
@@ -107,7 +107,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((Course?)null);
         courseRepository.Setup(cr => cr.GetMaxCourseId()).ReturnsAsync(5);
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
-        dossierService.Setup(ds => ds.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(ds => ds.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
         dossierService.Setup(cr => cr.SaveCourseCreationRequest(It.IsAny<CourseCreationRequest>()))
             .ThrowsAsync(new Exception());
 
@@ -124,7 +124,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
         dossierService.Setup(cr => cr.SaveCourseCreationRequest(It.IsAny<CourseCreationRequest>()))
             .Returns(Task.CompletedTask);
-        dossierService.Setup(cr => cr.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(cr => cr.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
 
         var courseCreationRequest = await courseService.InitiateCourseCreation(TestData.GetSampleCourseCreationInitiationDTO(dossier), user.Id);
 
@@ -141,7 +141,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
         dossierService.Setup(cr => cr.SaveCourseCreationRequest(It.IsAny<CourseCreationRequest>()))
             .Returns(Task.CompletedTask);
-        dossierService.Setup(cr => cr.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(cr => cr.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
 
         var courseCreationRequest = await courseService.InitiateCourseCreation(TestData.GetSampleCourseCreationInitiationDTO(dossier), user.Id);
 
@@ -210,7 +210,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(course);
         dossierService.Setup(cr => cr.GetDossierDetailsById(It.IsAny<Guid>())).ReturnsAsync(TestData.GetSampleDossier(user));
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
-        dossierService.Setup(ds => ds.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(ds => ds.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
         dossierService.Setup(cr => cr.SaveCourseModificationRequest(It.IsAny<CourseModificationRequest>())).ThrowsAsync(new Exception());
 
         await courseService.InitiateCourseModification(TestData.GetSampleCourseCreationModificationDTO(course, dossier), user.Id);
@@ -225,7 +225,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(course);
         dossierService.Setup(cr => cr.GetDossierDetailsById(It.IsAny<Guid>())).ReturnsAsync(TestData.GetSampleDossier(user));
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
-        dossierService.Setup(ds => ds.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(ds => ds.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
         dossierService.Setup(cr => cr.SaveCourseModificationRequest(It.IsAny<CourseModificationRequest>())).Returns(Task.CompletedTask);
 
         var courseModificationRequest = await courseService.InitiateCourseModification(TestData.GetSampleCourseCreationModificationDTO(course, dossier), user.Id);
@@ -270,7 +270,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(course);
         dossierService.Setup(cr => cr.GetDossierDetailsById(It.IsAny<Guid>())).ReturnsAsync(TestData.GetSampleDossier(user));
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
-        dossierService.Setup(ds => ds.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(ds => ds.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
         dossierService.Setup(cr => cr.SaveCourseModificationRequest(It.IsAny<CourseModificationRequest>())).Returns(Task.CompletedTask);
 
         var courseModificationRequest = await courseService.InitiateCourseModification(TestData.GetSampleCourseCreationModificationDTO(course, dossier), user.Id);
@@ -399,7 +399,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(course);
         dossierService.Setup(cr => cr.GetDossierDetailsById(It.IsAny<Guid>())).ReturnsAsync(TestData.GetSampleDossier(user));
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
-        dossierService.Setup(ds => ds.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(ds => ds.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
         dossierService.Setup(cr => cr.SaveCourseDeletionRequest(It.IsAny<CourseDeletionRequest>())).ThrowsAsync(new Exception());
 
         await courseService.InitiateCourseDeletion(TestData.GetSampleCourseCreationDeletionDTO(course, dossier), user.Id);
@@ -414,7 +414,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(course);
         dossierService.Setup(cr => cr.GetDossierDetailsById(It.IsAny<Guid>())).ReturnsAsync(TestData.GetSampleDossier(user));
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
-        dossierService.Setup(ds => ds.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(ds => ds.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
         dossierService.Setup(cr => cr.SaveCourseDeletionRequest(It.IsAny<CourseDeletionRequest>())).Returns(Task.CompletedTask);
 
         var courseDeletionRequest = await courseService.InitiateCourseDeletion(TestData.GetSampleCourseCreationDeletionDTO(course, dossier), user.Id);
@@ -473,7 +473,7 @@ public class CourseServiceTest
         courseRepository.Setup(cr => cr.GetCourseBySubjectAndCatalog(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(course);
         dossierService.Setup(cr => cr.GetDossierDetailsById(It.IsAny<Guid>())).ReturnsAsync(TestData.GetSampleDossier(user));
         courseRepository.Setup(cr => cr.SaveCourse(It.IsAny<Course>())).ReturnsAsync(true);
-        dossierService.Setup(ds => ds.GetDossierForUserOrThrow(dossier.Id, user.Id)).ReturnsAsync(dossier);
+        dossierService.Setup(ds => ds.GetDossierDetailsByIdOrThrow(dossier.Id)).ReturnsAsync(dossier);
         dossierService.Setup(cr => cr.SaveCourseDeletionRequest(It.IsAny<CourseDeletionRequest>())).Returns(Task.CompletedTask);
 
         var courseDeletionRequest = await courseService.InitiateCourseDeletion(TestData.GetSampleCourseCreationDeletionDTO(course, dossier), user.Id);

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Services/DossierServiceTest.cs
@@ -207,41 +207,6 @@ public class DossierServiceTest
     }
 
     [TestMethod]
-    public async Task GetDossierForUserOrThrow_ValidInput_ReturnsDossier()
-    {
-        var user = TestData.GetSampleUser();
-        var dossier = TestData.GetSampleDossier(user);
-
-        dossierRepository.Setup(d => d.GetDossierByDossierId(dossier.Id)).ReturnsAsync(dossier);
-
-        var returnedDossier = await dossierService.GetDossierForUserOrThrow(dossier.Id, user.Id);
-
-        Assert.AreEqual(dossier.Id, returnedDossier.Id);
-    }
-
-    [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public async Task GetDossierForUserOrThrow_DossierNotFound_Throws()
-    {
-        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync((Dossier)null!);
-
-        await dossierService.GetDossierForUserOrThrow(Guid.NewGuid(), Guid.NewGuid());
-    }
-
-    [TestMethod]
-    [ExpectedException(typeof(BadRequestException))]
-    public async Task GetDossierForUserOrThrow_DossierDoesNotBelongToUser_Throws()
-    {
-        var user = TestData.GetSampleUser();
-        var dossier = TestData.GetSampleDossier();
-        dossierRepository.Setup(d => d.GetDossierByDossierId(It.IsAny<Guid>())).ReturnsAsync(dossier);
-
-        await dossierService.GetDossierForUserOrThrow(Guid.NewGuid(), Guid.NewGuid());
-
-        logger.Verify(logger => logger.LogWarning(It.IsAny<string>()));
-    }
-
-    [TestMethod]
     public async Task SaveCourseCreationRequest_ValidInput_Saves()
     {
         dossierRepository.Setup(d => d.SaveCourseCreationRequest(It.IsAny<CourseCreationRequest>())).ReturnsAsync(true);


### PR DESCRIPTION
This PR fixes the problem where a reviewer couldn't create course requests for a dossier in review.
The endpoints for the edit/delete already allowed the reviewer to edit/delete the requests for the dossier in review, so nothing was changed there.

This closes #452 