### PR TITLE
#465 use web socket

### DIFF
--- a/App/__tests__/__mocks__/signalR_mock.tsx
+++ b/App/__tests__/__mocks__/signalR_mock.tsx
@@ -1,0 +1,9 @@
+export class SignalRManager {
+  constructor(dossierId: any, message: any) {}
+
+  startConnection() {}
+
+  endConnection() {}
+
+  sendMessage(message: any) {}
+}

--- a/App/__tests__/__mocks__/signalR_mock.tsx
+++ b/App/__tests__/__mocks__/signalR_mock.tsx
@@ -1,9 +1,9 @@
 export class SignalRManager {
-  constructor(dossierId: any, message: any) {}
+    constructor() {}
 
-  startConnection() {}
+    startConnection() {}
 
-  endConnection() {}
+    endConnection() {}
 
-  sendMessage(message: any) {}
+    sendMessage() {}
 }

--- a/App/jest.config.ts
+++ b/App/jest.config.ts
@@ -18,5 +18,6 @@ export default {
     moduleNameMapper: {
         "\\.(gif|ttf|eot|svg|png)$": "<rootDir>/__mocks__/image_mock.tsx",
         "\\.(css|less|sass|scss)$": "<rootDir>/__mocks__/styleMock.js",
+        ".*SignalRManager.*$": "<rootDir>/__mocks__/signalR_mock.tsx",
     },
 };

--- a/App/package-lock.json
+++ b/App/package-lock.json
@@ -14,6 +14,7 @@
         "@choc-ui/chakra-autocomplete": "^5.2.7",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@microsoft/signalr": "^8.0.0",
         "axios": "^1.5.0",
         "diff": "^5.1.0",
         "framer-motion": "^10.16.4",
@@ -3232,6 +3233,38 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@microsoft/signalr": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-8.0.0.tgz",
+      "integrity": "sha512-K/wS/VmzRWePCGqGh8MU8OWbS1Zvu7DG7LSJS62fBB8rJUXwwj4axQtqrAAwKGUZHQF6CuteuQR9xMsVpM2JNA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.4.5"
+      }
+    },
+    "node_modules/@microsoft/signalr/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3939,6 +3972,17 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -5804,6 +5848,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
@@ -5920,6 +5980,15 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -9161,6 +9230,44 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9732,14 +9839,12 @@
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9763,8 +9868,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -10070,8 +10174,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.4",
@@ -10386,6 +10489,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -10775,7 +10883,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -11044,7 +11151,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -11101,7 +11207,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -13877,6 +13982,26 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@microsoft/signalr": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-8.0.0.tgz",
+      "integrity": "sha512-K/wS/VmzRWePCGqGh8MU8OWbS1Zvu7DG7LSJS62fBB8rJUXwwj4axQtqrAAwKGUZHQF6CuteuQR9xMsVpM2JNA==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.4.5"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "requires": {}
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14428,6 +14553,14 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "8.10.0",
@@ -15807,6 +15940,16 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
+    },
     "execa": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
@@ -15907,6 +16050,15 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "requires": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "file-entry-cache": {
@@ -18256,6 +18408,35 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -18654,14 +18835,12 @@
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
-      "dev": true
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "pure-rand": {
       "version": "6.0.4",
@@ -18672,8 +18851,7 @@
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "dev": true
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -18861,8 +19039,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "resolve": {
       "version": "2.0.0-next.4",
@@ -19077,6 +19254,11 @@
           "dev": true
         }
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -19371,7 +19553,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
-      "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -19538,8 +19719,7 @@
     "universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
     },
     "untildify": {
       "version": "4.0.0",
@@ -19570,7 +19750,6 @@
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/App/package.json
+++ b/App/package.json
@@ -17,6 +17,7 @@
     "@choc-ui/chakra-autocomplete": "^5.2.7",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@microsoft/signalr": "^8.0.0",
     "axios": "^1.5.0",
     "diff": "^5.1.0",
     "framer-motion": "^10.16.4",

--- a/App/src/utils/SignalRManager.ts
+++ b/App/src/utils/SignalRManager.ts
@@ -1,0 +1,81 @@
+import * as signalR from "@microsoft/signalr";
+import { decodeTokenToUser } from "../services/auth";
+import { DossierDiscussionMessage } from "../models/dossier";
+
+export interface SignalRManagerProps {
+    handleMessageReceived: (dossierId: string, message: DossierDiscussionMessage) => void;
+    handleError: (error: string) => void;
+}
+
+export class SignalRManager {
+    private connection: signalR.HubConnection | null = null;
+    private accessToken: string | null = null;
+    private baseUrl: string = import.meta.env.VITE_API_URL as string;
+
+    constructor(
+        private dossierId: string,
+        private props: SignalRManagerProps
+    ) {
+        const token = localStorage.getItem("token");
+
+        if (token === null) {
+            this.props.handleError("Access token not found");
+        } else {
+            const user: User = decodeTokenToUser(token);
+
+            if (user.expiresAtTimestamp * 1000 < Date.now()) {
+                this.props.handleError("Access token expired");
+            } else {
+                this.accessToken = token;
+            }
+        }
+    }
+
+    startConnection() {
+        this.connection = new signalR.HubConnectionBuilder()
+            .withUrl(`${this.baseUrl}/ws/DossierReview?dossierId=${this.dossierId}`, {
+                accessTokenFactory: () => this.accessToken,
+            })
+            .configureLogging(signalR.LogLevel.Critical)
+            .build();
+
+        this.connection.on("ReviewDossier", (dossierId: string, message: DossierDiscussionMessage) => {
+            this.props.handleMessageReceived(dossierId, message);
+        });
+
+        this.connection.onclose((err) => {
+            console.log("SignalR closed");
+
+            if (err) {
+                console.log(err);
+            }
+        });
+
+        this.connection.on("Error", (message: string) => {
+            this.props.handleError(message);
+        });
+
+        return this.connection
+            .start()
+            .then(() => {
+                console.log("SignalR connected");
+            })
+            .catch((err) => {
+                this.props.handleError(err.toString());
+            });
+    }
+
+    endConnection() {
+        if (this.connection) {
+            this.connection.stop();
+        }
+    }
+
+    sendMessage(message: DossierDiscussionMessage) {
+        if (this.connection) {
+            this.connection.invoke("ReviewDossier", this.dossierId, message).catch((err) => {
+                this.props.handleError(err.toString());
+            });
+        }
+    }
+}

--- a/Server/ConcordiaCurriculumManager/Controllers/DossierReviewController.cs
+++ b/Server/ConcordiaCurriculumManager/Controllers/DossierReviewController.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using ConcordiaCurriculumManager.DTO.Dossiers;
 using ConcordiaCurriculumManager.DTO.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Filters.Exceptions;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;

--- a/Server/ConcordiaCurriculumManager/Program.cs
+++ b/Server/ConcordiaCurriculumManager/Program.cs
@@ -4,15 +4,15 @@ using ConcordiaCurriculumManager.Repositories.DatabaseContext;
 using ConcordiaCurriculumManager.Security;
 using ConcordiaCurriculumManager.Services;
 using ConcordiaCurriculumManager.Settings;
+using ConcordiaCurriculumManager.SignalR;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Npgsql;
 using Serilog;
 using Swashbuckle.AspNetCore.Filters;
-using System.Net;
-using System.Net.Mail;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -98,6 +98,7 @@ public class Program
 
         AddServices(builder.Services);
 
+        builder.Services.AddSignalR();
         builder.Services.AddMemoryCache();
         builder.Services.AddAutoMapper(typeof(Program));
 
@@ -179,6 +180,11 @@ public class Program
         app.UseMiddleware<EnrichLogContextMiddleware>();
 
         app.MapControllers();
+        app.MapHub<DossierDiscussionSignalR>("/ws/DossierReview", options =>
+        {
+            options.Transports = HttpTransportType.WebSockets | HttpTransportType.LongPolling;
+            options.CloseOnAuthenticationExpiration = true;
+        });
 
         app.Run();
     }

--- a/Server/ConcordiaCurriculumManager/SignalR/DossierDiscussionSignalR.cs
+++ b/Server/ConcordiaCurriculumManager/SignalR/DossierDiscussionSignalR.cs
@@ -1,0 +1,75 @@
+﻿using AutoMapper;
+using ConcordiaCurriculumManager.DTO.Dossiers.DossierReview;
+using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
+using ConcordiaCurriculumManager.Security;
+using ConcordiaCurriculumManager.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace ConcordiaCurriculumManager.SignalR;
+
+[Authorize]
+public class DossierDiscussionSignalR : Hub
+{
+    private readonly IMapper _mapper;
+    private readonly IDossierReviewService _dossierReviewService;
+
+    public DossierDiscussionSignalR(IMapper mapper, IDossierReviewService dossierReviewService)
+    {
+        _mapper = mapper;
+        _dossierReviewService = dossierReviewService;
+    }
+
+    [Authorize(Policies.IsOwnerOfDossier)]
+    public async Task ReviewDossier(Guid dossierId, CreateDossierDiscussionMessageDTO dossierMessageDTO)
+    {
+        var userId = GetCurrentUserClaim(Claims.Id);
+        var validUserId = Guid.TryParse(userId, out var parsedUserId);
+
+        if (userId is null || !validUserId)
+        {
+            await Clients.Client(Context.ConnectionId).SendAsync("Error", "Cannot post a review due to expired token");
+            return;
+        }
+
+        var dossierMessage = _mapper.Map<DiscussionMessage>(dossierMessageDTO);
+
+        if (dossierMessage is null)
+        {
+            await Clients.Client(Context.ConnectionId).SendAsync("Error", "Invalid message");
+            return;
+        }
+
+        Context.Items.TryGetValue("dossierId", out var authDossierId);
+        var validDossierId = Guid.TryParse(authDossierId?.ToString(), out var parsedDossierId);
+
+        if (!validDossierId || !parsedDossierId.Equals(dossierId))
+        {
+            await Clients.Client(Context.ConnectionId).SendAsync("Error", "Client error. dossier ids do not match");
+            return;
+        }
+
+        dossierMessage.DossierDiscussionId = parsedDossierId;
+        await _dossierReviewService.AddDossierDiscussionReview(parsedDossierId, dossierMessage, parsedUserId);
+
+        var outputMessage = _mapper.Map<DossierDiscussionMessageDTO>(dossierMessage);
+
+        if (outputMessage is null)
+        {
+            await Clients.All.SendAsync("Error", "Server error could not send the message. Please try to refresh the page.");
+            return;
+        }
+
+        await Clients.All.SendAsync(nameof(ReviewDossier), parsedDossierId.ToString(), outputMessage);
+    }
+
+    private string? GetCurrentUserClaim(string claim)
+    {
+        if (Context.User is null)
+        {
+            return null;
+        }
+
+        return Context.User.Claims.FirstOrDefault(i => i.Type.ToString() == claim)?.Value;
+    }
+}

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/CourseControllerTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/Controller/CourseControllerTest.cs
@@ -10,12 +10,7 @@ using ConcordiaCurriculumManager.DTO.Courses;
 using ConcordiaCurriculumManager.Filters.Exceptions;
 using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests.OutputDTOs;
 using ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
-using ConcordiaCurriculumManager.DTO.Dossiers.CourseRequests.InputDTOs;
-using ConcordiaCurriculumManager.Repositories;
 using ConcordiaCurriculumManager.Models.Curriculum;
-using Microsoft.AspNetCore.Http;
-using Org.BouncyCastle.Utilities;
-using ConcordiaCurriculumManager.Models.Users;
 
 namespace ConcordiaCurriculumManagerTest.UnitTests.Controller;
 

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/SignalR/DossierDiscussionSignalRTest.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/SignalR/DossierDiscussionSignalRTest.cs
@@ -1,0 +1,235 @@
+﻿using AutoMapper;
+using ConcordiaCurriculumManager.DTO.Dossiers.DossierReview;
+using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
+using ConcordiaCurriculumManager.Security;
+using ConcordiaCurriculumManager.Services;
+using ConcordiaCurriculumManager.SignalR;
+using ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using System.Security.Claims;
+
+namespace ConcordiaCurriculumManagerTest.UnitTests.SignalR;
+
+[TestClass]
+public class DossierDiscussionSignalRTest
+{
+    private DossierDiscussionSignalR _dossierDiscussionSignalR = null!;
+    private Mock<IMapper> _mapperMock = null!;
+    private Mock<IDossierReviewService> _dossierReviewServiceMock = null!;
+    private Mock<IHubCallerClients> _hubCallerClientsMock = null!;
+    private Mock<HubCallerContext> _hubCallerContextMock = null!;
+    private Mock<IClientProxy> _mockClientProxy = null!;
+    private Mock<ISingleClientProxy> _mockSingleClientProxy = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _mapperMock = new Mock<IMapper>();
+        _dossierReviewServiceMock = new Mock<IDossierReviewService>();
+        _hubCallerClientsMock = new Mock<IHubCallerClients>();
+        _hubCallerContextMock = new Mock<HubCallerContext>();
+        _mockClientProxy = new Mock<IClientProxy>();
+        _mockSingleClientProxy = new Mock<ISingleClientProxy>();
+
+        _hubCallerClientsMock.Setup(clients => clients.All).Returns(_mockClientProxy.Object);
+        _hubCallerClientsMock.Setup(clients => clients.Client(It.IsAny<string>())).Returns(_mockSingleClientProxy.Object);
+
+        _dossierDiscussionSignalR = new DossierDiscussionSignalR(_mapperMock.Object, _dossierReviewServiceMock.Object)
+        {
+            Context = _hubCallerContextMock.Object,
+            Clients = _hubCallerClientsMock.Object
+        };
+    }
+
+    [TestMethod]
+    public async Task ReviewDossier_WithValidData_CallsAddDossierDiscussionReviewAndSendsMessage()
+    {
+        var dossierId = Guid.NewGuid();
+        var dossierMessageDTO = TestData.GetSampleCreateDossierDiscussionMessageDTO();
+        var outputDTO = TestData.GetSampleDossierDiscussionMessageDTO();
+        var userId = Guid.NewGuid().ToString();
+
+        var discussionMessage = new DiscussionMessage()
+        {
+            DossierDiscussionId = dossierId,
+            Message = dossierMessageDTO.Message,
+            GroupId = dossierMessageDTO.GroupId,
+            AuthorId = Guid.NewGuid()
+        };
+
+        _hubCallerContextMock.SetupGet(x => x.User)
+            .Returns(new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new(Claims.Id, userId)
+            })));
+
+        var items = new Dictionary<object, object?>()
+        {
+            { "dossierId", dossierId }
+        };
+
+        _mapperMock.Setup(m => m.Map<DiscussionMessage>(dossierMessageDTO)).Returns(discussionMessage);
+        _dossierReviewServiceMock.Setup(d => d.AddDossierDiscussionReview(It.IsAny<Guid>(), It.IsAny<DiscussionMessage>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        _mapperMock.Setup(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>())).Returns(outputDTO);
+        _hubCallerContextMock.SetupGet(x => x.ConnectionId).Returns("connectionId");
+        _hubCallerContextMock.SetupGet(x => x.Items).Returns(items);
+
+        await _dossierDiscussionSignalR.ReviewDossier(dossierId, dossierMessageDTO);
+
+        _dossierReviewServiceMock.Verify(d => d.AddDossierDiscussionReview(dossierId, It.IsAny<DiscussionMessage>(), It.IsAny<Guid>()), Times.Once);
+        _mapperMock.Verify(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>()), Times.Once);
+        _hubCallerClientsMock.Verify(c => c.All.SendCoreAsync(nameof(DossierDiscussionSignalR.ReviewDossier), It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ReviewDossier_WithoutUserId_DoesNotCallAddDossierDiscussionReviewAndSendsErrorMessage()
+    {
+        var dossierId = Guid.NewGuid();
+        var dossierMessageDTO = TestData.GetSampleCreateDossierDiscussionMessageDTO();
+        var outputDTO = TestData.GetSampleDossierDiscussionMessageDTO();
+        var userId = Guid.NewGuid().ToString();
+
+        var discussionMessage = new DiscussionMessage()
+        {
+            DossierDiscussionId = dossierId,
+            Message = dossierMessageDTO.Message,
+            GroupId = dossierMessageDTO.GroupId,
+            AuthorId = Guid.NewGuid()
+        };
+
+        _hubCallerContextMock.SetupGet(x => x.User)
+            .Returns(new ClaimsPrincipal(new ClaimsIdentity(Array.Empty<Claim>())));
+
+        var items = new Dictionary<object, object?>()
+        {
+            { "dossierId", dossierId }
+        };
+
+        _mapperMock.Setup(m => m.Map<DiscussionMessage>(dossierMessageDTO)).Returns(discussionMessage);
+        _dossierReviewServiceMock.Setup(d => d.AddDossierDiscussionReview(It.IsAny<Guid>(), It.IsAny<DiscussionMessage>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        _mapperMock.Setup(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>())).Returns(outputDTO);
+        _hubCallerContextMock.SetupGet(x => x.ConnectionId).Returns("connectionId");
+        _hubCallerContextMock.SetupGet(x => x.Items).Returns(items);
+
+        await _dossierDiscussionSignalR.ReviewDossier(dossierId, dossierMessageDTO);
+
+        _dossierReviewServiceMock.Verify(d => d.AddDossierDiscussionReview(dossierId, It.IsAny<DiscussionMessage>(), It.IsAny<Guid>()), Times.Never);
+        _mapperMock.Verify(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>()), Times.Never);
+        _hubCallerClientsMock.Verify(c => c.Client("connectionId").SendCoreAsync(It.Is<string>(str => str.ToLowerInvariant().Contains("error")), It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ReviewDossier_WithInValidInput_DoesNotCallAddDossierDiscussionReviewAndSendsErrorMessage()
+    {
+        var dossierId = Guid.NewGuid();
+        var dossierMessageDTO = TestData.GetSampleCreateDossierDiscussionMessageDTO();
+        var outputDTO = TestData.GetSampleDossierDiscussionMessageDTO();
+        var userId = Guid.NewGuid().ToString();
+
+        _hubCallerContextMock.SetupGet(x => x.User)
+            .Returns(new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new(Claims.Id, userId)
+            })));
+
+        var items = new Dictionary<object, object?>()
+        {
+            { "dossierId", dossierId }
+        };
+
+        _mapperMock.Setup(m => m.Map<DiscussionMessage>(dossierMessageDTO)).Returns((DiscussionMessage)null!);
+        _dossierReviewServiceMock.Setup(d => d.AddDossierDiscussionReview(It.IsAny<Guid>(), It.IsAny<DiscussionMessage>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        _mapperMock.Setup(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>())).Returns(outputDTO);
+        _hubCallerContextMock.SetupGet(x => x.ConnectionId).Returns("connectionId");
+        _hubCallerContextMock.SetupGet(x => x.Items).Returns(items);
+
+        await _dossierDiscussionSignalR.ReviewDossier(dossierId, dossierMessageDTO);
+
+        _dossierReviewServiceMock.Verify(d => d.AddDossierDiscussionReview(dossierId, It.IsAny<DiscussionMessage>(), It.IsAny<Guid>()), Times.Never);
+        _mapperMock.Verify(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>()), Times.Never);
+        _hubCallerClientsMock.Verify(c => c.Client("connectionId").SendCoreAsync(It.Is<string>(str => str.ToLowerInvariant().Contains("error")), It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ReviewDossier_WithDifferentDossierId_DoesNotCallAddDossierDiscussionReviewAndSendsErrorMessage()
+    {
+        var dossierId = Guid.NewGuid();
+        var dossierMessageDTO = TestData.GetSampleCreateDossierDiscussionMessageDTO();
+        var outputDTO = TestData.GetSampleDossierDiscussionMessageDTO();
+        var userId = Guid.NewGuid().ToString();
+
+        var discussionMessage = new DiscussionMessage()
+        {
+            DossierDiscussionId = dossierId,
+            Message = dossierMessageDTO.Message,
+            GroupId = dossierMessageDTO.GroupId,
+            AuthorId = Guid.NewGuid()
+        };
+
+        _hubCallerContextMock.SetupGet(x => x.User)
+            .Returns(new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new(Claims.Id, userId)
+            })));
+
+        var items = new Dictionary<object, object?>()
+        {
+            { "dossierId", dossierId }
+        };
+
+        _mapperMock.Setup(m => m.Map<DiscussionMessage>(dossierMessageDTO)).Returns(discussionMessage);
+        _dossierReviewServiceMock.Setup(d => d.AddDossierDiscussionReview(It.IsAny<Guid>(), It.IsAny<DiscussionMessage>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        _mapperMock.Setup(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>())).Returns(outputDTO);
+        _hubCallerContextMock.SetupGet(x => x.ConnectionId).Returns("connectionId");
+        _hubCallerContextMock.SetupGet(x => x.Items).Returns(items);
+
+        await _dossierDiscussionSignalR.ReviewDossier(Guid.NewGuid(), dossierMessageDTO);
+
+        _dossierReviewServiceMock.Verify(d => d.AddDossierDiscussionReview(dossierId, It.IsAny<DiscussionMessage>(), It.IsAny<Guid>()), Times.Never);
+        _mapperMock.Verify(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>()), Times.Never);
+        _hubCallerClientsMock.Verify(c => c.Client("connectionId").SendCoreAsync(It.Is<string>(str => str.ToLowerInvariant().Contains("error")), It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+
+    [TestMethod]
+    public async Task ReviewDossier_WithInvalidOutput_SendsErrorMessageToEveryone()
+    {
+        var dossierId = Guid.NewGuid();
+        var dossierMessageDTO = TestData.GetSampleCreateDossierDiscussionMessageDTO();
+        var outputDTO = TestData.GetSampleDossierDiscussionMessageDTO();
+        var userId = Guid.NewGuid().ToString();
+
+        var discussionMessage = new DiscussionMessage()
+        {
+            DossierDiscussionId = dossierId,
+            Message = dossierMessageDTO.Message,
+            GroupId = dossierMessageDTO.GroupId,
+            AuthorId = Guid.NewGuid()
+        };
+
+        _hubCallerContextMock.SetupGet(x => x.User)
+            .Returns(new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+            {
+                new(Claims.Id, userId)
+            })));
+
+        var items = new Dictionary<object, object?>()
+        {
+            { "dossierId", dossierId }
+        };
+
+        _mapperMock.Setup(m => m.Map<DiscussionMessage>(dossierMessageDTO)).Returns(discussionMessage);
+        _dossierReviewServiceMock.Setup(d => d.AddDossierDiscussionReview(It.IsAny<Guid>(), It.IsAny<DiscussionMessage>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
+        _mapperMock.Setup(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>())).Returns((DossierDiscussionMessageDTO)null!);
+        _hubCallerContextMock.SetupGet(x => x.ConnectionId).Returns("connectionId");
+        _hubCallerContextMock.SetupGet(x => x.Items).Returns(items);
+
+        await _dossierDiscussionSignalR.ReviewDossier(dossierId, dossierMessageDTO);
+
+        _dossierReviewServiceMock.Verify(d => d.AddDossierDiscussionReview(dossierId, It.IsAny<DiscussionMessage>(), It.IsAny<Guid>()), Times.Once);
+        _mapperMock.Verify(m => m.Map<DossierDiscussionMessageDTO>(It.IsAny<DiscussionMessage>()), Times.Once);
+        _hubCallerClientsMock.Verify(c => c.All.SendCoreAsync(It.Is<string>(str => str.ToLowerInvariant().Contains("error")), It.IsAny<object[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+}


### PR DESCRIPTION
This PR closes: #465

Please note that in the front end due to using strict mode, each component is rendered (and un-rendered) twice and thus the SignalR connection will be first established, then lost (which explains the toast notification), and finally established again. This is not done in production since the react code is set for production in the pipeline before pushing it (from render side). If you want to test it without strict mode, remove the strict mode wrapper in `main.tsx`. 

Currently, there is a ref for checking whether to use web sockets or not which is set to true for now since the user profile setting is not done yet (this will be addressed in a different PR). If, for some reason, it is affecting your workflow, please set that flag to false and let me know if something is not working.