### PR TITLE
#469 Update Pipeline Dependencies

### DIFF
--- a/.github/workflows/backend-pipeline.yml
+++ b/.github/workflows/backend-pipeline.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '7.0.x'
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Generate HS256 Key
       id: generate-key

--- a/.github/workflows/clean-logs.yml
+++ b/.github/workflows/clean-logs.yml
@@ -10,7 +10,7 @@ jobs:
     container: gradle:jdk11
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Installing PSQL
         run: |

--- a/.github/workflows/frontend-pipeline.yml
+++ b/.github/workflows/frontend-pipeline.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '18'
 

--- a/.github/workflows/seeder-pipeline.yml
+++ b/.github/workflows/seeder-pipeline.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Check Path Filters
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/seeder-pipeline.yml
+++ b/.github/workflows/seeder-pipeline.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Check Path Filters
-      uses: dorny/paths-filter@v2
+      uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
@@ -51,7 +51,7 @@ jobs:
       runs-on: windows-latest
       steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Check Path Filters
         uses: dorny/paths-filter@v2


### PR DESCRIPTION
This PR closes: #469 

The updates include the following actions:
- For [actions/checkout](https://github.com/actions/checkout): the latest stable version is 4.
- For [actions/setup-dotnet](https://github.com/actions/setup-dotnet): the latest stable version is 4.
- For [actions/setup-node](https://github.com/actions/setup-node): the latest stable version is 4.
- For [dorny/paths-filter](https://github.com/dorny/paths-filter): the latest stable version is 3.

I did not find any compatibility issues.