### PR TITLE
Update dossier groupings on dossier being accepted

### DIFF
--- a/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/CourseGroupingRepository.cs
@@ -10,6 +10,7 @@ public interface ICourseGroupingRepository
 {
     public Task<bool> SaveCourseGroupingRequest(CourseGroupingRequest courseGroupingRequest);
     public Task<bool> DeleteCourseGroupingRequest(CourseGroupingRequest courseGroupingRequest);
+    public Task<bool> DeleteSubgrouping(CourseGroupingReference reference);
     public Task<CourseGroupingRequest?> GetCourseGroupingRequestById(Guid requestId);
     public Task<CourseGrouping?> GetCourseGroupingById(Guid groupingId);
     public Task<CourseGrouping?> GetCourseGroupingByCommonIdentifier(Guid commonId);
@@ -50,6 +51,13 @@ public class CourseGroupingRepository : ICourseGroupingRepository
     {
         _dbContext.CourseGroupings.Remove(courseGroupingRequest.CourseGrouping!);
         _dbContext.CourseGroupingRequest.Remove(courseGroupingRequest);
+        var result = await _dbContext.SaveChangesAsync();
+        return result > 0;
+    }
+
+    public async Task<bool> DeleteSubgrouping(CourseGroupingReference reference)
+    {
+        _dbContext.CourseGroupingReferences.Remove(reference);
         var result = await _dbContext.SaveChangesAsync();
         return result > 0;
     }

--- a/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
+++ b/Server/ConcordiaCurriculumManager/Repositories/DossierRepository.cs
@@ -322,6 +322,10 @@ public class DossierRepository : IDossierRepository
             .Include(d => d.CourseCreationRequests).ThenInclude(ccr => ccr.NewCourse)
             .Include(d => d.CourseModificationRequests).ThenInclude(cmr => cmr.Course)
             .Include(d => d.CourseDeletionRequests).ThenInclude(cdr => cdr.Course)
+            .Include(d => d.CourseGroupingRequests).ThenInclude(cgr => cgr.CourseGrouping)
+                .ThenInclude(cg => cg!.SubGroupingReferences)
+            .Include(d => d.CourseGroupingRequests).ThenInclude(cgr => cgr.CourseGrouping)
+                .ThenInclude(cg => cg!.CourseIdentifiers)
             .ToListAsync();
     }
 

--- a/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/CourseGroupingService.cs
@@ -25,6 +25,8 @@ public interface ICourseGroupingService
     public Task<CourseGroupingRequest> EditCourseGroupingDeletion(Guid originalRequestId, CourseGroupingModificationRequestDTO dto);
     public Task<CourseGroupingRequest> GetCourseGroupingRequest(Guid groupingRequestId);
     public Task DeleteCourseGroupingRequest(Guid dossierId, Guid requestId);
+    public Task<bool> DeleteCourseGroupingRequest(CourseGroupingRequest request);
+    public Task<bool> DeleteSubgrouping(CourseGroupingReference reference);
     public Task<CourseGrouping> PublishCourseGrouping(Guid commonIdentifier);
     public Task<IDictionary<Guid, int>> GetGroupingVersions(Dossier dossier);
 }
@@ -246,6 +248,12 @@ public class CourseGroupingService : ICourseGroupingService
             throw new ServiceUnavailableException("The course grouping could not be deleted");
         }
     }
+
+    public async Task<bool> DeleteCourseGroupingRequest(CourseGroupingRequest request) => 
+        await _courseGroupingRepository.DeleteCourseGroupingRequest(request);
+
+    public async Task<bool> DeleteSubgrouping(CourseGroupingReference reference) =>
+        await _courseGroupingRepository.DeleteSubgrouping(reference);
 
     public async Task<CourseGrouping> PublishCourseGrouping(Guid commonIdentifier)
     {

--- a/Server/ConcordiaCurriculumManager/Services/DossierReviewService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/DossierReviewService.cs
@@ -1,6 +1,7 @@
 ﻿using ConcordiaCurriculumManager.DTO.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Filters.Exceptions;
 using ConcordiaCurriculumManager.Models.Curriculum;
+using ConcordiaCurriculumManager.Models.Curriculum.CourseGroupings;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Models.Users;
@@ -209,6 +210,12 @@ public class DossierReviewService : IDossierReviewService
         {
             await ChangeAllCourseRequests(dossiers, request.Course!.Subject, request.Course.Catalog, "deletion");
         }
+
+        foreach (var existingDossier in dossiers)
+        {
+            await ChangeCourseGroupingRequests(dossier, existingDossier);
+            await _dossierRepository.UpdateDossier(dossier);
+        }
     }
 
     public async Task AddDossierDiscussionReview(Guid dossierId, DiscussionMessage message)
@@ -325,6 +332,80 @@ public class DossierReviewService : IDossierReviewService
                         d.CourseDeletionRequests = d.CourseDeletionRequests.Where(request => request.Course!.CourseID != course.CourseID).ToList();
                         await _dossierRepository.DeleteCourseDeletionRequest(cdr);
                     }
+                }
+            }
+        }
+    }
+
+    private async Task ChangeCourseGroupingRequests(Dossier acceptedDossier, Dossier existingDossier)
+    {
+        ChangeBasedOnGroupingCreations(acceptedDossier, existingDossier);
+
+        await ChangeBasedOnGroupingDeletions(acceptedDossier, existingDossier);
+    }
+
+    /// <summary>
+    /// Creation requests should be made into modification requests if the grouping has already been accepted
+    /// </summary>
+    /// <param name="acceptedDossier"></param>
+    /// <param name="existingDossier"></param>
+    private void ChangeBasedOnGroupingCreations(Dossier acceptedDossier, Dossier existingDossier)
+    {
+        var acceptedCreationRequests = acceptedDossier.CourseGroupingRequests.Where(request => request.RequestType.Equals(RequestType.CreationRequest));
+
+        foreach (var request in existingDossier.CourseGroupingRequests)
+        {
+            if (request.RequestType.Equals(RequestType.CreationRequest))
+            {
+                if (acceptedCreationRequests.Any(acr => acr.CourseGrouping!.CommonIdentifier.Equals(request.CourseGrouping!.CommonIdentifier)))
+                {
+                    request.RequestType = RequestType.ModificationRequest;
+                    request.CourseGrouping!.State = CourseGroupingStateEnum.CourseGroupingChangeProposal;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Modifications of deleted groupings should be made into creation requests.
+    /// Deletions of deleted groupings should be removed from the dossier.
+    /// Deleted subgroupings should be removed from grouping requests.
+    /// </summary>
+    /// <param name="acceptedDossier"></param>
+    /// <param name="existingDossier"></param>
+    /// <returns></returns>
+    private async Task ChangeBasedOnGroupingDeletions(Dossier acceptedDossier, Dossier existingDossier)
+    {
+        var acceptedDeletionRequests = acceptedDossier.CourseGroupingRequests.Where(request => request.RequestType.Equals(RequestType.DeletionRequest));
+
+        for (var i = 0; i < existingDossier.CourseGroupingRequests.Count; i++)
+        {
+            var request = existingDossier.CourseGroupingRequests[i];
+            if (acceptedDeletionRequests.Any(adr => adr.CourseGrouping!.CommonIdentifier.Equals(request.CourseGrouping!.CommonIdentifier)))
+            {
+                if (request.RequestType.Equals(RequestType.ModificationRequest))
+                {
+                    request.RequestType = RequestType.CreationRequest;
+                    request.CourseGrouping!.State = CourseGroupingStateEnum.NewCourseGroupingProposal;
+                }
+                else
+                {
+                    existingDossier.CourseGroupingRequests.RemoveAt(i);
+                    await _courseGroupingService.DeleteCourseGroupingRequest(request);
+                    i--;
+                    continue;
+                }
+            }
+
+            var subgroupings = request.CourseGrouping!.SubGroupingReferences.ToList();
+            for (var j = 0; j < subgroupings.Count; j++)
+            {
+                var subgrouping = subgroupings[j];
+                if (acceptedDeletionRequests.Any(adr => adr.CourseGrouping!.CommonIdentifier.Equals(subgrouping.ChildGroupCommonIdentifier)))
+                {
+                    subgroupings.RemoveAt(j);
+                    await _courseGroupingService.DeleteSubgrouping(subgrouping);
+                    j--;
                 }
             }
         }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/TestData.cs
@@ -639,7 +639,7 @@ public static class TestData
             IsTopLevel = true,
             School = SchoolEnum.GinaCody,
             State = CourseGroupingStateEnum.Accepted,
-            Published = true,
+            Published = false,
             SubGroupingReferences = new List<CourseGroupingReference>
             {
                 {


### PR DESCRIPTION
When a dossier is accepted, update course groupings in existing unaccepted dossiers. This PR closes #491 