### PR TITLE
#511 use longpolling as fallback

### DIFF
--- a/App/src/pages/dossier/DossierReview.tsx
+++ b/App/src/pages/dossier/DossierReview.tsx
@@ -512,7 +512,7 @@ export default function DossierReview() {
                         </Text>
                         <Text mt={2}>{message.message}</Text>
                         {!user.groups?.includes(group.groupId) ||
-                        !user.groups?.includes(currentGroup.groupId) ? null : (
+                        !user.groups?.includes(currentGroup?.groupId) ? null : (
                             <Button onClick={handleToggleReply} marginTop={2}>
                                 <ArrowLeftIcon marginRight={5} />
                                 {showReplyInput ? "Cancel Reply" : "Reply"}

--- a/App/src/utils/SignalRManager.ts
+++ b/App/src/utils/SignalRManager.ts
@@ -35,7 +35,7 @@ export class SignalRManager {
         this.connection = new signalR.HubConnectionBuilder()
             .withUrl(`${this.baseUrl}/ws/DossierReview?dossierId=${this.dossierId}`, {
                 accessTokenFactory: () => this.accessToken,
-                transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling
+                transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling,
             })
             .configureLogging(signalR.LogLevel.Critical)
             .build();

--- a/App/src/utils/SignalRManager.ts
+++ b/App/src/utils/SignalRManager.ts
@@ -35,6 +35,7 @@ export class SignalRManager {
         this.connection = new signalR.HubConnectionBuilder()
             .withUrl(`${this.baseUrl}/ws/DossierReview?dossierId=${this.dossierId}`, {
                 accessTokenFactory: () => this.accessToken,
+                transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling
             })
             .configureLogging(signalR.LogLevel.Critical)
             .build();

--- a/Server/ConcordiaCurriculumManager/SignalR/DossierDiscussionSignalR.cs
+++ b/Server/ConcordiaCurriculumManager/SignalR/DossierDiscussionSignalR.cs
@@ -1,7 +1,9 @@
 ﻿using AutoMapper;
 using ConcordiaCurriculumManager.DTO.Dossiers.DossierReview;
+using ConcordiaCurriculumManager.Models.Curriculum.Dossiers;
 using ConcordiaCurriculumManager.Models.Curriculum.Dossiers.DossierReview;
 using ConcordiaCurriculumManager.Security;
+using ConcordiaCurriculumManager.Security.Requirements;
 using ConcordiaCurriculumManager.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
@@ -12,15 +14,16 @@ namespace ConcordiaCurriculumManager.SignalR;
 public class DossierDiscussionSignalR : Hub
 {
     private readonly IMapper _mapper;
+    private readonly IDossierService _dossierService;
     private readonly IDossierReviewService _dossierReviewService;
 
-    public DossierDiscussionSignalR(IMapper mapper, IDossierReviewService dossierReviewService)
+    public DossierDiscussionSignalR(IMapper mapper, IDossierReviewService dossierReviewService, IDossierService dossierService)
     {
         _mapper = mapper;
         _dossierReviewService = dossierReviewService;
+        _dossierService = dossierService;
     }
 
-    [Authorize(Policies.IsOwnerOfDossier)]
     public async Task ReviewDossier(Guid dossierId, CreateDossierDiscussionMessageDTO dossierMessageDTO)
     {
         var userId = GetCurrentUserClaim(Claims.Id);
@@ -32,20 +35,35 @@ public class DossierDiscussionSignalR : Hub
             return;
         }
 
+        var httpContext = Context.GetHttpContext();
+        if (httpContext is null)
+        {
+            await Clients.Client(Context.ConnectionId).SendAsync("Error", "Could not access the query");
+            return;
+        }
+
+        httpContext.Request.Query.TryGetValue("dossierId", out var queryDossierId);
+        var validDossierId = Guid.TryParse(queryDossierId.ToString(), out var parsedDossierId);
+
+        if (!validDossierId || !parsedDossierId.Equals(dossierId))
+        {
+            await Clients.Client(Context.ConnectionId).SendAsync("Error", "Client error. dossier ids do not match");
+            return;
+        }
+
+        var isOwner = await IsOwnerOfPublishedDossier(parsedUserId, parsedDossierId);
+
+        if (!isOwner)
+        {
+            await Clients.Client(Context.ConnectionId).SendAsync("Error", "Client error. Cannot review a dossier when the dossier is not published yet and/or you are not an owner of the dossier");
+            return;
+        }
+
         var dossierMessage = _mapper.Map<DiscussionMessage>(dossierMessageDTO);
 
         if (dossierMessage is null)
         {
             await Clients.Client(Context.ConnectionId).SendAsync("Error", "Invalid message");
-            return;
-        }
-
-        Context.Items.TryGetValue("dossierId", out var authDossierId);
-        var validDossierId = Guid.TryParse(authDossierId?.ToString(), out var parsedDossierId);
-
-        if (!validDossierId || !parsedDossierId.Equals(dossierId))
-        {
-            await Clients.Client(Context.ConnectionId).SendAsync("Error", "Client error. dossier ids do not match");
             return;
         }
 
@@ -71,5 +89,36 @@ public class DossierDiscussionSignalR : Hub
         }
 
         return Context.User.Claims.FirstOrDefault(i => i.Type.ToString() == claim)?.Value;
+    }
+
+    private async Task<bool> IsOwnerOfPublishedDossier(Guid userId, Guid dossierId)
+    {
+        var dossier = await _dossierService.GetDossierDetailsById(dossierId);
+        if (dossier is null)
+        {
+            return false;
+        }
+
+        var isDossierPublished = !dossier.State.Equals(DossierStateEnum.Created);
+
+        if (!isDossierPublished)
+        {
+            return false;
+        }
+
+        var currentApprovalStage = dossier.ApprovalStages.Where(stage => stage.IsCurrentStage).FirstOrDefault();
+        var reviewingGroup = currentApprovalStage?.Group;
+
+        if (reviewingGroup is null)
+        {
+            return false;
+        }
+
+        if (isDossierPublished && !reviewingGroup.Members.Exists(m => m.Id.Equals(userId)))
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/HttpContextUtil.cs
+++ b/Server/ConcordiaCurriculumManagerTest/UnitTests/UtilityFunctions/HttpContextUtil.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Moq;
+using System.Collections.Specialized;
 using System.Security.Claims;
+using System.Linq;
+using Microsoft.Extensions.Primitives;
 
 namespace ConcordiaCurriculumManagerTest.UnitTests.UtilityFunctions;
 
@@ -29,5 +32,18 @@ internal static class HttpContextUtil
         authenticationServiceMock
             .Setup(x => x.AuthenticateAsync(httpContext.Object, It.IsAny<string>()))
             .ReturnsAsync(authResult);
+    }
+
+    public static Mock<HttpContext> GetMockHttpContextWithQuery(IEnumerable<(string, string)> queries)
+    {
+        var queryDict = new Dictionary<string, StringValues>();
+        queries.ToList().ForEach(query => queryDict.Add(query.Item1, query.Item2));
+
+        var mockRequest = new Mock<HttpRequest>();
+        mockRequest.Setup(r => r.Query).Returns(new QueryCollection(queryDict));
+        var mockHttpContext = new Mock<HttpContext>();
+        mockHttpContext.Setup(c => c.Request).Returns(mockRequest.Object);
+        
+        return mockHttpContext;
     }
 }


### PR DESCRIPTION
This PR closes: #511 

In addition to adding long polling, the PR will fix an issue where WebSockets is not supported (either by the server or the client); thus, preventing the user from sending more than one message.

Due to the internal routing rules of long polling requests, a custom authorization middleware cannot be used. 