### PR TITLE
Fix race condition on DbContext object

### DIFF
--- a/Server/ConcordiaCurriculumManager/Services/DossierReviewService.cs
+++ b/Server/ConcordiaCurriculumManager/Services/DossierReviewService.cs
@@ -75,7 +75,7 @@ public class DossierReviewService : IDossierReviewService
 
         if (isDossierSaved && areStagesSaved)
         {
-            _ = SendEmailToCurrentApprovingGroup(dossier, "Pending Dossier Review", EmailTemplates.GetDossierPendingReviewTemplate);
+            SendEmailToCurrentApprovingGroupInBackground(dossier, "Pending Dossier Review", EmailTemplates.GetDossierPendingReviewTemplate);
             _logger.LogInformation($"Dossier {dossier.Id} submitted for review to group {approvalStages.First().Id}");
         }
         else
@@ -439,6 +439,9 @@ public class DossierReviewService : IDossierReviewService
             }
         }
     }
+
+    private void SendEmailToCurrentApprovingGroupInBackground(Dossier dossier, string subject, Func<string, Guid, string> EmailTemplateFunc) =>
+        Task.Run(async () => await SendEmailToCurrentApprovingGroup(dossier, subject, EmailTemplateFunc));
 
     private async Task SendEmailToCurrentApprovingGroup(Dossier dossier, string subject, Func<string, Guid, string> EmailTemplateFunc)
     {


### PR DESCRIPTION
Fix race condition when using multiple calls to DbContext in a row with emails. Now, emails will be sent in the background when the dossier is submitted for review. This PR closes #540 