### PR TITLE
Fix bug where the "Dossiers Requiring Your Review" table still displays the dossier after performing a reviewal action

### DIFF
--- a/App/src/pages/dossier/DossierToReview.tsx
+++ b/App/src/pages/dossier/DossierToReview.tsx
@@ -29,7 +29,7 @@ export default function DossiersToReview() {
         console.log(selectedDossier);
     }, []);
 
-    function getAllDossiersRequired() {
+    async function getAllDossiersRequired() {
         getDossierRequiredReview()
             .then(
                 (res: GetMyDossiersResponse) => {


### PR DESCRIPTION
Made the getAllDossiersRequired() async

This PR closes #559 