### PR TITLE
Add Difference for course grouping to dossier report

### DIFF
--- a/App/src/components/Dossiers/DossierReportCourseGrouping.tsx
+++ b/App/src/components/Dossiers/DossierReportCourseGrouping.tsx
@@ -1,8 +1,12 @@
 import { useEffect, useState } from "react";
-import { CourseGroupingRequestDTO } from "../../models/courseGrouping";
+import { CourseGroupingDTO, CourseGroupingRequestDTO } from "../../models/courseGrouping";
 import { Box, Heading, ListItem, OrderedList, Stack, Text } from "@chakra-ui/react";
+import CourseGroupingDiffViewer from "../CourseDifference/CourseGroupingDifference";
 
-export default function DossierReportCourseGrouping(props: { courseGrouping: CourseGroupingRequestDTO[] }) {
+export default function DossierReportCourseGrouping(props: {
+    courseGrouping: CourseGroupingRequestDTO[];
+    oldGroupings: CourseGroupingDTO[];
+}) {
     const [creationRequests, setCreationRequests] = useState<CourseGroupingRequestDTO[]>([]);
     const [modificationRequest, setModificationRequests] = useState<CourseGroupingRequestDTO[]>([]);
     const [deletionRequests, setDeletionRequests] = useState<CourseGroupingRequestDTO[]>([]);
@@ -47,6 +51,10 @@ export default function DossierReportCourseGrouping(props: { courseGrouping: Cou
             default:
                 return "N/A";
         }
+    }
+
+    function getOldCourseGrouping(commonIdentifier: string) {
+        return props.oldGroupings.find((grouping) => grouping.commonIdentifier === commonIdentifier);
     }
     return (
         <>
@@ -143,7 +151,7 @@ export default function DossierReportCourseGrouping(props: { courseGrouping: Cou
                                 </Box>
                             )}
 
-                            {modificationRequest.map((creationRequest, index) => (
+                            {modificationRequest.map((modificationRequest, index) => (
                                 <ListItem
                                     className="pageBreak"
                                     key={index}
@@ -152,61 +160,34 @@ export default function DossierReportCourseGrouping(props: { courseGrouping: Cou
                                     borderRadius={"xl"}
                                     mb={2}
                                 >
-                                    <Text fontSize="md" marginBottom="3">
+                                    <Text fontSize="md" mb="3">
                                         <b>Course Group Name: </b>
-                                        {creationRequest.courseGrouping.name ?? "N/A"}
+                                        {modificationRequest.courseGrouping.name ?? "N/A"}
                                     </Text>
-                                    <Text fontSize="md" marginBottom="3">
-                                        <b>Course Group School: </b>
-                                        {getSchoolName(creationRequest.courseGrouping.school) ?? "N/A"}
-                                    </Text>
-                                    {displayMapping.map(({ key, title }) => (
-                                        <Text fontSize="md" marginBottom="3" key={key}>
-                                            <b>{title}: </b>
-                                            {creationRequest.courseGrouping[key] ?? "N/A"}
-                                        </Text>
-                                    ))}
-                                    <Text fontSize="md" marginBottom="3">
-                                        <b>Courses: </b>
-                                        {creationRequest.courseGrouping.courses.length == 0 && <span>N/A</span>}
-                                        {creationRequest.courseGrouping.courses.map((course, index) => (
-                                            <span key={index}>
-                                                {course.subject}-{course.catalog}
-                                                {index < creationRequest.courseGrouping.courses.length - 1 ? ", " : ""}
-                                            </span>
-                                        ))}
-                                    </Text>
-                                    <Text fontSize="md" marginBottom="3">
-                                        <b>Sub-Groupings: </b>
-                                        {creationRequest.courseGrouping.subGroupings.length == 0 && <span>N/A</span>}
-                                        {creationRequest.courseGrouping.subGroupings.map((subGroup, index) => (
-                                            <span key={subGroup.id}>
-                                                {subGroup.name}
-                                                {index < creationRequest.courseGrouping.subGroupings.length - 1
-                                                    ? ", "
-                                                    : ""}
-                                            </span>
-                                        ))}
-                                    </Text>
-
-                                    <Text fontSize="md" marginBottom="3">
+                                    <CourseGroupingDiffViewer
+                                        oldGrouping={getOldCourseGrouping(
+                                            modificationRequest.courseGrouping.commonIdentifier
+                                        )}
+                                        newGrouping={modificationRequest.courseGrouping}
+                                    ></CourseGroupingDiffViewer>
+                                    <Text fontSize="md" mb="3" mt={6}>
                                         <b>Rationale:</b> <br />
-                                        {creationRequest.rationale ?? "N/A"}
+                                        {modificationRequest.rationale ?? "N/A"}
                                     </Text>
 
                                     <Text fontSize="md" marginBottom="3">
                                         <b> Ressource Implications:</b> <br />
-                                        {creationRequest.resourceImplication ?? "N/A"}
+                                        {modificationRequest.resourceImplication ?? "N/A"}
                                     </Text>
 
                                     <Text fontSize="md" marginBottom="3">
                                         <b>Comments:</b> <br />
-                                        {creationRequest.comment == "" ? "N/A" : creationRequest.comment}
+                                        {modificationRequest.comment == "" ? "N/A" : modificationRequest.comment}
                                     </Text>
 
                                     <Text fontSize="md" marginBottom="3">
                                         <b>Conflicts:</b> <br />
-                                        {creationRequest.conflict == "" ? "N/A" : creationRequest.comment}
+                                        {modificationRequest.conflict == "" ? "N/A" : modificationRequest.comment}
                                     </Text>
                                 </ListItem>
                             ))}

--- a/App/src/models/dossier.ts
+++ b/App/src/models/dossier.ts
@@ -1,6 +1,6 @@
 import { GroupDTO } from "../services/group";
 import { Course, CourseCreationRequest, CourseDeletionRequest, CourseModificationRequest } from "./course";
-import { CourseGroupingRequestDTO } from "./courseGrouping";
+import { CourseGroupingDTO, CourseGroupingRequestDTO } from "./courseGrouping";
 import { UserDTO } from "./user";
 
 export interface DossierDTO {
@@ -109,6 +109,7 @@ export interface DossierReportDTO {
     oldCourses: Course[];
     state: number;
     title: string | null;
+    oldGroupings: CourseGroupingDTO;
 }
 
 export interface DossierReportResponse {

--- a/App/src/models/dossier.ts
+++ b/App/src/models/dossier.ts
@@ -109,7 +109,7 @@ export interface DossierReportDTO {
     oldCourses: Course[];
     state: number;
     title: string | null;
-    oldGroupings: CourseGroupingDTO;
+    oldGroupings: CourseGroupingDTO[];
 }
 
 export interface DossierReportResponse {

--- a/App/src/pages/dossier/DossierReport.tsx
+++ b/App/src/pages/dossier/DossierReport.tsx
@@ -465,6 +465,7 @@ export default function DossierReport() {
                 </Center>
                 <DossierReportCourseGrouping
                     courseGrouping={dossierReport?.courseGroupingRequests}
+                    oldGroupings={dossierReport?.oldGroupings}
                 ></DossierReportCourseGrouping>
             </Container>
 


### PR DESCRIPTION
Feature added:
1. Added the difference viewer to the dossier report for the course groupings modification requests, to compare the old version and new version of the modified course grouping

To test:
1. Go to Manage Dossier
2. Click on the view dossier report of the desired dossier
3. Scroll down to the course grouping modification requests

This PR closes #578 